### PR TITLE
shot-manager: fix setpoints not storing

### DIFF
--- a/shot_manager.py
+++ b/shot_manager.py
@@ -71,7 +71,7 @@ class Shot:
                 "flow": shotData.flow,
                 "weight": shotData.weight,
                 "gravimetric_flow": shotData.gravimetric_flow,
-                "setpoints": shotData.to_sio().get("setPoints", {}),
+                "setpoints": shotData.to_sio().get("setpoints", {}),
             },
             "time": shotData.time,
             "status": shotData.status,


### PR DESCRIPTION
In esp_serial/data.py#L365 the field is called "setpoints", so querrying for "setPoints" will never yield a result