### PR TITLE
fix: reset action

### DIFF
--- a/api/action.py
+++ b/api/action.py
@@ -10,14 +10,21 @@ logger = MeticulousLogger.getLogger(__name__)
 
 class ExecuteActionHandler(BaseHandler):
     def post(self, action):
-        allowed_actions = ["start", "stop", "reset", "tare"]
-        if action in allowed_actions:
+        BACKEND_ACTIONS = ["reset"]
+        ESP_ACTIONS = ["start", "stop", "tare"]
+        allowed_actions = BACKEND_ACTIONS + ESP_ACTIONS
+        if action in ESP_ACTIONS:
             success = Machine.action(action_event=action)
             if success:
                 self.write(json.dumps({"action": action, "status": "ok"}))
             else:
                 self.set_status(409)
                 self.write(json.dumps({"status": "error", "action": action}))
+        elif action in BACKEND_ACTIONS:
+            match action:
+                case "reset":
+                    Machine.reset()
+                    self.write(json.dumps({"action": action, "status": "ok"}))
         else:
             self.set_status(400)
             self.write(


### PR DESCRIPTION
When receiving a reset action, the API was forwarding the action to the ESP32, but it cannot reset itself, so the action was not being executed even is the response was successful, this commit separates the valid actions to ESP_ACTIONS and BACKEND_ACTIONS, so the reset action is not forwarded to the ESP32 but executed by the backend itself. The new ESP_ACTIONS are: "start", "stop", "tare"
while the BACKEND_ACTIONS are: "reset"