### PR TITLE
fix: multi update settings via SettingsHandler

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -54,22 +54,24 @@ class SettingsHandler(BaseHandler):
             )
             return
 
+        complete_success: bool = True
+        any_success: bool = False
         for setting_target in settings:
             value = settings.get(setting_target)
             setting = MeticulousConfig[CONFIG_USER].get(setting_target)
             if setting is not None:
+                save_value = True
                 if type(value) is not type(setting):
-                    self.set_status(404)
+                    complete_success = False
+                    self.set_status(404 if not any_success else 207)
                     self.write(
                         {
                             "status": "error",
-                            "error": f"setting value invalid, expected {type(setting)}",
                             "setting": setting_target,
-                            "value": value,
+                            "details": f"setting value invalid, received {type(value)} and expected {type(setting)}",
                         }
                     )
-                    MeticulousConfig.load()
-                    return
+                    save_value = False
                 if setting_target == TIMEZONE_SYNC:
                     status = "Success"
                     if (
@@ -79,11 +81,23 @@ class SettingsHandler(BaseHandler):
 
                         status = await TimezoneManager.request_and_sync_tz()
                         logger.debug(f"timezone endpoint status: {status}")
-                    MeticulousConfig[CONFIG_USER][setting_target] = value
-                    MeticulousConfig.save()
-                    self.set_status(200)
-                    self.write({"status": status})
-                    return
+
+                    any_success = any_success or status == "Success"
+                    self.set_status(
+                        200
+                        if (complete_success and status == "Success")
+                        else 207 if (any_success and status == "Success") else 404
+                    )
+
+                    if status != "Success":
+                        self.write(
+                            {
+                                "status": "error",
+                                "setting": TIMEZONE_SYNC,
+                                "details": f"{status}",
+                            }
+                        )
+                        complete_success = False
 
                 if setting_target == TIME_ZONE:
                     try:
@@ -93,10 +107,23 @@ class SettingsHandler(BaseHandler):
                         logger.error(f"Failed setting the new timezone\n\t{e}")
                         status = f"failed to set new timezone: {e}"
 
-                    self.set_status(200 if status == "Success" else 400)
-                    self.write({"status": f"{status}"})
-                    MeticulousConfig[CONFIG_USER][setting_target] = value
-                    return
+                    any_success = any_success or status == "Success"
+                    self.set_status(
+                        200
+                        if (complete_success and status == "Success")
+                        else 207 if (any_success and status == "Success") else 404
+                    )
+
+                    if status != "Success":
+                        complete_success = False
+                        self.write(
+                            {
+                                "status": "error",
+                                "setting": TIME_ZONE,
+                                "details": f"{status}",
+                            }
+                        )
+                    save_value = False  # the value is saved by the function TimezoneManager.update_timezone()
 
                 if setting_target == MACHINE_HEATING_TIMEOUT:
                     try:
@@ -104,47 +131,49 @@ class SettingsHandler(BaseHandler):
                     except ValueError as e:
                         error_message = str(e)
                         logger.warning(f"Invalid heater timeout value: {error_message}")
-                        self.set_status(400)
                         self.write(
                             {
                                 "status": "error",
-                                "error": "invalid heater timeout value",
-                                "details": error_message,
+                                "setting": MACHINE_HEATING_TIMEOUT,
+                                "details": f"invalid heater timeout value: {error_message} ",
                             }
                         )
-                        return
+                        complete_success = False
+                        save_value = False
 
-                MeticulousConfig[CONFIG_USER][setting_target] = value
+                    self.set_status(
+                        200 if complete_success else 207 if any_success else 404
+                    )
 
                 if setting_target == USB_MODE:
                     try:
                         USB_MODES(value)
-                        USBManager.setUSBMode()
-                    except ValueError:
+                        USBManager.setUSBMode(value)
+                    except (ValueError, RuntimeError) as error:
                         self.set_status(400)
+                        complete_success = False
                         self.write(
                             {
                                 "status": "error",
-                                "error": "invalid USB mode",
-                                "setting": setting_name,
-                                "value": value,
+                                "setting": USB_MODE,
+                                "details": f"{error}",
                             }
                         )
                         logger.info(f"Invalid USB mode: {value}")
-                        MeticulousConfig.load()
-                        return
+                        save_value = False
+
+                if save_value:
+                    MeticulousConfig[CONFIG_USER][setting_target] = value
             else:
-                self.set_status(404)
+                self.set_status(207 if any_success else 404)
                 self.write(
                     {
                         "status": "error",
-                        "error": "setting not found",
                         "setting": setting_target,
+                        "details": "setting not found",
                     }
                 )
                 logger.info(f"Setting not found: {setting_target}")
-                MeticulousConfig.load()
-                return
         MeticulousConfig.save()
         UpdateManager.setChannel(MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL])
         return self.get()

--- a/usb.py
+++ b/usb.py
@@ -16,18 +16,26 @@ class USBManager:
             return
         USBManager.usbPdController = PTN5150H()
         logger.info("USB PD Controller initialized")
-        USBManager.setUSBMode()
+        try:
+            USB_MODES(MeticulousConfig[CONFIG_USER][USB_MODE])
+            USBManager.setUSBMode(MeticulousConfig[CONFIG_USER][USB_MODE])
+        except RuntimeError as error:
+            logger.error(
+                f"error initializing USB Manager: f{error}, starting USB as client"
+            )
+            USBManager.setUSBMode(USB_MODES.CLIENT.value)
 
     @staticmethod
-    def setUSBMode():
+    def setUSBMode(new_usb_mode):
         logger.warning("Setting USB mode is temporarely disabled")
         return
+
         if Machine.emulated:
             logger.info("Emulated machine, skipping USB mode setup")
             return
         ptn = USBManager.usbPdController
 
-        match MeticulousConfig[CONFIG_USER][USB_MODE]:
+        match new_usb_mode:
             case USB_MODES.CLIENT.value:
                 logger.info("Setting USB mode to CLIENT")
                 ptn.set_port_state(PortState.UFP)
@@ -37,9 +45,7 @@ class USBManager:
             case USB_MODES.DUAL.value:
                 logger.info("Setting USB mode to DUAL")
                 ptn.set_port_state(PortState.DRP)
-
             case _:
-                logger.error(
-                    f"Unknown USB mode {MeticulousConfig[CONFIG_USER][USB_MODE]}"
-                )
+                logger.error(f"Unknown USB mode {new_usb_mode}")
+                raise RuntimeError(f"Unknown USB mode {new_usb_mode}")
         ptn.set_rp_selection(RpSelection.X330_uA)


### PR DESCRIPTION
When usind the SettingsHandler, the workflow should allow to modify multiple settings with one request, but rn if any of the provided settings fails to update correctly, any further setting changes are aborted as the function returns.

Now, the function can handle individual failure cases for the already defined settings. All the errors encountered are reported back in the request response body and the status code for the request can vary from `200 (OK)` when no settings encounter errors, `207 (Multi-status)` when at least 1 setting was successfully updated and `404 (not found)` when none of the settings were successfully updated

## Aditional changes to `usb.py`

In order to avoid the method USBManager.setUSBMode() to rely on the loaded value of the MeticulousConfig dictionary -that made necessary to update it first before calling the function- the value is passed as a parameter to the function, also in case that the value is not valid, a RuntimeError is raised