### PR TITLE
Feat/link shotdb with debug shots

### DIFF
--- a/alembic/versions/2025_07_15_1307-470a6d3b0f44_create_debug_file_column_to_history_.py
+++ b/alembic/versions/2025_07_15_1307-470a6d3b0f44_create_debug_file_column_to_history_.py
@@ -1,0 +1,27 @@
+"""create 'debug_file' column to history table to link the shot with its debug file
+
+Revision ID: 470a6d3b0f44
+Revises: 1a598cd3ace3
+Create Date: 2025-07-15 13:07:03.844816
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '470a6d3b0f44'
+down_revision: Union[str, None] = '1a598cd3ace3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("history", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("debug_file", sa.Text(), nullable=True))
+
+def downgrade() -> None:
+    with op.batch_alter_table("history", schema=None) as batch_op:
+        batch_op.drop_column("debug_file")

--- a/alembic/versions/2025_07_15_1307-470a6d3b0f44_create_debug_file_column_to_history_.py
+++ b/alembic/versions/2025_07_15_1307-470a6d3b0f44_create_debug_file_column_to_history_.py
@@ -5,6 +5,7 @@ Revises: 1a598cd3ace3
 Create Date: 2025-07-15 13:07:03.844816
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '470a6d3b0f44'
-down_revision: Union[str, None] = '1a598cd3ace3'
+revision: str = "470a6d3b0f44"
+down_revision: Union[str, None] = "1a598cd3ace3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -21,6 +22,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     with op.batch_alter_table("history", schema=None) as batch_op:
         batch_op.add_column(sa.Column("debug_file", sa.Text(), nullable=True))
+
 
 def downgrade() -> None:
     with op.batch_alter_table("history", schema=None) as batch_op:

--- a/back.py
+++ b/back.py
@@ -82,8 +82,6 @@ def run():
             ShotManager.init()
         except Exception as e:
             logger.error("Failed to initialize ShotManager", exc_info=e)
-
-        logger.info("Running database migrations")
         try:
             update_db_migrations()
         except Exception as e:

--- a/database_models.py
+++ b/database_models.py
@@ -50,6 +50,7 @@ history = Table(
     Column("profile_name", Text, nullable=False),
     Column("profile_id", Text, nullable=False),
     Column("profile_key", Integer, ForeignKey("profile.key"), nullable=False),
+    Column("debug_file", Text, nullable=True),
 )
 
 shot_annotation = Table(

--- a/db_migration_updater.py
+++ b/db_migration_updater.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 
 logger = MeticulousLogger.getLogger(__name__)
 
-DB_VERSION_REQUIRED = "1a598cd3ace3"
+DB_VERSION_REQUIRED = "470a6d3b0f44"
 
 USER_DB_MIGRATION_DIR = os.getenv(
     "USER_DB_MIGRATION_DIR", "/meticulous-user/.dbmigrations"

--- a/shot_database.py
+++ b/shot_database.py
@@ -90,9 +90,7 @@ class ShotDataBase:
         ShotDataBase.session = sessionmaker(bind=ShotDataBase.engine)
 
         try:
-            # Ensure tables are created
-            ShotDataBase.metadata.create_all(ShotDataBase.engine)
-
+            
             # Ensure FTS tables are created
             with ShotDataBase.engine.connect() as connection:
                 connection.execute(

--- a/shot_database.py
+++ b/shot_database.py
@@ -289,6 +289,20 @@ class ShotDataBase:
                 logger.info(f"debug file linked, affected rows: {{{result.rowcount}}}")
 
     @staticmethod
+    def unlink_debug_file(file_relative_path):
+
+        stmt = (
+            update(history_table)
+            .where(history_table.c.debug_file == file_relative_path)
+            .values(debug_file=None)
+        )
+        with ShotDataBase.engine.connect() as connection:
+            with connection.begin():
+                result = connection.execute(stmt)
+                if result.rowscount == 0:
+                    raise Exception("no columns affected, check relative file path")
+
+    @staticmethod
     def delete_shot(shot_id):
         with ShotDataBase.engine.connect() as connection:
             with connection.begin():

--- a/shot_database.py
+++ b/shot_database.py
@@ -302,8 +302,9 @@ class ShotDataBase:
                 if result.rowcount == 0:
                     logger.warning("no columns affected, check relative file path")
                 else:
-                    logger.info(f"debug file linked, affected rows: {{{result.rowcount}}}")
-
+                    logger.info(
+                        f"debug file linked, affected rows: {{{result.rowcount}}}"
+                    )
 
     @staticmethod
     def delete_shot(shot_id):

--- a/shot_database.py
+++ b/shot_database.py
@@ -90,7 +90,7 @@ class ShotDataBase:
         ShotDataBase.session = sessionmaker(bind=ShotDataBase.engine)
 
         try:
-            
+
             # Ensure FTS tables are created
             with ShotDataBase.engine.connect() as connection:
                 connection.execute(
@@ -275,15 +275,19 @@ class ShotDataBase:
                 )
                 result = connection.execute(ins_stmt)
                 return result.inserted_primary_key[0]
-            
+
     @staticmethod
     def link_debug_file(history_shot_id, debug_filename):
-        stmt = update(history_table).where(history_table.c.id == history_shot_id).values(debug_file=debug_filename)
+        stmt = (
+            update(history_table)
+            .where(history_table.c.id == history_shot_id)
+            .values(debug_file=debug_filename)
+        )
         with ShotDataBase.engine.connect() as connection:
             with connection.begin():
                 result = connection.execute(stmt)
                 logger.info(f"debug file linked, affected rows: {{{result.rowcount}}}")
-    
+
     @staticmethod
     def delete_shot(shot_id):
         with ShotDataBase.engine.connect() as connection:

--- a/shot_database.py
+++ b/shot_database.py
@@ -300,7 +300,10 @@ class ShotDataBase:
             with connection.begin():
                 result = connection.execute(stmt)
                 if result.rowcount == 0:
-                    raise Exception("no columns affected, check relative file path")
+                    logger.warning("no columns affected, check relative file path")
+                else:
+                    logger.info(f"debug file linked, affected rows: {{{result.rowcount}}}")
+
 
     @staticmethod
     def delete_shot(shot_id):

--- a/shot_database.py
+++ b/shot_database.py
@@ -275,8 +275,17 @@ class ShotDataBase:
                     profile_id=profile_data["id"],
                     profile_key=profile_key,
                 )
-                connection.execute(ins_stmt)
-
+                result = connection.execute(ins_stmt)
+                return result.inserted_primary_key[0]
+            
+    @staticmethod
+    def link_debug_file(history_shot_id, debug_filename):
+        stmt = update(history_table).where(history_table.c.id == history_shot_id).values(debug_file=debug_filename)
+        with ShotDataBase.engine.connect() as connection:
+            with connection.begin():
+                result = connection.execute(stmt)
+                logger.info(f"debug file linked, affected rows: {{{result.rowcount}}}")
+    
     @staticmethod
     def delete_shot(shot_id):
         with ShotDataBase.engine.connect() as connection:

--- a/shot_database.py
+++ b/shot_database.py
@@ -299,7 +299,7 @@ class ShotDataBase:
         with ShotDataBase.engine.connect() as connection:
             with connection.begin():
                 result = connection.execute(stmt)
-                if result.rowscount == 0:
+                if result.rowcount == 0:
                     raise Exception("no columns affected, check relative file path")
 
     @staticmethod
@@ -450,6 +450,9 @@ class ShotDataBase:
                     "db_key": row_dict.pop("history_id"),
                     "time": datetime.timestamp(row_dict.pop("history_time")),
                     "file": file_entry,
+                    "debug_file": row_dict.pop(
+                        "history_debug_file", "column not found"
+                    ),
                     "name": row_dict.pop("history_profile_name"),
                     "data": data,
                     "profile": profile,

--- a/shot_database.py
+++ b/shot_database.py
@@ -454,9 +454,7 @@ class ShotDataBase:
                     "db_key": row_dict.pop("history_id"),
                     "time": datetime.timestamp(row_dict.pop("history_time")),
                     "file": file_entry,
-                    "debug_file": row_dict.pop(
-                        "history_debug_file", "column not found"
-                    ),
+                    "debug_file": row_dict.pop("history_debug_file", None),
                     "name": row_dict.pop("history_profile_name"),
                     "data": data,
                     "profile": profile,

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -141,7 +141,10 @@ class ShotDebugManager:
                 continue
             p = datetime.strptime(f, DEBUG_FOLDER_FORMAT)
             if p < cutoff_date:
-                shutil.rmtree(os.path.join(DEBUG_HISTORY_PATH, f))
+                date_dir = os.path.join(DEBUG_HISTORY_PATH, f)
+                shutil.rmtree(date_dir)
+                for name in os.listdir(date_dir):
+                    ShotDataBase.unlink_debug_file(os.path.join(f, name))
                 logger.info(f"Deleted all shots in {f}")
 
     @staticmethod

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -142,9 +142,9 @@ class ShotDebugManager:
             p = datetime.strptime(f, DEBUG_FOLDER_FORMAT)
             if p < cutoff_date:
                 date_dir = os.path.join(DEBUG_HISTORY_PATH, f)
-                shutil.rmtree(date_dir)
                 for name in os.listdir(date_dir):
                     ShotDataBase.unlink_debug_file(os.path.join(f, name))
+                shutil.rmtree(date_dir)
                 logger.info(f"Deleted all shots in {f}")
 
     @staticmethod

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -8,6 +8,7 @@ import shutil
 import zipfile
 import logging
 import threading
+from shot_database import ShotDataBase
 
 import zstandard as zstd
 
@@ -21,7 +22,7 @@ from config import (
 from esp_serial.data import SensorData, ShotData, MachineStatus, MachineStatusToProfile
 from telemetry_service import TelemetryService
 from log import MeticulousLogger
-from shot_manager import Shot
+from shot_manager import (Shot, ShotManager)
 import copy
 
 
@@ -263,6 +264,13 @@ class ShotDebugManager:
             time_ms = (time.time() - start) * 1000
             logger.info(f"Writing debug json to disc took {time_ms} ms")
 
+            #link the Debug file to the shot in the db
+            if ShotManager.db_history_id is not None:
+                debug_dir_filename = os.path.join(*file_path.split(os.path.sep)[-2:])
+                ShotDataBase.link_debug_file(ShotManager.db_history_id, debug_dir_filename)
+                
+            ShotManager.db_history_id = None
+            
             if MeticulousConfig[CONFIG_USER][MACHINE_DEBUG_SENDING] is True:
                 if Machine.emulated:
                     logger.info("Not sending emulated debug shots")

--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -22,7 +22,7 @@ from config import (
 from esp_serial.data import SensorData, ShotData, MachineStatus, MachineStatusToProfile
 from telemetry_service import TelemetryService
 from log import MeticulousLogger
-from shot_manager import (Shot, ShotManager)
+from shot_manager import Shot, ShotManager
 import copy
 
 
@@ -264,13 +264,15 @@ class ShotDebugManager:
             time_ms = (time.time() - start) * 1000
             logger.info(f"Writing debug json to disc took {time_ms} ms")
 
-            #link the Debug file to the shot in the db
+            # link the Debug file to the shot in the db
             if ShotManager.db_history_id is not None:
                 debug_dir_filename = os.path.join(*file_path.split(os.path.sep)[-2:])
-                ShotDataBase.link_debug_file(ShotManager.db_history_id, debug_dir_filename)
-                
+                ShotDataBase.link_debug_file(
+                    ShotManager.db_history_id, debug_dir_filename
+                )
+
             ShotManager.db_history_id = None
-            
+
             if MeticulousConfig[CONFIG_USER][MACHINE_DEBUG_SENDING] is True:
                 if Machine.emulated:
                     logger.info("Not sending emulated debug shots")

--- a/shot_manager.py
+++ b/shot_manager.py
@@ -102,6 +102,7 @@ class Shot:
 class ShotManager:
     _last_shot: Shot = None
     _current_shot: Shot = None
+    db_history_id = None
 
     # The ShotDatabase is required to work once we use the ShotManager.
     # We therefore initialize it here
@@ -220,15 +221,19 @@ class ShotManager:
                 try:
                     dbEntry = shot_data
                     dbEntry["file"] = str(file_path)
-                    ShotDataBase.insert_history(shot_data)
+                    history_id = ShotDataBase.insert_history(shot_data)
                     ShotManager._last_shot = None
                     ShotManager.getLastShot()
+
+                    #notify the SDM that the current shot is in the db
                 except Exception as e:
                     logger.error(f"Failed to insert shot into sqlite: {e}")
                     logger.error(traceback.format_exc())
                 else:
+                    ShotManager.db_history_id = history_id
                     time_ms = (time.time() - start) * 1000
                     logger.info(f"Ingesting shot into sqlite took {time_ms} ms")
+                    logger.info(f"Shot ingested with history id: {ShotManager.db_history_id}")
                 shot_data = None
 
             compresson_thread = NamedThread(

--- a/shot_manager.py
+++ b/shot_manager.py
@@ -225,7 +225,7 @@ class ShotManager:
                     ShotManager._last_shot = None
                     ShotManager.getLastShot()
 
-                    #notify the SDM that the current shot is in the db
+                    # notify the SDM that the current shot is in the db
                 except Exception as e:
                     logger.error(f"Failed to insert shot into sqlite: {e}")
                     logger.error(traceback.format_exc())
@@ -233,7 +233,9 @@ class ShotManager:
                     ShotManager.db_history_id = history_id
                     time_ms = (time.time() - start) * 1000
                     logger.info(f"Ingesting shot into sqlite took {time_ms} ms")
-                    logger.info(f"Shot ingested with history id: {ShotManager.db_history_id}")
+                    logger.info(
+                        f"Shot ingested with history id: {ShotManager.db_history_id}"
+                    )
                 shot_data = None
 
             compresson_thread = NamedThread(


### PR DESCRIPTION
This PR allows linking the debug shot file saved with the "normal" shot recorded in the database. This allows to retrieve the debug file when its needed much more easily as it is referenced into the history database table next to the historic shot it belongs to.

For the DB, a new column `debug_file` of type text was added to the `history` table to keep the name of the debug file. That name is appended to the data provided when the history endpoint is requested.