### PR TITLE
patch(max_piston distance): Changed to 82

### DIFF
--- a/modes/italian_1_0/closing_valve_stage.py
+++ b/modes/italian_1_0/closing_valve_stage.py
@@ -1,6 +1,7 @@
 import json
 
 def get_closing_valve_stage(parameters: json,start_node: int, end_node: int):
+    max_piston_position = 82
     
     closing_valve_stage = {
         "name": "closing valve",
@@ -31,7 +32,7 @@ def get_closing_valve_stage(parameters: json,start_node: int, end_node: int):
                         "kind": "piston_position_trigger",
                         "position_reference_id": 0,
                         "operator": ">=",
-                        "value": 78,
+                        "value": max_piston_position ,
                         "next_node_id": -2,
                         "source": "Piston Position Raw"
                     }

--- a/modes/italian_1_0/end_purge_stage.py
+++ b/modes/italian_1_0/end_purge_stage.py
@@ -1,7 +1,7 @@
 import json
 
 def get_end_purge_stage(parameters: json, start_node: int, end_node: int):
-    
+    max_piston_position = 82
     end_purge_stage =      {
       "name": "purge",
       "nodes": [
@@ -32,7 +32,7 @@ def get_end_purge_stage(parameters: json, start_node: int, end_node: int):
           "position_reference_id": 0,
           "source": "Piston Position Raw",
           "operator": ">=",
-          "value": 78,
+          "value": max_piston_position,
           "next_node_id": end_node
          },
          {
@@ -68,7 +68,7 @@ def get_end_purge_stage(parameters: json, start_node: int, end_node: int):
           "position_reference_id": 0,
           "source": "Piston Position Raw",
           "operator": ">=",
-          "value": 78,
+          "value": max_piston_position,
           "next_node_id": end_node
          },
          {

--- a/modes/italian_1_0/preinfusion_stage.py
+++ b/modes/italian_1_0/preinfusion_stage.py
@@ -95,7 +95,7 @@ def get_preinfusion_stage(parameters: json, start_node: int, end_node: int):
           "source": "Flow Raw",
           "operator": ">=",
           "curve_id": 4,
-          "next_node_id": 10
+          "next_node_id": start_node
          },
          {
           "kind": "weight_value_trigger",

--- a/modes/italian_1_0/prepurge_stage.py
+++ b/modes/italian_1_0/prepurge_stage.py
@@ -2,6 +2,7 @@ import json
 
 def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
     
+    max_piston_position = 82
     prepurge_stage = {
         "name": "purge",
         "nodes": [
@@ -13,7 +14,7 @@ def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
                         "kind": "piston_position_trigger",
                         "position_reference_id": 0,
                         "operator": ">=",
-                        "value": 78,
+                        "value": max_piston_position,
                         "next_node_id": end_node,
                         "source": "Piston Position Raw"
                     },
@@ -21,7 +22,7 @@ def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
                         "kind": "piston_position_trigger",
                         "position_reference_id": 0,
                         "operator": "<",
-                        "value": 78,
+                        "value": max_piston_position,
                         "next_node_id": 2,
                         "source": "Piston Position Raw"
                     },
@@ -60,7 +61,7 @@ def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
                         "position_reference_id": 0,
                         "source": "Piston Position Raw",
                         "operator": ">=",
-                        "value": 78,
+                        "value": max_piston_position,
                         "next_node_id": end_node
                     },
                     {
@@ -96,7 +97,7 @@ def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
                         "position_reference_id": 0,
                         "source": "Piston Position Raw",
                         "operator": ">=",
-                        "value": 78,
+                        "value": max_piston_position,
                         "next_node_id": end_node
                     },
                     {

--- a/profile_converter/profile_converter.py
+++ b/profile_converter/profile_converter.py
@@ -16,6 +16,7 @@ class ComplexProfileConverter:
         self.complex = SimplifiedJson(self.parameters)
         self.temperature = self.complex.get_temperature() 
         self.offset_temperature = 1
+        self.max_piston_position = 82
         
     def head_template(self):
         if self.click_to_start:
@@ -36,7 +37,7 @@ class ComplexProfileConverter:
                         "next_node_id": 45,
                         "source": "Piston Position Raw",
                         "operator": ">=",
-                        "value": 78
+                        "value": self.max_piston_position 
                     },
                     {
                         "kind": "piston_position_trigger",
@@ -44,7 +45,7 @@ class ComplexProfileConverter:
                         "next_node_id": 6,
                         "source": "Piston Position Raw",
                         "operator": "<",
-                        "value": 78
+                        "value": self.max_piston_position 
                     },
                     {
                         "kind": "button_trigger",
@@ -82,7 +83,7 @@ class ComplexProfileConverter:
                         "next_node_id": 45,
                         "source": "Piston Position Raw",
                         "operator": ">=",
-                        "value": 78
+                        "value": self.max_piston_position 
                     },
                     {
                         "kind": "button_trigger",
@@ -121,7 +122,7 @@ class ComplexProfileConverter:
                         "next_node_id": 45,
                         "source": "Piston Position Raw",
                         "operator": ">=",
-                        "value": 78
+                        "value": self.max_piston_position 
                     },
                     {
                         "kind": "button_trigger",
@@ -518,7 +519,7 @@ class ComplexProfileConverter:
                         "next_node_id": -2,
                         "source": "Piston Position Raw",
                         "operator": ">=",
-                        "value": 78
+                        "value": self.max_piston_position 
                     }
                 ]
                 }
@@ -716,7 +717,7 @@ class ComplexProfileConverter:
                             "next_node_id": -2,
                             "source": "Piston Position Raw",
                             "operator": ">=",
-                            "value": 78
+                            "value": self.max_piston_position 
                             },
                             {
                             "kind": "button_trigger",
@@ -755,7 +756,7 @@ class ComplexProfileConverter:
                             "next_node_id": -2,
                             "source": "Piston Position Raw",
                             "operator": ">=",
-                            "value": 78
+                            "value": self.max_piston_position 
                             },
                             {
                             "kind": "button_trigger",


### PR DESCRIPTION
Problem: The max_piston distance was set to 78, but now the motor shaft is larger. Due to this, purge mode sometimes doesn't work properly.

We take the opportunity to change a problem in the "next node id" property of the pre-infusion stage for the italian_1_0 mode.

I also would like to get the max piston position from the firmware, so I created variables as preparation for this implementation in a near future. 