### PR TITLE
Purge trigger added to end a profile

### DIFF
--- a/profile_converter/profile_converter.py
+++ b/profile_converter/profile_converter.py
@@ -1106,20 +1106,20 @@ class ComplexProfileConverter:
                         "triggers": (
                             [
                                 {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 22,
-                                    "operator": ">=",
-                                    "value": 1,
+                                    "kind": "pressure_value_trigger",
+                                    "source": "Pressure Raw",
+                                    "operator": "<=",
+                                    "value": 0.5,
                                     "next_node_id": -2,
                                 }
                             ]
                             if no_skipping
                             else [
                                 {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 22,
-                                    "operator": ">=",
-                                    "value": 1,
+                                    "kind": "pressure_value_trigger",
+                                    "source": "Pressure Raw",
+                                    "operator": "<=",
+                                    "value": 0.5,
                                     "next_node_id": -2,
                                 },
                                 {


### PR DESCRIPTION
These modifications are intended to ensure that the profile ends when the pressure, after purging, is equal to or less than 0.5 bar. Currently, the profile ends once the motor completes its cycle, which can sometimes result in a residual pressure of up to 6 bar. This makes it impossible to remove the portafilter