### PR TITLE
wifi_thread: dont crash if the timezone could not be fetched

### DIFF
--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -252,11 +252,14 @@ class TimezoneManager:
     def tz_background_update():
         tz_config = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
         if tz_config == "automatic" and not TimezoneManager.__system_synced:
-            logger.info(
-                "Timezone is set to automatic, fetching timezone in the background"
-            )
-            loop = asyncio.get_event_loop()
-            loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+            try:
+                logger.info(
+                    "Timezone is set to automatic, fetching timezone in the background"
+                )
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+            except Exception as e:
+                logger.error(f"Error while fetching timezone in the background: {e}")
 
     @staticmethod
     async def request_and_sync_tz() -> str:


### PR DESCRIPTION
If the timezone fetching fails we can crash the wifi thread leaving the machine in a bad state where it cant automatically reconnect to wifis. Put the timezone fetching into a try block so that we dont fail here:

```
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]: 2025-06-01 13:52:34,473 named_thread ERROR Thread WifiAutoConnect crashed:
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]: Traceback (most recent call last):
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:   File "/opt/meticulous-venv/lib/python3.11/site-packages/aiohttp/connector.py", line 1283, in _wrap_create_connection
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:     return await self._loop.create_connection(*args, **kwargs, sock=sock)
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:   File "/usr/lib/python3.11/asyncio/base_events.py", line 1112, in create_connection
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:     transport, protocol = await self._create_connection_transport(
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:   File "/usr/lib/python3.11/asyncio/base_events.py", line 1145, in _create_connection_transport
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:     await waiter
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:   File "/usr/lib/python3.11/asyncio/sslproto.py", line 574, in _on_handshake_complete
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:     raise handshake_exc
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:   File "/usr/lib/python3.11/asyncio/sslproto.py", line 556, in _do_handshake
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:     self._sslobj.do_handshake()
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:   File "/usr/lib/python3.11/ssl.py", line 979, in do_handshake
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]:     self._sslobj.do_handshake()
Jun 01 13:52:34 meticulousFoamyCoffeeRoaster python3[21737]: ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate is not yet valid (_ssl.c:992)

```