### PR TITLE
net: fetch timezone in the background once networking is available

### DIFF
--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -6,6 +6,8 @@ from config import (
     MeticulousConfig,
     CONFIG_USER,
     TIME_ZONE,
+    TIMEZONE_SYNC,
+    DEFAULT_TIME_ZONE,
 )
 import asyncio
 from datetime import datetime
@@ -240,6 +242,17 @@ class TimezoneManager:
                 "Json file for UI timezones does not exist and could not be created"
             )
             return {}
+
+    @staticmethod
+    def tz_background_update():
+        tz = MeticulousConfig[CONFIG_USER][TIME_ZONE]
+        tz_config = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
+        if tz == DEFAULT_TIME_ZONE and tz_config == "automatic":
+            logger.info(
+                "Timezone is set to automatic, fetching timezone in the background"
+            )
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(TimezoneManager.request_and_sync_tz())
 
     @staticmethod
     async def request_and_sync_tz() -> str:

--- a/wifi.py
+++ b/wifi.py
@@ -22,6 +22,8 @@ from config import (
     MeticulousConfig,
 )
 from hostname import HostnameManager
+from timezone_manager import TimezoneManager
+
 from log import MeticulousLogger
 from named_thread import NamedThread
 
@@ -204,6 +206,7 @@ class WifiManager:
         return WifiManager._networking_available
 
     def tryAutoConnect():
+        logger.info("Starting Networking background Thread")
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         while True:
@@ -212,8 +215,10 @@ class WifiManager:
             if MeticulousConfig[CONFIG_WIFI][WIFI_MODE] == WIFI_MODE_AP:
                 continue
 
+            # Check if we are already connected to something
             current = WifiManager.getCurrentConfig()
             if current.connected:
+                TimezoneManager.tz_background_update()
                 continue
 
             networks = WifiManager.scanForNetworks(timeout=10)


### PR DESCRIPTION
example logs:
```
Feb 17 01:38:40 meticulousDevMimojaFika1 python3[7335]: 2025-02-17 01:38:40,655 timezone_manager INFO Timezone is set to automatic, fetching timezone in the background
[...]
[...]
Feb 17 01:38:42 meticulousDevMimojaFika1 python3[7335]: 2025-02-17 01:38:42,192 timezone_manager DEBUG setting system timezone
[...]
[...]
[...]
Feb 17 01:38:42 meticulousDevMimojaFika1 python3[7335]: 2025-02-17 01:38:42,360 timezone_manager DEBUG new system time zone: XXX/YYYY ]
Feb 17 01:38:42 meticulousDevMimojaFika1 python3[7335]: 2025-02-17 01:38:42,360 timezone_manager DEBUG update timezone status: Success

```