### PR TITLE
feat(machine): add mainVoltage to response payload

### DIFF
--- a/api/machine.py
+++ b/api/machine.py
@@ -122,6 +122,7 @@ class MachineInfoHandler(BaseHandler):
 
         if Machine.esp_info is not None:
             response["firmware"] = Machine.esp_info.firmwareV
+            response["mainVoltage"] = Machine.esp_info.mainVoltage
 
         serial = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]
         if serial is None or serial == "":


### PR DESCRIPTION
Includes mainVoltage in the response of the MachineInfoHandler endpoint. This allows easier access to voltage data, which is useful for future testing.

- Add mainVoltage to the response payload in MachineInfoHandler