### PR TITLE
Save all debug shot files

### DIFF
--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -225,6 +225,14 @@ class MachineStatus:
     RETRACTING = "retracting"
     CLOSING_VALVE = "closing valve"
     HOME = "home"
+    BOOT = "boot"
+
+
+MachineStatusToProfile = {
+    MachineStatus.PURGE: "Purge",
+    MachineStatus.HOME: "Home",
+    MachineStatus.BOOT: "Bootup",
+}
 
 
 # Backend outwards

--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -215,6 +215,19 @@ class ESPInfo:
             return None
         return info
 
+    def to_sio(self):
+        """Convert ESPInfo to a dictionary for socket.io communication."""
+        return {
+            "firmware_version": self.firmwareV,
+            "esp_pinout": self.espPinout,
+            "main_voltage": self.mainVoltage,
+            "color": self.color,
+            "serial_number": self.serialNumber,
+            "batch_number": self.batchNumber,
+            "build_date": self.buildDate,
+            "scale_module": self.scaleModule,
+        }
+
 
 # From ESP32 to backend
 class MachineStatus:

--- a/machine.py
+++ b/machine.py
@@ -399,7 +399,6 @@ class Machine:
                         shot_start_time = time.time()
                         logger.info("shot start_time: {:.1f}".format(shot_start_time))
                         ShotManager.start()
-                        ShotDebugManager._shot_in_progress = True
                         SoundPlayer.play_event_sound(Sounds.BREWING_START)
                     elif time_flag:
                         # A shot could have ended
@@ -434,7 +433,7 @@ class Machine:
                             SoundPlayer.play_event_sound(Sounds.BREWING_END)
                             ShotManager.stop()
 
-                    if Machine.is_idle or is_purge:
+                    if Machine.is_idle:
                         ShotDebugManager.stop()
 
                     if old_status == MachineStatus.IDLE and not Machine.is_idle:

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -155,6 +155,8 @@ class ShotDebugManager:
         csv_data = ShotDebugManager._current_data.to_csv()
 
         async def compress_current_data(data_json):
+            from machine import Machine
+
             # Compress and write the shot to disk
             logger.info("Writing and compressing debug file")
             start = time.time()
@@ -171,15 +173,20 @@ class ShotDebugManager:
             data_json = None
 
             if MeticulousConfig[CONFIG_USER][MACHINE_DEBUG_SENDING] is True:
-                try:
-                    await TelemetryService.upload_debug_shot(compressed_data)
-                except Exception as e:
-                    logger.error(f"Failed to send debug shot to server: {e}")
+                if Machine.emulated:
+                    logger.info("Not sending emulated debug shots")
+                else:
+                    try:
+                        await TelemetryService.upload_debug_shot(compressed_data)
+                        logger.info("Debug shot data compressed and saved")
+
+                    except Exception as e:
+                        logger.error(f"Failed to send debug shot to server: {e}")
 
             compressed_data = None
             cctx = None
             data_json = None
-            logger.info("Debug shot data compressed and sent")
+            logger.info("Debug shot data compressed and saved")
 
             ShotDebugManager.deleteOldDebugShotData()
 

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -86,12 +86,13 @@ class DebugData:
 
 class ShotDebugManager:
     _current_data: DebugData = None
-    _shot_in_progress: bool = False
+    _current_data_type: str = "shot"
 
     @staticmethod
     def start():
         if ShotDebugManager._current_data is None:
             ShotDebugManager._current_data = DebugData()
+            ShotDebugManager._current_data_type = "shot"
             logger.info("Starting debug shot")
 
     @staticmethod
@@ -103,6 +104,10 @@ class ShotDebugManager:
     def handleShotData(shotData: ShotData):
         if shotData is not None and ShotDebugManager._current_data is not None:
             ShotDebugManager._current_data.addShotData(shotData)
+            status = shotData.status
+            profile = shotData.profile
+            if status in ["purge", "home"] and profile == status.capitalize():
+                ShotDebugManager._current_data_type = status
 
     @staticmethod
     def deleteOldDebugShotData():
@@ -126,12 +131,6 @@ class ShotDebugManager:
 
     @staticmethod
     def stop():
-        if ShotDebugManager._shot_in_progress is False:
-            # logger.info("shot did not start, clearing debug data") # This message is not needed, only for debugging purposes
-            ShotDebugManager._current_data = None
-
-        ShotDebugManager._shot_in_progress = False
-
         if ShotDebugManager._current_data is None:
             return
 
@@ -146,7 +145,8 @@ class ShotDebugManager:
 
         # Prepare the file path
         formatted_time = start.strftime(DEBUG_FILE_FORMAT)
-        file_name = f"{formatted_time}.debug.csv.zst"
+        file_type = ShotDebugManager._current_data_type
+        file_name = f"{formatted_time}.{file_type}.csv.zst"
         file_path = os.path.join(folder_path, file_name)
 
         csv_data = ShotDebugManager._current_data.to_csv()

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -15,7 +15,7 @@ from config import (
     MACHINE_DEBUG_SENDING,
     MeticulousConfig,
 )
-from esp_serial.data import SensorData, ShotData
+from esp_serial.data import SensorData, ShotData, MachineStatus, MachineStatusToProfile
 from telemetry_service import TelemetryService
 from log import MeticulousLogger
 
@@ -106,7 +106,10 @@ class ShotDebugManager:
             ShotDebugManager._current_data.addShotData(shotData)
             status = shotData.status
             profile = shotData.profile
-            if status in ["purge", "home"] and profile == status.capitalize():
+            if (
+                status in [MachineStatus.PURGE, MachineStatus.HOME, MachineStatus.BOOT]
+                and MachineStatusToProfile.get(status, "") == profile
+            ):
                 ShotDebugManager._current_data_type = status
 
     @staticmethod

--- a/shot_manager.py
+++ b/shot_manager.py
@@ -76,6 +76,9 @@ class Shot:
             "time": shotData.time,
             "status": shotData.status,
         }
+        self.append_shot_data(formated_data)
+
+    def append_shot_data(self, formated_data):
         self.shotData.append(formated_data)
 
     def to_json(self):


### PR DESCRIPTION
This will create `.home.csv.zst` and `.purge.csv.zst` and `.shot.csv.zst ` files instead of the previous `.debug.csv.zstd`-
It will also enable the debug shot manager as soon as we leave the idle state.

NOTE: this does not work with the emulated shotfiles too well as they are not implementing the correct format for a while now