### PR TITLE
fix(purge_distance): Purge without distance

### DIFF
--- a/modes/italian_1_0/end_purge_stage.py
+++ b/modes/italian_1_0/end_purge_stage.py
@@ -1,86 +1,193 @@
 import json
 
 def get_end_purge_stage(parameters: json, start_node: int, end_node: int):
-    max_piston_position = 81
+    max_piston_position = 82
     end_purge_stage =      {
       "name": "purge",
       "nodes": [
-       {
-        "id": start_node,
-        "controllers": [
-         {
-          "kind": "move_piston_controller",
-          "algorithm": "Piston Ease-In",
-          "direction": "DOWN",
-          "speed": 6
-         },
-         {
-          "kind": "time_reference",
-          "id": 1
-         }
-        ],
-        "triggers": [
-         {
-          "kind": "pressure_value_trigger",
-          "source": "Pressure Raw",
-          "operator": ">=",
-          "value": 6,
-          "next_node_id": 17
-         },
-         {
-          "kind": "piston_position_trigger",
-          "position_reference_id": 0,
-          "source": "Piston Position Raw",
-          "operator": ">=",
-          "value": max_piston_position,
-          "next_node_id": end_node
-         },
-         {
-          "kind": "button_trigger",
-          "source": "Encoder Button",
-          "gesture": "Single Tap",
-          "next_node_id": end_node
-         }
-        ]
-       },
-       {
-        "id": 17,
-        "controllers": [
-         {
-          "kind": "pressure_controller",
-          "algorithm": "Pressure PID v1.0",
-          "curve": {
-           "id": 20,
-           "interpolation_kind": "linear_interpolation",
-           "points": [
-            [
-             0,
-             6
+        {   
+            "id": start_node,
+            "controllers": [
+             {
+                "kind": "move_piston_controller",
+                "algorithm": "Piston Ease-In",
+                "direction": "DOWN",
+                "speed": 6
+             },
+             {
+                "kind": "time_reference",
+                "id": 12
+             }
+            ],
+            "triggers": [
+            {
+                "kind": "exit",
+                "next_node_id": 17
+            },
+             {
+                "kind": "button_trigger",
+                "source": "Encoder Button",
+                "gesture": "Single Tap",
+                "next_node_id": end_node
+             }
             ]
-           ],
-           "time_reference_id": 1
-          }
-         }
-        ],
-        "triggers": [
-         {
-          "kind": "piston_position_trigger",
-          "position_reference_id": 0,
-          "source": "Piston Position Raw",
-          "operator": ">=",
-          "value": max_piston_position,
-          "next_node_id": end_node
-         },
-         {
-          "kind": "button_trigger",
-          "source": "Encoder Button",
-          "gesture": "Single Tap",
-          "next_node_id": end_node
-         }
+        },
+        {   
+            "id": 17,
+            "controllers": [],
+            "triggers": [
+                {
+                    "kind": "pressure_value_trigger",
+                    "next_node_id": 18,
+                    "source": "Pressure Raw",
+                    "operator": ">=",
+                    "value": 6
+                },
+                {
+                    "kind": "timer_trigger",
+                    "timer_reference_id": 12,
+                    "operator": ">=",
+                    "value": 1.5,
+                    "next_node_id": 28
+                },
+                {
+                    "kind": "button_trigger",
+                    "source": "Encoder Button",
+                    "gesture": "Single Tap",
+                    "next_node_id": end_node
+                }
+            ]
+        },
+        {
+            "id": 18,
+            "controllers": [
+                {
+                    "kind": "pressure_controller",
+                    "algorithm": "Pressure PID v1.0",
+                    "curve": {
+                        "id": 1,
+                        "interpolation_kind": "linear_interpolation",
+                        "points": [
+                        [
+                            0,
+                            6
+                        ]
+                        ],
+                        "reference": {
+                        "kind": "time",
+                        "id": 8
+                        }
+                    }
+                }
+            ],
+            "triggers": [
+                {
+                    "kind": "piston_speed_trigger",
+                    "operator": "==",
+                    "value": 0,
+                    "next_node_id": 29
+                },
+                {
+                    "kind": "button_trigger",
+                    "next_node_id": end_node,
+                    "gesture": "Single Tap",
+                    "source": "Encoder Button"
+                }
+            ]
+        },
+        {
+            "id": 28,
+            "controllers": [
+                {
+                    "kind": "move_piston_controller",
+                    "algorithm": "Piston Ease-In",
+                    "direction": "DOWN",
+                    "speed": 6
+                }
+            ],
+            "triggers": [
+                {
+                    "kind": "piston_speed_trigger",
+                    "operator": "==",
+                    "value": 0,
+                    "next_node_id": 29
+                },
+                {
+                    "kind": "pressure_value_trigger",
+                    "source": "Pressure Raw",
+                    "operator": ">=",
+                    "value": 6,
+                    "next_node_id": 18
+                },
+                {
+                    "kind": "button_trigger",
+                    "next_node_id": end_node,
+                    "gesture": "Single Tap",
+                    "source": "Encoder Button"
+                }
+                ]
+        },
+        {
+            "id": 29,
+            "controllers": [
+                {
+                    "kind" : "time_reference",
+                    "id": 7
+                }
+                ],
+                    "triggers": [
+                {
+                    "kind": "exit",
+                    "next_node_id": 31
+                }
+                ]
+        },
+        {
+            "id": 31,
+            "controllers": [],
+            "triggers": [
+                {
+                    "kind": "piston_speed_trigger",
+                    "operator": "!=",
+                    "value": 0,
+                    "next_node_id": 29
+                },
+                {
+                    "kind": "timer_trigger",
+                    "timer_reference_id": 7,
+                    "operator": ">=",
+                    "value": 1,
+                    "next_node_id": 33
+                },
+                {
+                    "kind": "button_trigger",
+                    "next_node_id": end_node,
+                    "gesture": "Single Tap",
+                    "source": "Encoder Button"
+                }
+            ]
+        },
+        {
+            "id": 33,
+            "controllers": [],
+            "triggers" : [
+                {
+                    "kind": "timer_trigger",
+                    "timer_reference_id": 8,
+                    "operator": ">=",
+                    "value": 1,
+                    "next_node_id": end_node
+                },
+                {
+                    "kind": "button_trigger",
+                    "next_node_id": end_node,
+                    "gesture": "Single Tap",
+                    "source": "Encoder Button"
+                }
+            ]
+        }
         ]
-       }
-      ]
-     }
+    }
     
     return end_purge_stage
     # return {}

--- a/modes/italian_1_0/prepurge_stage.py
+++ b/modes/italian_1_0/prepurge_stage.py
@@ -2,52 +2,40 @@ import json
 
 def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
     
-    max_piston_position = 81
+    max_piston_position = 82
     prepurge_stage = {
         "name": "purge",
         "nodes": [
             {
                 "id": start_node,
-                "controllers": [],
-                "triggers": [
+                "controllers": [
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
-                        "operator": ">=",
-                        "value": max_piston_position,
-                        "next_node_id": end_node,
-                        "source": "Piston Position Raw"
+                        "kind": "time_reference",
+                        "id": 29
                     },
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
-                        "operator": "<",
-                        "value": max_piston_position,
-                        "next_node_id": 2,
-                        "source": "Piston Position Raw"
+                        "kind": "move_piston_controller",
+                        "algorithm": "Piston Fast",
+                        "direction": "DOWN",
+                        "speed": 6
+                    }
+                ],
+                "triggers": [
+                    {
+                        "kind": "exit",
+                        "next_node_id": 2
                     },
                     {
                         "kind": "button_trigger",
-                        "source": "Encoder Button",
+                        "next_node_id": end_node,
                         "gesture": "Single Tap",
-                        "next_node_id": end_node
+                        "source": "Encoder Button"
                     }
                 ]
             },
             {
                 "id": 2,
-                "controllers": [
-                    {
-                        "kind": "move_piston_controller",
-                        "algorithm": "Piston Ease-In",
-                        "direction": "DOWN",
-                        "speed": 6.0
-                    },
-                    {
-                        "kind": "time_reference",
-                        "id": 30
-                    }
-                ],
+                "controllers": [],
                 "triggers": [
                     {
                         "kind": "pressure_value_trigger",
@@ -57,12 +45,11 @@ def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
                         "next_node_id": 3
                     },
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
-                        "source": "Piston Position Raw",
+                        "kind": "timer_trigger",
+                        "timer_reference_id": 29,
                         "operator": ">=",
-                        "value": max_piston_position,
-                        "next_node_id": end_node
+                        "value": 1.5,
+                        "next_node_id": 21
                     },
                     {
                         "kind": "button_trigger",
@@ -87,18 +74,16 @@ def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
                                     6
                                 ]
                             ],
-                            "time_reference_id": 30
+                            "time_reference_id": 29
                         }
                     }
                 ],
                 "triggers": [
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
-                        "source": "Piston Position Raw",
-                        "operator": ">=",
-                        "value": max_piston_position,
-                        "next_node_id": end_node
+                        "kind": "piston_speed_trigger",
+                        "operator": "==",
+                        "value": 0,
+                        "next_node_id": 22
                     },
                     {
                         "kind": "button_trigger",
@@ -108,9 +93,100 @@ def get_prepurge_stage(parameters: json,start_node: int, end_node: int):
                     }
                 ]
             },
+            {
+            "id": 21,
+            "controllers": [
+                {
+                        "kind": "move_piston_controller",
+                        "algorithm": "Piston Ease-In",
+                        "direction": "DOWN",
+                        "speed": 6
+                    }
+                ],
+            "triggers": [
+                    {
+                        "kind": "piston_speed_trigger",
+                        "operator": "==",
+                        "value": 0,
+                        "next_node_id": 22
+                    },
+                    {
+                        "kind": "pressure_value_trigger",
+                        "source": "Pressure Raw",
+                        "operator": ">=",
+                        "value": 6,
+                        "next_node_id": 3
+                    },
+                    {
+                        "kind": "button_trigger",
+                        "next_node_id": end_node,
+                        "gesture": "Single Tap",
+                        "source": "Encoder Button"
+                    }
+                ]
+            },
+            {
+            "id": 22,
+            "controllers": [
+                    {
+                        "kind" : "time_reference",
+                        "id": 21
+                    }
+                ],
+                        "triggers": [
+                    {
+                        "kind": "exit",
+                        "next_node_id": 23
+                    }
+                ]
+            },
+            {
+            "id": 23,
+            "controllers": [],
+            "triggers": [
+                    {
+                        "kind": "piston_speed_trigger",
+                        "operator": "!=",
+                        "value": 0,
+                        "next_node_id": 22
+                    },
+                    {
+                        "kind": "timer_trigger",
+                        "timer_reference_id": 21,
+                        "operator": ">=",
+                        "value": 1,
+                        "next_node_id": 24
+                    },
+                    {
+                        "kind": "button_trigger",
+                        "next_node_id": end_node,
+                        "gesture": "Single Tap",
+                        "source": "Encoder Button"
+                    }
+                ]
+            },
+            {
+            "id": 24,
+            "controllers": [],
+            "triggers" : [
+                    {
+                        "kind": "timer_trigger",
+                        "timer_reference_id": 29,
+                        "operator": ">=",
+                        "value": 1,
+                        "next_node_id": end_node
+                    },
+                    {
+                        "kind": "button_trigger",
+                        "next_node_id": end_node,
+                        "gesture": "Single Tap",
+                        "source": "Encoder Button"
+                    }
+                ]
+            }
         ]
     }
-    
+
     # The merged dictionary is now in pre_purge_stage
     return prepurge_stage
     # return {}

--- a/modes/italian_1_0/remove_cup_stage.py
+++ b/modes/italian_1_0/remove_cup_stage.py
@@ -38,7 +38,7 @@ def get_remove_cup_stage(parameters: json, start_node: int, end_node: int):
           "kind": "timer_trigger",
           "timer_reference_id": 5,
           "operator": ">=",
-          "value": 2,
+          "value": 5,
           "next_node_id": end_node
          }
         ]

--- a/profile_converter/profile_converter.py
+++ b/profile_converter/profile_converter.py
@@ -29,23 +29,22 @@ class ComplexProfileConverter:
             "nodes": [
                 {
                 "id": -1,
-                "controllers": [],
-                "triggers": [
+                "controllers": [
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
-                        "next_node_id": 45,
-                        "source": "Piston Position Raw",
-                        "operator": ">=",
-                        "value": self.max_piston_position 
+                        "kind": "time_reference",
+                        "id": 20
                     },
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
-                        "next_node_id": 6,
-                        "source": "Piston Position Raw",
-                        "operator": "<",
-                        "value": self.max_piston_position 
+                        "kind": "move_piston_controller",
+                        "algorithm": "Piston Fast",
+                        "direction": "DOWN",
+                        "speed": 6
+                    }
+                ],
+                "triggers": [
+                    {
+                        "kind": "exit",
+                        "next_node_id": 1
                     },
                     {
                         "kind": "button_trigger",
@@ -56,34 +55,22 @@ class ComplexProfileConverter:
                 ]
                 },
                 {
-                "id": 6,
-                "controllers": [
-                    {
-                        "kind": "move_piston_controller",
-                        "speed": 6,
-                        "direction": "DOWN",
-                        "algorithm": "Piston Ease-In"
-                    },
-                    {
-                        "kind": "time_reference",
-                        "id": 3
-                    }
-                ],
+                "id": 1,
+                "controllers": [],
                 "triggers": [
                     {
                         "kind": "pressure_value_trigger",
-                        "next_node_id": 11,
+                        "next_node_id": 2,
                         "source": "Pressure Raw",
                         "operator": ">=",
                         "value": 6
                     },
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
-                        "next_node_id": 45,
-                        "source": "Piston Position Raw",
+                        "kind": "timer_trigger",
+                        "timer_reference_id": 20,
                         "operator": ">=",
-                        "value": self.max_piston_position 
+                        "value": 1.5,
+                        "next_node_id": 40
                     },
                     {
                         "kind": "button_trigger",
@@ -94,7 +81,7 @@ class ComplexProfileConverter:
                 ]
                 },
                 {
-                "id": 11,
+                "id": 2,
                 "controllers": [
                     {
                         "kind": "pressure_controller",
@@ -110,19 +97,108 @@ class ComplexProfileConverter:
                             ],
                             "reference": {
                             "kind": "time",
-                            "id": 3
+                            "id": 20
                             }
                         }
                     }
                 ],
                 "triggers": [
                     {
-                        "kind": "piston_position_trigger",
-                        "position_reference_id": 0,
+                        "kind": "piston_speed_trigger",
+                        "operator": "==",
+                        "value": 0,
+                        "next_node_id": 3
+                    },
+                    {
+                        "kind": "button_trigger",
                         "next_node_id": 45,
-                        "source": "Piston Position Raw",
+                        "gesture": "Single Tap",
+                        "source": "Encoder Button"
+                    }
+                ]
+                },
+                {
+                "id": 40,
+                "controllers": [
+                    {
+                        "kind": "move_piston_controller",
+                        "algorithm": "Piston Ease-In",
+                        "direction": "DOWN",
+                        "speed": 6
+                    }
+                ],
+                "triggers": [
+                    {
+                        "kind": "piston_speed_trigger",
+                        "operator": "==",
+                        "value": 0,
+                        "next_node_id": 3
+                    },
+                    {
+                        "kind": "pressure_value_trigger",
+                        "source": "Pressure Raw",
                         "operator": ">=",
-                        "value": self.max_piston_position 
+                        "value": 6,
+                        "next_node_id": 2
+                    },
+                    {
+                        "kind": "button_trigger",
+                        "next_node_id": 45,
+                        "gesture": "Single Tap",
+                        "source": "Encoder Button"
+                    }
+                    ]
+                },
+                {
+                "id": 3,
+                "controllers": [
+                    {
+                        "kind" : "time_reference",
+                        "id": 21
+                    }
+                    ],
+                        "triggers": [
+                    {
+                        "kind": "exit",
+                        "next_node_id": 6
+                    }
+                    ]
+                },
+                {
+                "id": 6,
+                "controllers": [],
+                "triggers": [
+                    {
+                        "kind": "piston_speed_trigger",
+                        "operator": "!=",
+                        "value": 0,
+                        "next_node_id": 3
+                    },
+                    {
+                        "kind": "timer_trigger",
+                        "timer_reference_id": 21,
+                        "operator": ">=",
+                        "value": 1,
+                        "next_node_id": 4
+                    },
+                    {
+                        "kind": "button_trigger",
+                        "next_node_id": 45,
+                        "gesture": "Single Tap",
+                        "source": "Encoder Button"
+                    }
+                ]
+                },
+                {
+                "id": 4,
+                "controllers": [],
+                "triggers" : [
+                    {
+                        "kind": "timer_trigger",
+                        "timer_reference_id": 20,
+                        "operator": ">=",
+                        "value": 1,
+                        "next_node_id": 45
                     },
                     {
                         "kind": "button_trigger",
@@ -274,7 +350,7 @@ class ComplexProfileConverter:
                     "controllers": [
                         {
                             "kind": "time_reference",
-                            "id": 3
+                            "id": 10
                         }    
                     ],
                     "triggers": [
@@ -301,7 +377,7 @@ class ComplexProfileConverter:
                     "triggers": [
                         {
                             "kind": "timer_trigger",
-                            "timer_reference_id": 3,
+                            "timer_reference_id": 10,
                             "next_node_id": 8,
                             "operator": ">=",
                             "value": 1
@@ -690,81 +766,183 @@ class ComplexProfileConverter:
               "name": "purge",
               "nodes": [
                     {
-                        "id": 31,
-                        "controllers": [
-                            {
-                            "kind": "move_piston_controller",
-                            "speed": 6,
-                            "direction": "DOWN",
-                            "algorithm": "Piston Ease-In"
-                            },
-                            {
+                    "id": 31,
+                    "controllers": [
+                        {
                             "kind": "time_reference",
-                            "id": 8
-                            }
-                        ],
-                        "triggers": [
-                            {
-                            "kind": "pressure_value_trigger",
-                            "next_node_id": 32,
-                            "source": "Pressure Raw",
-                            "operator": ">=",
-                            "value": 6
-                            },
-                            {
-                            "kind": "piston_position_trigger",
-                            "position_reference_id": 0,
-                            "next_node_id": -2,
-                            "source": "Piston Position Raw",
-                            "operator": ">=",
-                            "value": self.max_piston_position 
-                            },
-                            {
+                            "id": 22
+                        },
+                        {
+                            "kind": "move_piston_controller",
+                            "algorithm": "Piston Fast",
+                            "direction": "DOWN",
+                            "speed": 6
+                        }
+                    ],
+                    "triggers": [
+                        {
+                            "kind": "exit",
+                            "next_node_id": 32
+                        },
+                        {
                             "kind": "button_trigger",
                             "next_node_id": -2,
                             "gesture": "Single Tap",
                             "source": "Encoder Button"
-                            }
-                        ]
+                        }
+                    ]
                     },
                     {
-                        "id": 32,
-                        "controllers": [
-                            {
+                    "id": 32,
+                    "controllers": [],
+                    "triggers": [
+                        {
+                            "kind": "pressure_value_trigger",
+                            "source": "Pressure Raw",
+                            "operator": ">=",
+                            "value": 6,
+                            "next_node_id": 33
+                        },
+                        {
+                            "kind": "timer_trigger",
+                            "timer_reference_id": 22,
+                            "operator": ">=",
+                            "value": 1.5,
+                            "next_node_id": 34
+                        },
+                        {
+                            "kind": "button_trigger",
+                            "next_node_id": -2,
+                            "gesture": "Single Tap",
+                            "source": "Encoder Button"
+                        }
+                    ]
+                    },
+                    {
+                    "id": 33,
+                    "controllers": [
+                        {
                             "kind": "pressure_controller",
                             "algorithm": "Pressure PID v1.0",
                             "curve": {
-                                "id": 5,
+                                "id": 10,
                                 "interpolation_kind": "linear_interpolation",
-                                "points": [
-                                    [
-                                        0,
-                                        6
-                                    ]
-                                ],
-                                "reference": {
-                                    "kind": "time",
-                                    "id": 8
-                                }
+                                "points": [[0, 6]],
+                                "time_reference_id": 22
                             }
-                            }
-                        ],
-                        "triggers": [
-                            {
-                            "kind": "piston_position_trigger",
-                            "position_reference_id": 0,
-                            "next_node_id": -2,
-                            "source": "Piston Position Raw",
-                            "operator": ">=",
-                            "value": self.max_piston_position 
-                            },
-                            {
+                        }
+                    ],
+                    "triggers": [
+                        {
+                            "kind": "piston_speed_trigger",
+                            "operator": "==",
+                            "value": 0,
+                            "next_node_id": 35
+                        },
+                        {
                             "kind": "button_trigger",
                             "next_node_id": -2,
                             "gesture": "Single Tap",
                             "source": "Encoder Button"
-                            }
-                        ]
+                        }
+                    ]
+                    },
+                    {
+                    "id": 34,
+                    "controllers": [
+                        {
+                            "kind": "move_piston_controller",
+                            "algorithm": "Piston Ease-In",
+                            "direction": "DOWN",
+                            "speed": 6
+                        }
+                    ],
+                    "triggers": [
+                        {
+                            "kind": "piston_speed_trigger",
+                            "operator": "==",
+                            "value": 0,
+                            "next_node_id": 35
+                        },
+                        {
+                            "kind": "pressure_value_trigger",
+                            "source": "Pressure Raw",
+                            "operator": ">=",
+                            "value": 6,
+                            "next_node_id": 33
+                        },
+                        {
+                            "kind": "button_trigger",
+                            "next_node_id": -2,
+                            "gesture": "Single Tap",
+                            "source": "Encoder Button"
+                        }
+                    ]
+                    },
+                    {
+                    "id": 35,
+                    "controllers": [
+                        {
+                            "kind" : "time_reference",
+                            "id": 23
+                        }
+                    ],
+                    "triggers": [
+                        {
+                            "kind": "exit",
+                            "next_node_id": 36
+                        },
+                        {
+                            "kind": "button_trigger",
+                            "next_node_id": -2,
+                            "gesture": "Single Tap",
+                            "source": "Encoder Button"
+                        }
+                    ]
+                    },
+                    {
+                    "id": 36,
+                    "controllers": [],
+                    "triggers": [
+                        {
+                            "kind": "piston_speed_trigger",
+                            "operator": "!=",
+                            "value": 0,
+                            "next_node_id": 35
+                        },
+                        {
+                            "kind": "timer_trigger",
+                            "timer_reference_id": 23,
+                            "operator": ">=",
+                            "value": 1,
+                            "next_node_id": 37
+                        },
+                        {
+                            "kind": "button_trigger",
+                            "next_node_id": -2,
+                            "gesture": "Single Tap",
+                            "source": "Encoder Button"
+                        }
+                    ]
+                    },
+                    {
+                    "id": 37,
+                    "controllers": [],
+                    "triggers" : [
+                        {
+                            "kind": "timer_trigger",
+                            "timer_reference_id": 22,
+                            "operator": ">=",
+                            "value": 1,
+                            "next_node_id": -2
+                        },
+                        {
+                            "kind": "button_trigger",
+                            "next_node_id": -2,
+                            "gesture": "Single Tap",
+                            "source": "Encoder Button"
+                        }
+                    ]
                     }
                 ]
               },


### PR DESCRIPTION
Work:

- Added a purge logic to work without maximum distance.

- Edit remove cup timeout for automatic purge after finishing coffee. Changed to 5 seconds. 

Problem:

The motors have different maximum distance, so a proposal to solve this is to make a purge routine with no maximum distance and only stop if the speed is equal to 0 at least 2 seconds. 