### PR TITLE
feat(italian mode and profile converter)

### DIFF
--- a/modes/italian_1_0/end_purge_stage.py
+++ b/modes/italian_1_0/end_purge_stage.py
@@ -75,7 +75,7 @@ def get_end_purge_stage(parameters: json, start_node: int, end_node: int):
                         ],
                         "reference": {
                         "kind": "time",
-                        "id": 8
+                        "id": 12
                         }
                     }
                 }
@@ -173,7 +173,7 @@ def get_end_purge_stage(parameters: json, start_node: int, end_node: int):
             "triggers" : [
                 {
                     "kind": "timer_trigger",
-                    "timer_reference_id": 8,
+                    "timer_reference_id": 12,
                     "operator": ">=",
                     "value": 1,
                     "next_node_id": end_node

--- a/modes/italian_1_0/heating_stage.py
+++ b/modes/italian_1_0/heating_stage.py
@@ -59,7 +59,7 @@ def get_heating_stage(parameters: json, start_node: int, end_node: int):
                     "kind": "button_trigger",
                     "source": "Encoder Button",
                     "gesture": "Single Tap",
-                    "next_node_id": 6,
+                    "next_node_id": start_node_preheat,
                 },
             ],
             },
@@ -150,14 +150,40 @@ def get_heating_stage(parameters: json, start_node: int, end_node: int):
             "nodes": [
                 {
                 "id": start_node_preheat,
+                "controllers": [
+                {
+                    "kind": "log_controller",
+                    "message": "Click to start"
+                },
+                {
+                    "kind": "time_reference",
+                    "id": 14
+                }
+                ],
+                "triggers": [
+                {
+                    "kind": "exit",
+                    "next_node_id": 50
+                }
+                ]
+                },
+                {
+                "id": 50,
                 "controllers": [],
                 "triggers": [
-                    {
+                {
                         "kind": "button_trigger",
                         "source": "Encoder Button",
                         "gesture": "Single Tap",
                         "next_node_id": end_node,
-                    },
+                },
+                {
+                    "kind": "timer_trigger",
+                    "timer_reference_id": 14,
+                    "next_node_id": -2,
+                    "operator": ">=",
+                    "value": 600
+                },
                 ],
                 },
             ],

--- a/modes/italian_1_0/infusion_stage.py
+++ b/modes/italian_1_0/infusion_stage.py
@@ -87,67 +87,6 @@ def get_infusion_stage(parameters: json, start_node: int, end_node: int):
                "next_node_id": end_node
               },
               {
-               "kind": "flow_value_trigger",
-               "source": "Flow Raw",
-               "operator": ">=",
-               "value": 8,
-               "next_node_id": 20
-              },
-              {
-               "kind": "button_trigger",
-               "source": "Encoder Button",
-               "gesture": "Single Tap",
-               "next_node_id": end_node
-              }
-             ]
-            },
-            {
-             "id": 20,
-             "controllers": [
-              {
-               "kind": "flow_controller",
-               "algorithm": "Flow PID v1.0",
-               "curve": {
-                "id": 9,
-                "interpolation_kind": "catmull_interpolation",
-                "points": [
-                 [
-                  0,
-                  8
-                 ]
-                ],
-                "time_reference_id": 4
-               }
-              },
-              {
-               "kind": "position_reference",
-               "id": 1
-              }
-             ],
-             "triggers": [
-              {
-               "kind": "timer_trigger",
-               "timer_reference_id": 4,
-               "operator": ">=",
-               "value": 100,
-               "next_node_id": end_node
-              },
-              {
-               "kind": "weight_value_trigger",
-               "source": "Weight Raw",
-               "weight_reference_id": 1,
-               "operator": ">=",
-               "value": out_weight,
-               "next_node_id": end_node
-              },
-              {
-               "kind": "pressure_curve_trigger",
-               "source": "Pressure Raw",
-               "operator": ">=",
-               "curve_id": 7,
-               "next_node_id": 13
-              },
-              {
                "kind": "button_trigger",
                "source": "Encoder Button",
                "gesture": "Single Tap",
@@ -162,7 +101,7 @@ def get_infusion_stage(parameters: json, start_node: int, end_node: int):
     
 if __name__ == '__main__':
   
-    parameters = '{"preheat": true,"temperature": 200}'
+    parameters = '{"preheat": true,"temperature": 200, "out_weight": 0.3, "pressure": 8}'
 
     json_parameters = json.loads(parameters)
 

--- a/modes/italian_1_0/preinfusion_stage.py
+++ b/modes/italian_1_0/preinfusion_stage.py
@@ -2,6 +2,12 @@ import json
 
 def get_preinfusion_stage(parameters: json, start_node: int, end_node: int):
     
+    try:
+        pressure = parameters["pressure"]
+    except:
+        print('Error: Pressure is not defined')
+        return None
+    
     preinfusion_stage =   {
       "name": "preinfusion",
       "nodes": [
@@ -40,7 +46,7 @@ def get_preinfusion_stage(parameters: json, start_node: int, end_node: int):
           "kind": "pressure_value_trigger",
           "source": "Pressure Predictive",
           "operator": ">=",
-          "value": 8,
+          "value": pressure,
           "next_node_id": 11
          },
          {
@@ -71,7 +77,7 @@ def get_preinfusion_stage(parameters: json, start_node: int, end_node: int):
            "points": [
             [
              0,
-             8
+             pressure
             ]
            ],
            "time_reference_id": 3
@@ -120,7 +126,7 @@ def get_preinfusion_stage(parameters: json, start_node: int, end_node: int):
 
 if __name__ == '__main__':
   
-    parameters = '{"preheat": true,"temperature": 200}'
+    parameters = '{"preheat": true,"temperature": 200, "out_weight": 0.3, "pressure": 3.5}'
 
     json_parameters = json.loads(parameters)
 

--- a/profile_converter/profile_converter.py
+++ b/profile_converter/profile_converter.py
@@ -334,7 +334,7 @@ class ComplexProfileConverter:
                     },
                     {
                         "kind": "button_trigger",
-                        "next_node_id": 5,
+                        "next_node_id": 16,
                         "gesture": "Single Tap",
                         "source": "Encoder Button"
                     }
@@ -434,14 +434,35 @@ class ComplexProfileConverter:
                         {
                             "kind": "log_controller",
                             "message": "Click to start"
+                        },
+                        {
+                            "kind": "time_reference",
+                            "id": 30
                         }
                     ],
+                    "triggers": [
+                        {
+                            "kind": "exit",
+                            "next_node_id": 25
+                        }
+                    ]
+                },
+                {
+                    "id": 25,
+                    "controllers": [],
                     "triggers": [
                         {
                             "kind": "button_trigger",
                             "next_node_id": 17,
                             "gesture": "Single Tap",
                             "source": "Encoder Button"
+                        },
+                        {
+                            "kind": "timer_trigger",
+                            "timer_reference_id": 30,
+                            "next_node_id": -2,
+                            "operator": ">=",
+                            "value": 600
                         }
                     ]
                 }


### PR DESCRIPTION
- A timeout has been added to skip the click-to-start stage if there is no response after 10 minutes. 

- There was a bug in the warm-up stage, because you had to click twice to skip the stage. Now you only have to press the encoder button once. 

- We removed the flow limit control from the pre-infusion, this in order to get a better control of the pressure in the infusion. This is according to Henry's test results. 