### PR TITLE
Fix/thread without eventloop

### DIFF
--- a/config.py
+++ b/config.py
@@ -339,9 +339,9 @@ class MeticulousConfigDict(dict):
                     if asyncio.get_event_loop().is_running()
                     else asyncio.new_event_loop()
                 )
-            except:
+            except RuntimeError:
                 loop = asyncio.new_event_loop()
-            
+
             asyncio.set_event_loop(loop)
 
             async def sendSettingsNotification():

--- a/config.py
+++ b/config.py
@@ -330,11 +330,18 @@ class MeticulousConfigDict(dict):
             yaml.dump(self.copy(), f, default_flow_style=False, allow_unicode=True)
 
         if self.__sio:
-            loop = (
-                asyncio.get_event_loop()
-                if asyncio.get_event_loop().is_running()
-                else asyncio.new_event_loop()
-            )
+
+            # when running in an executor asyncio.get_event_loop() might fail, as there might
+            # not be a loop in the thread created by asyncio
+            try:
+                loop = (
+                    asyncio.get_event_loop()
+                    if asyncio.get_event_loop().is_running()
+                    else asyncio.new_event_loop()
+                )
+            except:
+                loop = asyncio.new_event_loop()
+            
             asyncio.set_event_loop(loop)
 
             async def sendSettingsNotification():


### PR DESCRIPTION
When the backend saved the last file in the config.yml calling the .save method, the thread it is running on created by asyncio.run_in_executor does not have an event loop thus the get_event_loop() function raises a RuntimeError exception. Now getting the loop is wrapped in a try-except block for that case