### PR TITLE
Feat: Predictive weight enable

### DIFF
--- a/profile_converter/simplified_json.py
+++ b/profile_converter/simplified_json.py
@@ -227,7 +227,7 @@ class SimplifiedJson:
                             reference_id = 1
                         weight_comparison = self.set_comparison_type(json_comparison)
                         exit_trigger = WeightTrigger(
-                            SourceType.RAW,
+                            SourceType.PREDICTIVE,
                             weight_comparison,
                             exit_trigger_value,
                             reference_id,
@@ -420,7 +420,7 @@ class SimplifiedJson:
                 ButtonSourceType.ENCODER_BUTTON, next_node_id=next_stage_node_id
             )
             weight_final_trigger = WeightTrigger(
-                SourceType.RAW,
+                SourceType.PREDICTIVE,
                 TriggerOperatorType.GREATER_THAN_OR_EQUAL,
                 self.get_final_weight(),
                 1,


### PR DESCRIPTION
With the firmware update, the weight prediction has been enabled. However, JSONs generated in the backend are hardcoded to use "Weight Raw" as a source. To ensure that this option is widely used, the source has been changed to "Weight Predictive." Further discussion should be held to enable the use of raw or predictive triggers based on user preferences.