### PR TITLE
Handle nan values

### DIFF
--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -17,6 +17,7 @@ def safeFloat(val):
         return 0
     return convert
 
+
 def safe_float_with_nan(value):
     try:
         f_value = float(value)
@@ -25,6 +26,7 @@ def safe_float_with_nan(value):
         return f_value
     except ValueError:
         return "NaN"
+
 
 @dataclass
 class SensorData:


### PR DESCRIPTION
## What was done?
replace "nan" values with string literal "NaN" when sending sensor data through Socket.io

## Why?
The value NaN causes issues with socket.io-client, leading to socket disconnections as it fails to process messages containing that value. The NaN value does not reach the client due to the communication interruption. Therefore, when sending the string literal "NaN", it should be handled appropriately to avoid errors or exceptions.
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/a5c24d8a-6a8b-4625-ab4f-8dc73e5df3db">
Message after changes
<img width="1484" alt="image" src="https://github.com/user-attachments/assets/b9f06f97-4175-4891-abc2-c91b5c741135">


