### PR TITLE
fix(serial-number): generate random serial if missing

### DIFF
--- a/api/machine.py
+++ b/api/machine.py
@@ -123,9 +123,12 @@ class MachineInfoHandler(BaseHandler):
         if Machine.esp_info is not None:
             response["firmware"] = Machine.esp_info.firmwareV
 
-        response["serial"] = ""
-        if MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER] is not None:
-            response["serial"] = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]
+        serial = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]
+        if serial is None or serial == "":
+            serial = Machine.generate_random_serial()
+            MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER] = serial
+            MeticulousConfig.save()
+        response["serial"] = serial
 
         response["color"] = ""
         if MeticulousConfig[CONFIG_SYSTEM][MACHINE_COLOR] is not None:

--- a/machine.py
+++ b/machine.py
@@ -80,6 +80,19 @@ class Machine:
 
     is_idle = True
 
+    @staticmethod
+    def generate_random_serial():
+        """
+        Generates a random serial number when none is assigned.
+        Format: 999XXXXX where X are random digits.
+        Returns: String with format '999' followed by 5 random digits
+        """
+        import random
+        import string
+
+        random_digits = "".join(random.choices(string.digits, k=5))
+        return f"999{random_digits}"
+
     def check_machine_alive():
         if not Machine.infoReady:
             if MeticulousConfig[CONFIG_USER][DISALLOW_FIRMWARE_FLASHING]:


### PR DESCRIPTION
# Add automatic serial number generation for machines with empty SN

## Problem
The mobile app is experiencing issues with machine selection due to non-unique identifiers when machines have empty serial numbers. When multiple machines lack a serial number, they all return empty strings, causing the mobile app to potentially select incorrect machines as it cannot distinguish between them.

## Solution
Implemented an automatic serial number generation system that creates unique identifiers for machines that lack a serial number. The generated serial numbers follow a specific format (`999XXXXX`) where:
- `999` prefix indicates the serial number was auto-generated
- `XXXXX` represents 5 random digits ensuring uniqueness

## Implementation Details
Added new functionality in `api/machine.py`:
```python
@staticmethod
def generate_random_serial():
    """
    Generates a random serial number when none is assigned.
    Format: 999XXXXX where X are random digits.
    Returns: String with format '999' followed by 5 random digits
    """
    import random
    import string
    random_digits = "".join(random.choices(string.digits, k=5))
    return f"999{random_digits}"
```

Modified the GET endpoint to handle empty serial numbers:
```python
serial = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]
if serial is None or serial == "":
    serial = Machine.generate_random_serial()
    MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER] = serial
    MeticulousConfig.save()
response["serial"] = serial
```