### PR TITLE
Fix: Incorrect time.sleep() Calls

### DIFF
--- a/back.py
+++ b/back.py
@@ -135,7 +135,7 @@ async def feed_profile(sid, data):
             logger.info(json_result)
             obj_json = json.loads(json_result) #<class 'dict'>
             Machine.send_json_with_hash(obj_json)
-            time.sleep(5)
+            await asyncio.sleep(5)
             _input = "action,"+"start"+"\x03"
             Machine.write(str.encode(_input))
             
@@ -147,7 +147,7 @@ async def feed_profile(sid, data):
                 logger.info(json_result)
                 obj_json = json.loads(json_result) #<class 'dict'>
                 Machine.send_json_with_hash(obj_json)
-                time.sleep(5)
+                await asyncio.sleep(5)
                 _input = "action,"+"start"+"\x03"
                 Machine.write(str.encode(_input))
                 logger.info("Se envio start")
@@ -242,11 +242,11 @@ async def send_data():
             for i in range(0,10):
                 _input = "action,"+"purge"+"\x03"
                 Machine.write(str.encode(_input))
-                time.sleep(15)
+                await asyncio.sleep(15)
                 logger.info(_input)
                 _input = "action,"+"home"+"\x03"
                 Machine.write(str.encode(_input))
-                time.sleep(15)
+                await asyncio.sleep(15)
                 contador = "Numero de prueba: "+str(i+1)
                 logger.info(_input)
                 logger.info(contador)

--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -141,7 +141,7 @@ class GATTServer:
             logger.info(
                 f"GattServer started to fast after system boot. Waiting {uptime_missing} seconds"
             )
-            time.sleep(uptime_missing)
+            await asyncio.sleep(uptime_missing)
 
         if self.bless_gatt_server is None:
             self.bless_gatt_server = BlessServer(

--- a/machine.py
+++ b/machine.py
@@ -116,7 +116,7 @@ class Machine:
         Machine.startTime = time.time()
         while True:
             if Machine._stopESPcomm:
-                time.sleep(0.1)
+                await asyncio.sleep(0.1)
                 Machine.startTime = time.time()
                 continue
 


### PR DESCRIPTION
Multiple instances of time.sleep() are present in the code within async def functions, leading to the blocking of data emission to the dial app. We are now using await asyncio.sleep() to ensure these functions do not block, avoiding a blocking state in the dial app.