### PR TITLE
feat(machine): emit preheat_remaining every second during preheat

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -276,9 +276,11 @@ class Machine:
                                 timeoutArgs
                             )
                             Machine.heater_timeout_info = heater_timeout_info
+                            await Machine._sio.emit(
+                                "heater_status", heater_timeout_info.preheat_remaining
+                            )
                             if heater_timeout_info.preheat_remaining == 0:
-                                await Machine._sio.emit("heater_status", "off")
-                                logger.info("Emitted heater_status: off")
+                                logger.info("Heater_status: off")
                         except Exception as e:
                             logger.error(
                                 f"Error processing HeaterTimeoutInfo: {e}",


### PR DESCRIPTION
Ensure consistent emission of heater preheat status by sending 'preheat_remaining' every second until the preheat completes.

- Add emission of 'heater_timeout_info.preheat_remaining' every second
- Remove redundant emission of 'heater_status: off' when preheat is 0
- Retain logging of 'heater_status: off' for visibility