### PR TITLE
Fix Typo Causing Backend Crash on Debug Profile Saving

### DIFF
--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -46,7 +46,7 @@ class DebugData:
 
         shotFields = list(emptyShot.__dict__.keys())
         sensorFields = list(emptySensors.__dict__.keys())
-        classFields = ["startTime", "profile_time"]
+        classFields = ["startTime", "profile_ms"]
 
         allFields = shotFields + sensorFields + classFields
 


### PR DESCRIPTION
This PR fixes a typo that was causing the backend to crash when the option to save debug profiles was enabled. The crash occurred at the moment of profile completion.