### PR TITLE
feat(machine): emit heater status when preheat is complete

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -276,6 +276,9 @@ class Machine:
                                 timeoutArgs
                             )
                             Machine.heater_timeout_info = heater_timeout_info
+                            if heater_timeout_info.preheat_remaining == 0:
+                                await Machine._sio.emit("heater_status", "off")
+                                logger.info("Emitted heater_status: off")
                         except Exception as e:
                             logger.error(
                                 f"Error processing HeaterTimeoutInfo: {e}",


### PR DESCRIPTION
Add logic to emit 'heater_status: off' when preheating completes. This improves tracking of heater status in real-time.

- Emit 'heater_status: off' if preheat_remaining equals 0
- Log heater status emission for tracking