### PR TITLE
Update profile in the same file instead of create a new one

### DIFF
--- a/profile.py
+++ b/profile.py
@@ -25,7 +25,7 @@ class ProfileManager:
         if "id" not in data:
             data["id"] = str(uuid.uuid4())
 
-        name = f'{data["name"]}_{data["id"]}.json'
+        name = f'{data["id"]}.json'
 
         if set_last_changed:
             data["last_changed"] = time.time()


### PR DESCRIPTION
If we save a profile with the name `profile-name_uuid.json` when we change only the profile name the API will create a new FILE with the new name instead of overwriting the same file, but if we save the profile with the name `uuid.json` and we change only the profile name the API will search and update the same file instead of create a new one with the new name