### PR TITLE
Fix: Incorrect character for new workflow

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -364,7 +364,7 @@ class Machine:
         logger.info(f"JSON Hash: {json_hash}")
 
         start = time.time()
-        Machine.write("hash ".encode("utf-8"))
+        Machine.write("hash,".encode("utf-8"))
         Machine.write(json_hash.encode("utf-8"))
         Machine.write("\x03".encode("utf-8"))
         Machine.write(json_data.encode("utf-8"))


### PR DESCRIPTION
We have been sending 'hash ' when transmitting the hash. It has worked so far due to the previous
method of "parsing data" . With the refactor on how data is parsed on the ESP32, consistency is needed in those messages. 'hash ' has been changed to 'hash,'.