### PR TITLE
Fix: end of shot using ACAIA stable weight report

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -413,18 +413,21 @@ class Machine:
 
                         if is_retracting:
                             if Machine.stable_start_timestamp is not None:
-                                time_flag = (time.time() - Machine.stable_start_timestamp) < Machine.stable_time_threshold
+                                time_flag = (
+                                    time.time() - Machine.stable_start_timestamp
+                                ) < Machine.stable_time_threshold
                                 if not data.stable_weight:
                                     Machine.stable_start_timestamp = None
                             else:
                                 if data.stable_weight:
                                     Machine.stable_start_timestamp = time.time()
-                            
 
                         if time_flag is False:
                             now_time = time.time()
                             if Machine.stable_start_timestamp is not None:
-                                logger.info(f"shot ended at {now_time} with a stable weight time of: {now_time - Machine.stable_start_timestamp}s")
+                                logger.info(
+                                    f"shot ended at {now_time} with a stable weight time of: {now_time - Machine.stable_start_timestamp}s"
+                                )
                                 Machine.stable_start_timestamp = None
                             else:
                                 logger.info("shot ended with weight unstable")

--- a/shot_manager.py
+++ b/shot_manager.py
@@ -251,9 +251,12 @@ class ShotManager:
         if len(last_weights) < nr_samples_per_group * 2:
             logger.warning("Not enough datapoints")
             return False
-        
-        #make sure its all numbers
-        last_weights = [(float(weight.strip(' "')) if isinstance(weight,str) else float(weight)) for weight in last_weights]
+
+        # make sure its all numbers
+        last_weights = [
+            (float(weight.strip(' "')) if isinstance(weight, str) else float(weight))
+            for weight in last_weights
+        ]
 
         try:
             last_avg = sum(last_weights[-nr_samples_per_group:]) / nr_samples_per_group


### PR DESCRIPTION
 - Feat: use of the ACAIA stable weight flag to stop a shot
     When on retracting instead of calculating on the backend if the weight is stable, use the flag reported by ACAIA, if the flag is still on for more than 2s, end the shot.

- Fix: Make sure to operate only on integer when calculating the weight stability on `isWeightStable` function