### PR TITLE
machine: add brew abort action

### DIFF
--- a/api/action.py
+++ b/api/action.py
@@ -23,6 +23,8 @@ class ExecuteActionHandler(BaseHandler):
                 case "reset":
                     Machine.reset()
                     self.write(json.dumps({"action": action, "status": "ok"}))
+                case "abort":
+                    Machine.end_profile()
         else:
             self.set_status(400)
             self.write(

--- a/backend.py
+++ b/backend.py
@@ -81,6 +81,12 @@ def disconnect(sid):
 def msg(sid, data):
     if data in Machine.ALLOWED_ESP_ACTIONS:
         Machine.action(action_event=data)
+    elif data in Machine.ALLOWED_BACKEND_ACTIONS:
+        match data:
+            case "reset":
+                logger.warning("action,reset is not allowed from socket.io")
+            case "abort":
+                Machine.end_profile()
     else:
         logger.warning(f"Invalid action {data}")
 

--- a/machine.py
+++ b/machine.py
@@ -79,7 +79,7 @@ class esp_nvs_keys(Enum):
 
 class Machine:
 
-    ALLOWED_BACKEND_ACTIONS = ["reset"]
+    ALLOWED_BACKEND_ACTIONS = ["reset", "abort"]
     ALLOWED_ESP_ACTIONS = [
         "start",
         "stop",
@@ -651,6 +651,7 @@ class Machine:
     def end_profile():
         if Machine.data_sensors.status == "idle":
             return
+        logger.info("Ending profile due to user request")
         if (
             Machine.data_sensors.state == "brewing"
             and Machine.data_sensors.status


### PR DESCRIPTION
To be able to abort brews from the frontend and not just via double tap we add a new abort action to be handled by the backend which homes during extraction but just stops during heating