### PR TITLE
system: Create Dockerfile and docker compose yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-bullseye
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install dependencies:
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+WORKDIR /app
+# Copy Application files
+# FIXME use src-layout
+COPY . .
+
+CMD ["python", "back.py"]

--- a/back.py
+++ b/back.py
@@ -72,7 +72,11 @@ def gatherVersionInfo():
     # #OBTENEMOS SU VERSION USANDO LOS COMANDOS DPKG y GREP
     command = f'dpkg --list | grep meticulous-ui'
     result = subprocess.run(command, shell=True, capture_output=True, text=True)
-    lcd_version = result.stdout.split()[2]
+    try:
+        lcd_version = result.stdout.split()[2]
+    except IndexError:
+        logger.warning("LCD DialApp is not installed")
+        lcd_version = "0.0.0"
     infoSolicited = True
 
     software_info["lcdV"] = lcd_version
@@ -377,7 +381,11 @@ def send_data():
 
     while (True):
         print("> ", end="")
-        _input = input()
+        try:
+            _input = input()
+        except EOFError:
+            logger.warning("no STDIN attached, not listening to commands!")
+            break
 
         if _input == "reset":
             connection.reset()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8080:8080
+    expose:
+      - 8080
+    environment:
+      - BACKEND=emulation
+      - EMULATION_SPEED=100


### PR DESCRIPTION
To allow the frontend team to develop against the backend without the neeed for a real machine we are building a standalone backend running in a docker container so that the websocket connection can be used with this dummy data. As a first draft the container is running in host networking mode to allow for easy connection to localhost.