### PR TITLE
Manage tz exceptions

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -106,7 +106,7 @@ class SettingsHandler(BaseHandler):
                 if setting_target == TIMEZONE_SYNC:
                     new_tz = await self.update_timezone_sync(value)
                     if new_tz:
-                        self.validate_setting(TIME_ZONE,new_tz)
+                        self.validate_setting(TIME_ZONE, new_tz)
                         workConfig[TIME_ZONE] = new_tz
 
                 if setting_target == TIME_ZONE:

--- a/api/settings.py
+++ b/api/settings.py
@@ -134,9 +134,7 @@ class SettingsHandler(BaseHandler):
             self.write({"status": "error", "error": f"{e}"})
             return
 
-        # we have a valid config update the entries we changed to make race conditions more fun
-        for key, value in workConfig.items():
-            MeticulousConfig[CONFIG_USER][key] = value
+        MeticulousConfig[CONFIG_USER] = workConfig
 
         MeticulousConfig.save()
         return self.get()

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -20,11 +20,7 @@ TIMEZONE_JSON_FILE_PATH: str = os.getenv(
 
 
 class TimezoneManagerError(Exception):
-
-    def __init__(self, message, log=False):
-        super().__init__(message)
-        if log:
-            logger.error(f"{message}")
+    pass
 
 
 class TimezoneManager:
@@ -67,7 +63,8 @@ class TimezoneManager:
                 TimezoneManager.set_system_timezone(stripped_new_tz)
                 logger.debug("update timezone status: Success")
             except TimezoneManagerError as e:
-                raise TimezoneManagerError(f"Error updating timezone:\n\t{e}", log=True)
+                logger.error(f"Error updating timezone: {e}")
+                raise TimezoneManagerError(f"Error updating timezone: {e}")
 
     @staticmethod
     def set_system_timezone(new_timezone: str) -> str:
@@ -85,14 +82,14 @@ class TimezoneManager:
 
             if len(cmd_result.stderr) > 0 or len(cmd_result.stdout) > 0:
                 error = f"[ Out:{cmd_result.stdout} | Err: {cmd_result.stderr} ]"
-                raise Exception(f"{error}")
+                raise Exception(error)
 
             logger.debug(
                 f"new system time zone: {TimezoneManager.get_system_timezone()} ]"
             )
         except Exception as e:
-            logger.error(f"Error setting system time zone\n\t{e}")
-            raise TimezoneManagerError(f"Error setting system time zone\n\t{e}")
+            logger.error(f"Error setting system time zone: {e}")
+            raise TimezoneManagerError(f"Error setting system time zone: {e}")
 
     @staticmethod
     def get_system_timezone():

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -18,12 +18,14 @@ TIMEZONE_JSON_FILE_PATH: str = os.getenv(
     "TIMEZONE_JSON_FILE_PATH", "/usr/share/zoneinfo/UI_timezones.json"
 )
 
+
 class TimezoneManagerError(Exception):
 
     def __init__(self, message, log=False):
         super().__init__(message)
-        if log is True:
+        if log:
             logger.error(f"{message}")
+
 
 class TimezoneManager:
 
@@ -47,7 +49,7 @@ class TimezoneManager:
                     MeticulousConfig[CONFIG_USER][TIME_ZONE]
                 )
             except TimezoneManagerError:
-            # If fails, set the system_timezone as the user timezone and report the error
+                # If fails, set the system_timezone as the user timezone and report the error
                 logger.error(
                     f"failed to set system TZ, updating user TZ to {TimezoneManager.__system_timezone} "
                 )
@@ -59,13 +61,11 @@ class TimezoneManager:
 
     @staticmethod
     def update_timezone(new_timezone: str) -> None:
-        stripped_new_tz = new_timezone.rstrip(
-                    '"'
-                ).lstrip('"')
+        stripped_new_tz = new_timezone.rstrip('"').lstrip('"')
         if MeticulousConfig[CONFIG_USER][TIME_ZONE] != stripped_new_tz:
             try:
                 TimezoneManager.set_system_timezone(stripped_new_tz)
-                logger.debug(f"update timezone status: Success")
+                logger.debug("update timezone status: Success")
             except TimezoneManagerError as e:
                 raise TimezoneManagerError(f"Error updating timezone:\n\t{e}", log=True)
 
@@ -274,19 +274,26 @@ class TimezoneManager:
                             str_content = await response.text()
                             tz = json.loads(str_content).get("tz")
                             if tz is not None:
-                                TimezoneManager.update_timezone(tz) # raises TimezoneManagerError if fails
+                                TimezoneManager.update_timezone(
+                                    tz
+                                )  # raises TimezoneManagerError if fails
                                 return tz
                             logger.warning("Invalid response from server, re-fetching")
                         else:
                             logger.warning(
                                 f"timezone fetch failed with status code: {response.status}, re-fetching"
                             )
+
         try:
             new_tz = await asyncio.wait_for(request_tz_task(), timeout=20)
             return new_tz
         except asyncio.TimeoutError:
-            logger.error("time out error, server could not be contacted or took too long to answer")
-            raise Exception("time out error, server could not be contacted or took too long to answer")
+            logger.error(
+                "time out error, server could not be contacted or took too long to answer"
+            )
+            raise Exception(
+                "time out error, server could not be contacted or took too long to answer"
+            )
         except TimezoneManagerError as e:
             logger.error(f"failed to set the provided timezone\n\t{e}")
             raise Exception("failed to set the provided timezone")

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -67,7 +67,7 @@ class TimezoneManager:
                 TimezoneManager.set_system_timezone(stripped_new_tz)
                 logger.debug(f"update timezone status: Success")
             except TimezoneManagerError as e:
-                raise TimezoneManagerError("Error updating timezone:\n\t{e}", log=True)
+                raise TimezoneManagerError(f"Error updating timezone:\n\t{e}", log=True)
 
     @staticmethod
     def set_system_timezone(new_timezone: str) -> str:

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -260,7 +260,7 @@ class TimezoneManager:
     @staticmethod
     async def request_and_sync_tz() -> str:
 
-        async def request_tz_task() -> None:
+        async def request_tz_task() -> str:
             # nonlocal error
             import aiohttp
 
@@ -275,14 +275,15 @@ class TimezoneManager:
                             tz = json.loads(str_content).get("tz")
                             if tz is not None:
                                 TimezoneManager.update_timezone(tz) # raises TimezoneManagerError if fails
-                                return
+                                return tz
                             logger.warning("Invalid response from server, re-fetching")
                         else:
                             logger.warning(
                                 f"timezone fetch failed with status code: {response.status}, re-fetching"
                             )
         try:
-            await asyncio.wait_for(request_tz_task(), timeout=20)
+            new_tz = await asyncio.wait_for(request_tz_task(), timeout=20)
+            return new_tz
         except asyncio.TimeoutError:
             logger.error("time out error, server could not be contacted or took too long to answer")
             raise Exception("time out error, server could not be contacted or took too long to answer")


### PR DESCRIPTION
## The following changes were made to the `TimezoneManager` and `SettingsHandler` class

The `TimezoneManager` functions now raise exceptions when failing Instead of returning a string containing the result of the function, if the result is successful, they return normally.

The `TimezoneManager.updateTimezone()` fcn used to set directly the synced tz to the `MeticulousConfig` object and file after setting the system value. As there is now a buffer dictionary `workConfig`, after setting the system tz, it propagates the new tz value back to the `settingsHandler` to make use of the `workConfig` dictionary buffer