### PR TITLE
Fix: ShotDebugManager._current_data was not threadsafe

### DIFF
--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -75,7 +75,6 @@ class DebugShot(Shot):
 
 class ShotDebugManager:
     _current_data: DebugShot = None
-    current_shot_logs_lock = threading.Lock()
     clear_current_data_lock = threading.Lock()
     logging_handler = None
 


### PR DESCRIPTION
As `ShotDebugManager._current_data` can be modified by multiple threads, now use a lock to access the data, avoiding it to be modified while another thread was accessing it