### PR TITLE
profile_converter: Reduce max piston position to 77 to ensure we dont flicker on purge startup

### DIFF
--- a/profile_converter/profile_converter.py
+++ b/profile_converter/profile_converter.py
@@ -25,7 +25,7 @@ class ComplexProfileConverter:
         self.temperature = self.complex.get_temperature()
         # Use this value to prevent overshooting with a global offset
         self.offset_temperature = 0
-        self.max_piston_position = 81
+        self.max_piston_position = 77
 
     def head_template(self):
         no_skipping = not MeticulousConfig[CONFIG_USER][MACHINE_ALLOW_STAGE_SKIPPING]


### PR DESCRIPTION
The purge max position is used as a descision tool if the machine is already purged fully. 
If it is not we do not need to show the purging screen in the dial app.
It is therefore important that the machine knows if it has purged already.