### PR TITLE
log: Refactor logging into its own class

### DIFF
--- a/log.py
+++ b/log.py
@@ -1,0 +1,67 @@
+import gzip
+import logging
+import logging.handlers
+import os
+import shutil
+
+class MeticulousLogger:
+    _path = "./logs"
+    _rh = None
+    _f = None
+    _sh = None
+
+    LOGLEVEL=os.getenv('LOGLEVEL', 'DEBUG').upper()
+    FORCE_STDOUT_LOG=os.getenv("FORCE_STDOUT_LOG", 'False').lower() in ('true', '1', 'y')
+
+    def setLogPath(path):
+        MeticulousLogger._path = path
+        MeticulousLogger._createHandler();
+
+    def setFileLogLevel(level):
+        if MeticulousLogger._rh is None:
+            MeticulousLogger._createHandler()
+        MeticulousLogger._rh.setLevel(level)
+
+    def setLogLevel(level):
+        logging.getLogger().setLevel(level)
+
+    # Callback when a new log is created
+    def cb_logname(name):
+        return name + ".gz"
+
+    # function called to rotatethe log at a certain size or time
+    def cb_logrotate(source, dest):
+        with open(source, 'rb') as f_in:
+            with gzip.open(dest, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        os.remove(source)
+
+    def _createHandler():
+        MB = 1024 * 1024
+        # Create directory for the logfiles if it doesn't exist
+        os.makedirs(MeticulousLogger._path, exist_ok=True)
+        logfilePath = os.path.join(MeticulousLogger._path, 'backend.log')
+        
+        MeticulousLogger._rh = logging.handlers.RotatingFileHandler(
+            logfilePath, maxBytes=200*MB, backupCount=10)
+        MeticulousLogger._rh.rotator = MeticulousLogger.cb_logrotate
+        MeticulousLogger._rh.namer = MeticulousLogger.cb_logname
+
+        MeticulousLogger._f = logging.Formatter(logging.BASIC_FORMAT)
+        MeticulousLogger._rh.setFormatter(MeticulousLogger._f)
+        MeticulousLogger._rh.doRollover()
+        MeticulousLogger._sh = logging.StreamHandler()
+        MeticulousLogger.setLogLevel(MeticulousLogger.LOGLEVEL)
+
+    def getLogger(name):
+        if MeticulousLogger._rh is None:
+            MeticulousLogger._createHandler()
+
+        logger = logging.getLogger(name=name)
+        if MeticulousLogger._rh not in logger.handlers:
+            logger.addHandler(MeticulousLogger._rh)
+        # This will lead to double logging on some systems, so it is disabled by default
+        if MeticulousLogger.FORCE_STDOUT_LOG and MeticulousLogger._sh not in logger.handlers:
+            logger.addHandler(MeticulousLogger._sh)
+
+        return logger


### PR DESCRIPTION
The existing logging logic manually rotates the logs on application start. The old logs are appended and the new logs go into a new file. The maximum amount of logs was 99999 files.
This comes with multiple problems: Not only can we not use the auto formating capabilities of pythons logging modules but we are also unable to control the maximum amount of discspace the logs can occupy.

For rotating logs python itself offers the RotatingFileHandler class. We can as for logs to automatically rotate after 200MiB and a maximum amount of logs which we hardcode to 10 for now. This means that we have a hard upper bar of how much discspace the logs can occupy. To reduce this even further we are additionally compressing the logs with gzip. As we are printing logs with a lot of pretetition we can be reasonably sure that the compressed logs will always be smaller than the original files and therefore will never be more than 2GiB in total. On top of that the newly introduced MeticulousLogger class takes the modules name as a parameter so that we get a good overview which file / modules has been the source of a speicific log.
Due to the nature of using log handlers we can log to disc and stdout at the same time and are not longer required to differentiate between print() and "log()" or "add_to_buffer()" respectively.
The logging is currently happening blocking with the file writes being async on OS level. Blackbox testing did not show significant performance differences, however we might need to revisit this behaviour in the future again.