### PR TITLE
feat: save logs happening within a shot timeframe into the debug shot file

### DIFF
--- a/log.py
+++ b/log.py
@@ -49,3 +49,33 @@ class MeticulousLogger:
             logger.addHandler(MeticulousLogger._sh)
         logger.setLevel(LOGLEVEL)
         return logger
+
+    @staticmethod
+    def add_logging_handler(handler: logging.Handler, logger_name: str | None = None):
+        if handler is None:
+            return
+        if logger_name is not None:
+            target_logger = logging.Logger.manager.loggerDict.get(logger_name, None)
+            if isinstance(target_logger, logging.Logger):
+                target_logger.addHandler(handler)
+                return
+        for _, logger in logging.Logger.manager.loggerDict.items():
+            if not isinstance(logger, logging.Logger):
+                continue
+            logger.addHandler(handler)
+
+    @staticmethod
+    def remove_logging_handler(
+        handler: logging.Handler, logger_name: str | None = None
+    ):
+        if handler is None:
+            return
+        if logger_name is not None:
+            target_logger = logging.Logger.manager.loggerDict.get(logger_name, None)
+            if isinstance(target_logger, logging.Logger):
+                target_logger.removeHandler(handler)
+                return
+        for _, logger in logging.Logger.manager.loggerDict.items():
+            if not isinstance(logger, logging.Logger):
+                continue
+            logger.removeHandler(handler)

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -31,8 +31,6 @@ DEBUG_FOLDER_FORMAT = "%Y-%m-%d"
 DEBUG_FILE_FORMAT = "%H:%M:%S"
 DEBUG_HISTORY_PATH = os.getenv("DEBUG_HISTORY_PATH", "/meticulous-user/history/debug")
 
-shot_log_lock = threading.Lock()
-
 
 class ShotLogHandler(logging.Handler):
 
@@ -292,6 +290,7 @@ class ShotDebugManager:
             "profile_ms": int(
                 (log_record.created - ShotDebugManager._current_data.startTime) * 1000.0
             ),
+            "loglevel": log_record.levelname,
             "caller": log_record.name,
             "log_message": msg,
         }


### PR DESCRIPTION

A `ShotLogHandler` handler was created to also send the logging messages to a list of log messages in the `ShotDebugManager` class. This handler is added to all existing loggers when a debug shot is started and removed once the debug shot is stopped. While the handler is active in the loggers they will append an object like the following, for every message processed, into the mentioned list.

``` json
{
    "profile_ms": int,
    "caller": str,
    "log_message": str,
}
```

where
`profile_ms` is the time respect the start of the profile in ms that the log was created.
`caller` is the name of the logger instance that created the log e.g(`machine` or `tornado.access`).
`log_message` is the message logged

Finally that list of dicts is copied to the DebugShot object to be saved in the json debug file, and then cleared