### PR TITLE
    actions: Update workflow python to 3.12

### DIFF
--- a/.github/workflows/generate_release.yml
+++ b/.github/workflows/generate_release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.12.1"
 
       - name: Get PR description
         id: get_pr_description

--- a/.github/workflows/generate_release.yml
+++ b/.github/workflows/generate_release.yml
@@ -18,86 +18,86 @@ jobs:
     if: ((github.event.pull_request.merged == true || github.event.pull_request.rebase == true ) && github.event.pull_request.base.ref == 'dev') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with: 
-        token: ${{ secrets.GH_VERSIONING }}
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_VERSIONING }}
 
-    - name: Cache library
-      uses: actions/cache@v2
-      with:
-        path: requirements.txt
-        key: ${{ runner.os }}-library-${{ hashFiles('requirements.txt') }}
-        restore-keys: ${{ runner.os }}-library-
+      - name: Cache library
+        uses: actions/cache@v2
+        with:
+          path: requirements.txt
+          key: ${{ runner.os }}-library-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-library-
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
 
-    - name: Get PR description
-      id: get_pr_description
-      run: |
-        echo "::set-output name=pr_description::$(jq -r '.pull_request.body' $GITHUB_EVENT_PATH)"
-      shell: bash
+      - name: Get PR description
+        id: get_pr_description
+        run: |
+          echo "::set-output name=pr_description::$(jq -r '.pull_request.body' $GITHUB_EVENT_PATH)"
+        shell: bash
 
-    - name: Update version and CHANGELOG
-      run: |
-        PR_DESCRIPTION="${{ steps.get_pr_description.outputs.pr_description }}"
-        # Convert empty string to null to prevent JSONDecodeError
-        if [ -z "$PR_DESCRIPTION" ]; then
-          PR_DESCRIPTION="null"
-        fi
-        python .github/workflows/scripts/update_version.py "${{ github.ref }}" "$PR_DESCRIPTION" "${{ github.event.inputs.version_bump_type }}"
-      shell: bash
+      - name: Update version and CHANGELOG
+        run: |
+          PR_DESCRIPTION="${{ steps.get_pr_description.outputs.pr_description }}"
+          # Convert empty string to null to prevent JSONDecodeError
+          if [ -z "$PR_DESCRIPTION" ]; then
+            PR_DESCRIPTION="null"
+          fi
+          python .github/workflows/scripts/update_version.py "${{ github.ref }}" "$PR_DESCRIPTION" "${{ github.event.inputs.version_bump_type }}"
+        shell: bash
 
-    - name: Set Version
-      run: | 
-        echo "BUILD_VERSION=$(python -c 'from version import VERSION; print(VERSION)')" >> $GITHUB_ENV
-        
-    - name: Commit and push changes
-      run: |
-        git config user.name "GitHub Actions Bot"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add version.py CHANGELOG.md
-        git commit -m "Update version to ${{ env.BUILD_VERSION }} and CHANGELOG"
-        git push
+      - name: Set Version
+        run: |
+          echo "BUILD_VERSION=$(python -c 'from version import VERSION; print(VERSION)')" >> $GITHUB_ENV
 
-    - name: Create folder to copy the files
-      run: |
-        mkdir -p meticulous/library 
-        mkdir -p meticulous/backend_for_esp32 
+      - name: Commit and push changes
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add version.py CHANGELOG.md
+          git commit -m "Update version to ${{ env.BUILD_VERSION }} and CHANGELOG"
+          git push
 
-    - name: Copy files, excep the folder meticulous using exclude 
-      run: |
-        rsync -avq --exclude='meticulous' ./ meticulous/backend_for_esp32/
+      - name: Create folder to copy the files
+        run: |
+          mkdir -p meticulous/library 
+          mkdir -p meticulous/backend_for_esp32
 
-    - name: Create folder to save library
-      run: |
-        mkdir -p library
+      - name: Copy files, excep the folder meticulous using exclude
+        run: |
+          rsync -avq --exclude='meticulous' ./ meticulous/backend_for_esp32/
 
-    - name: Create virtual environment, download dependencies and copy them to the library folder of meticulous
-      run: |
-        python3 -m venv venv && source venv/bin/activate
-        cd library
-        pip download -r ../requirements.txt --platform manylinux_2_28_aarch64 --platform manylinux_2_17_aarch64 --python-version 3.9 --implementation cp --abi cp39 --no-deps
-        deactivate
-        cp -rf . ../meticulous/library/
-        cd
+      - name: Create folder to save library
+        run: |
+          mkdir -p library
 
-    - name: upload files
-      uses: actions/upload-artifact@v2
-      with:
-        name: Update_files_backend
-        path: meticulous
+      - name: Create virtual environment, download dependencies and copy them to the library folder of meticulous
+        run: |
+          python3 -m venv venv && source venv/bin/activate
+          cd library
+          pip download -r ../requirements.txt --platform manylinux_2_28_aarch64 --platform manylinux_2_17_aarch64 --python-version 3.9 --implementation cp --abi cp39 --no-deps
+          deactivate
+          cp -rf . ../meticulous/library/
+          cd
 
-    - uses: montudor/action-zip@v1
-      name: Preparing ZIP
-      with:
-        args: zip -qq -r update_back.zip meticulous/
+      - name: upload files
+        uses: actions/upload-artifact@v2
+        with:
+          name: Update_files_backend
+          path: meticulous
 
-    - name: Release
-      env:
-        GITHUB_TOKEN: "${{ secrets.G_CLONE_TOKEN }}"
-      run: |
-        gh release create backend_for_esp32-${{ env.BUILD_VERSION }} update_back.zip -R https://github.com/FFFuego/Meticulous-Releases
-        echo "Release created, And version updated to ${{ env.BUILD_VERSION }}"
+      - uses: montudor/action-zip@v1
+        name: Preparing ZIP
+        with:
+          args: zip -qq -r update_back.zip meticulous/
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: "${{ secrets.G_CLONE_TOKEN }}"
+        run: |
+          gh release create backend_for_esp32-${{ env.BUILD_VERSION }} update_back.zip -R https://github.com/FFFuego/Meticulous-Releases
+          echo "Release created, And version updated to ${{ env.BUILD_VERSION }}"

--- a/.github/workflows/scripts/update_version.py
+++ b/.github/workflows/scripts/update_version.py
@@ -1,13 +1,15 @@
 import sys
 import re
 from datetime import datetime
-import json
+
 
 def main(ref, pr_comments, version_bump_type):
     with open("version.py", "r") as f:
         version_file = f.read()
 
-    current_version = re.search(r'VERSION\s*=\s*[\'"]([^\'"]*)[\'"]', version_file).group(1)
+    current_version = re.search(
+        r'VERSION\s*=\s*[\'"]([^\'"]*)[\'"]', version_file
+    ).group(1)
     major, minor, patch = map(int, current_version.split("."))
 
     if version_bump_type == "major":


### PR DESCRIPTION
  Since the inclusion of pyImprov we require python 3.10 for match-case statements.
  Furthermore we are prefering to use at least 3.11 for better byte-slice handeling.
  As we are using 3.12.1 as latest stable on the target Debian bullseye system we are
  updating the now failing python 3.9 to 3.12.1