### PR TITLE
fix(machine.py): Notification from ESP

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -281,7 +281,9 @@ class Machine:
                     case ["ESPInfo", *infoArgs]:
                         info = ESPInfo.from_args(infoArgs)
                     case ["Notify", *notifyArgs]:
-                        notify = MachineNotify(notifyArgs[0], ",".join(notifyArgs[1:]))
+                        notify = MachineNotify(
+                            notifyArgs[0], ",".join(notifyArgs[1:]).replace(";", "\n")
+                        )
 
                     case ["HeaterTimeoutInfo", *timeoutArgs]:
                         try:

--- a/machine.py
+++ b/machine.py
@@ -282,9 +282,6 @@ class Machine:
                         info = ESPInfo.from_args(infoArgs)
                     case ["Notify", *notifyArgs]:
                         notify = MachineNotify(notifyArgs[0], ",".join(notifyArgs[1:]))
-                    case ["acaia_msg", *notifyArgs]:
-                        notify = MachineNotify(*["acaia_msg", "".join(notifyArgs)])
-                        logger.info(f"Acaia message parsed: {notify}")
 
                     case ["HeaterTimeoutInfo", *timeoutArgs]:
                         try:

--- a/machine.py
+++ b/machine.py
@@ -281,7 +281,7 @@ class Machine:
                     case ["ESPInfo", *infoArgs]:
                         info = ESPInfo.from_args(infoArgs)
                     case ["Notify", *notifyArgs]:
-                        notify = MachineNotify(notifyArgs)
+                        notify = MachineNotify(notifyArgs[0], ",".join(notifyArgs[1:]))
                     case ["acaia_msg", *notifyArgs]:
                         notify = MachineNotify(*["acaia_msg", "".join(notifyArgs)])
                         logger.info(f"Acaia message parsed: {notify}")


### PR DESCRIPTION
When the ESP tried to create a notification using "Notify", the backend parsed everything coming after that keyword into the MachineNotify's notificationType parameter, leaving the message parameter empty, now both parameters are assigned correctly

e.g.
*BEFORE:*

ESP sends: 
> Notify,starting ACAIA Master Calibration,please do not unplug the scale

The backend parses:
![image](https://github.com/user-attachments/assets/ae652140-1959-44c8-be9a-d03210ac9a91)

*AFTER:*
ESP sends:
> Notify,process,starting ACAIA Master Calibration,please do not unplug the scale


The backend parses:
![image](https://github.com/user-attachments/assets/83f88c36-8b78-4b74-b569-0d70b1688af8)

