### PR TITLE
fix: Tz gets lost on reboots (or backend restarts)

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -57,7 +57,7 @@ class SettingsHandler(BaseHandler):
             raise KeyError(error_message)
 
         if type(value) is not type(MeticulousConfig[CONFIG_USER][setting_target]):
-            error_message = f"setting value invalid, received {type(value)} and expected {type(setting_target)}"
+            error_message = f"setting value invalid, received {type(value)} and expected {type(MeticulousConfig[CONFIG_USER][setting_target])}"
             raise KeyError(error_message)
 
     async def update_timezone_sync(self, value) -> str:
@@ -156,11 +156,13 @@ class SettingsHandler(BaseHandler):
         except KeyError as e:  # The variable is invalid in some way
             self.set_status(404)
             self.write({"status": "error", "error": f"{e}"})
+            logger.error(f"KeyError on Settings Handler: {e}")
             return
 
         except Exception as e:  # The variable specific callbacks could not be activated
             self.set_status(400)
             self.write({"status": "error", "error": f"{e}"})
+            logger.error(f"Exception on Settings Handler: {e}")
             return
 
         MeticulousConfig[CONFIG_USER] = workConfig

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -36,12 +36,10 @@ class TimezoneManager:
         if target_timezone != TimezoneManager.__system_timezone:
 
             if target_timezone == DEFAULT_TIME_ZONE:
-                logger.info("No timezone was ever configured")
-                if TimezoneManager.__system_timezone == "Etc/UTC":
-                    return
-
+                logger.info("No timezone was ever configured by user")
                 logger.info("Setting system timezone to Etc/UTC as a default")
                 target_timezone = "Etc/UTC"
+                MeticulousConfig[CONFIG_USER][TIME_ZONE] = target_timezone
             else:
                 logger.warning(
                     f"user config and system timezones confilct, updating system config to {MeticulousConfig[CONFIG_USER][TIME_ZONE]}"


### PR DESCRIPTION
When the user has not modified the TZ configuration, the default configuration for it is `None`, the system tz is set to UTC but the new value is not saved in the config file, so when the user first tries to modify it using the settings endpoint, the function `validate_setting` recieves a string from the incoming setting type and a NoneType for the current configuration type in file, so it thinks that the correct type is NoneType as it is the one already in memory and fails the to update the setting in the configuration file and returns a 404 http error.

If the setting is tried to be set to automatic, the whole process of  retrieving the tz and setting it in the linux system happens previous to the setting type validation and goes uneventful, but then the validation fails and the new tz is never saved in the config file.

With this the cycle repeats on every boot resetting the tz to UTC

To fix this, if the user has never set the TZ, besides setting the system tz to UTC. it is also saved in the configuration file, this will avoid the error in `validate settings`

Also an error log is produced when settings endpoint fails to update the setting