### PR TITLE
fix: set correct filename to delete profile

### DIFF
--- a/profile.py
+++ b/profile.py
@@ -43,7 +43,7 @@ class ProfileManager:
         if not profile:
             return None
 
-        filename = f'{profile["name"]}_{profile["id"]}.json'
+        filename = f'{profile["id"]}.json'
         file_path = os.path.join(PROFILE_PATH, filename)
         os.remove(file_path)
         del ProfileManager._known_profiles[profile["id"]]


### PR DESCRIPTION
Now we search the profile file only by the uuid 