### PR TITLE
fix: debug_shot missing 'profile' attribute

### DIFF
--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -161,7 +161,10 @@ class ShotDebugManager:
     def stop():
         if ShotDebugManager._current_data is None:
             return
-
+        
+        if ShotDebugManager._current_data.profile is None:
+            ShotDebugManager._current_data.profile = {}
+            
         # Determine the folder path based on the current date
         start_timestamp = ShotDebugManager._current_data.startTime
         start = datetime.fromtimestamp(start_timestamp)

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -161,10 +161,10 @@ class ShotDebugManager:
     def stop():
         if ShotDebugManager._current_data is None:
             return
-        
+
         if ShotDebugManager._current_data.profile is None:
             ShotDebugManager._current_data.profile = {}
-            
+
         # Determine the folder path based on the current date
         start_timestamp = ShotDebugManager._current_data.startTime
         start = datetime.fromtimestamp(start_timestamp)

--- a/shot_manager.py
+++ b/shot_manager.py
@@ -34,15 +34,16 @@ class Shot:
             # Append onto the last shotData
             self.shotData[-1]["sensors"] = dict(sensorData.__dict__)
 
-    def hasValidProfileName(self):
-        return self.profile_name is not None and self.profile_name != "Init Profile"
-
     def addShotData(self, shotData: ShotData):
         from profiles import ProfileManager
 
         from machine import Machine
 
-        if not self.hasValidProfileName() and shotData.profile is not None:
+        if (
+            self.profile_name is None
+            and shotData.profile is not None
+            and shotData.status != "starting..."
+        ):
 
             # Special case the emulation case
             if (

--- a/shot_manager.py
+++ b/shot_manager.py
@@ -34,12 +34,15 @@ class Shot:
             # Append onto the last shotData
             self.shotData[-1]["sensors"] = dict(sensorData.__dict__)
 
+    def hasValidProfileName(self):
+        return self.profile_name is not None and self.profile_name != "Init Profile"
+
     def addShotData(self, shotData: ShotData):
         from profiles import ProfileManager
 
         from machine import Machine
 
-        if self.profile_name is None and shotData.profile is not None:
+        if not self.hasValidProfileName() and shotData.profile is not None:
 
             # Special case the emulation case
             if (
@@ -61,8 +64,6 @@ class Shot:
                     and last_profile["profile"]["name"] == self.profile_name
                 ):
                     self.profile = last_profile["profile"]
-                else:
-                    self.profile = {}
 
         # Shotdata is not json serialziable and we dont need the profile entry multiple times
         formated_data = {


### PR DESCRIPTION
When the backend tries to add the 'profile' attribute, it compares the name of the last profile with the on-going profile name that should be the same as the last profile is the last profile sent to the ESP, which is the on-going shot. The issue comes when the profile is loading in the ESP it reports the name 'Init Profile' which is then saved as the on-going name (false), so now we validate the name before saving it and only then the profile data is saved.

When the name 'Init Profile' is sent by the ESP, it is sent next to the status 'starting...', if the status is different to that, the name is considered to be user chosen even if it is also 'Init Profile'