### PR TITLE
Fix API history endpoint

### DIFF
--- a/api/history.py
+++ b/api/history.py
@@ -14,7 +14,7 @@ from .base_handler import BaseHandler
 from .api import API, APIVersion
 
 logger = MeticulousLogger.getLogger(__name__)
-
+last_version_path = f"/api/{APIVersion.latest_version().name.lower()}"
 
 class ZstdHistoryHandler(tornado.web.StaticFileHandler):
     async def get(self, path, include_body=True):
@@ -66,19 +66,14 @@ class ZstdHistoryHandler(tornado.web.StaticFileHandler):
         # Ensure content type for served files is correct
         return 'application/octet-stream'
 
-
-class ZstdDebugHandler(ZstdHistoryHandler):
-    def get_content_type(self):
-        return "text/plain; charset=utf-8"
-
-
 API.register_handler(APIVersion.V1, r'/history/debug',
-                     tornado.web.RedirectHandler, url="/history/debug/"),
+                     tornado.web.RedirectHandler, url=f"{last_version_path}/history/debug/"),
 
 API.register_handler(APIVersion.V1, r'/history/debug/(.*)',
-                     ZstdDebugHandler, path=DEBUG_HISTORY_PATH),
+                     ZstdHistoryHandler, path=DEBUG_HISTORY_PATH),
 
 API.register_handler(APIVersion.V1, r'/history',
-                     tornado.web.RedirectHandler, url="/history/"),
-API.register_handler(APIVersion.V1, r'/history/(.*)',
+                     tornado.web.RedirectHandler, url=f"{last_version_path}/history/"),
+
+API.register_handler(APIVersion.V1, r'/history/((?!debug)).*)',
                      ZstdHistoryHandler, path=HISTORY_PATH),


### PR DESCRIPTION
The redirect from `history` to `history/` and from `history/debug` to `history/debug/` got broken when the transition to the versioned API, the URL used to redirect was not taking into account the version prefix as it was added to the URL on the `get_routes()` method of the API class and the redirect was manually added to the request handler.

The previous location of the debug logs hid a bug using the `history/` endpoint. When trying to access the `history/debug` endpoint, request was catched by the `history` endpoint due to the `history/(.*)` regex so the directory looked for was `meticulous-user/history/debug` which is no longer existing.

This commit fixes the redirect by getting the latest API version prefix and appending it to the URL used to redirect, also adds an exclusion regex for the `debug` pattern on the history endpoint regex, with this, the debug endpoint is now accessible at `history/debug`.