### PR TITLE
Fix: delete method in profile endpoint

### DIFF
--- a/api/base_handler.py
+++ b/api/base_handler.py
@@ -8,7 +8,7 @@ class BaseHandler(tornado.web.RequestHandler):
         #FIXME: I know this is not great, you know this isn't great. What shall we do about this?
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header('Content-type', 'application/json')
-        self.set_header('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
+        self.set_header('Access-Control-Allow-Methods', 'GET,POST,OPTIONS,DELETE')
         self.set_header('Access-Control-Allow-Headers', 'content-type')
     
     def options(self):

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -64,6 +64,9 @@ class GetProfileHandler(BaseHandler):
 
 class DeleteProfileHandler(BaseHandler):
     def get(self, profile_id):
+        return self.delete(profile_id)
+    
+    def delete(self, profile_id):
         logger.info("Deletion for profile "+profile_id)
         data = ProfileManager.delete_profile(profile_id)
         if data:

--- a/profile.py
+++ b/profile.py
@@ -47,7 +47,7 @@ class ProfileManager:
         file_path = os.path.join(PROFILE_PATH, filename)
         os.remove(file_path)
         del ProfileManager._known_profiles[profile["id"]]
-        return (profile["name"], profile["id"])
+        return {"profile": profile["name"], "id": profile["id"]}
 
     def get_profile(id):
         logger.info(f"Serving profile: {id}")


### PR DESCRIPTION
- `delete_profile` function was returning a tuple instead of a dict, self.write receives a dict
- Add DELETE method to allowed methods
- Change get for delete to use the correct HTTP request