### PR TITLE
serial: fix the status to be lowercase

### DIFF
--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -221,10 +221,10 @@ class MachineStatus:
     # Enum representing the events from the machine
     IDLE = "idle"
     HEATING = "heating"
-    PURGE = "Purge"
+    PURGE = "purge"
     RETRACTING = "retracting"
     CLOSING_VALVE = "closing valve"
-    HOME = "Home"
+    HOME = "home"
 
 
 # Backend outwards


### PR DESCRIPTION
The firmware now sets the status to lowercase home and purge:
        uart->set_profile_status("purge");
        uart->set_profile_name("Purge");
Adjust the serial class accordingly