### PR TITLE
fix: skip stage reimplementation

### DIFF
--- a/profile_converter/dictionaries.py
+++ b/profile_converter/dictionaries.py
@@ -68,6 +68,7 @@ trigger_type = {
     TriggerType.WEIGHT: "weight_value_trigger",
     TriggerType.BUTTON: "button_trigger",
     TriggerType.WATER_DETECTION: "water_detection_trigger",
+    TriggerType.USER_MESSAGE: "user_message_trigger",
     TriggerType.CURVE: {
         TriggerType.FLOW: "flow_curve_trigger",
         TriggerType.PRESSURE: "pressure_curve_trigger",

--- a/profile_converter/enums.py
+++ b/profile_converter/enums.py
@@ -96,6 +96,7 @@ class TriggerType(Enum):
     PRESSURE = "pressure"
     TEMPERATURE = "temperature"
     POWER = "power"
+    USER_MESSAGE = "user_message_trigger"
 
 
 class SourceType(Enum):

--- a/profile_converter/profile_converter.py
+++ b/profile_converter/profile_converter.py
@@ -32,7 +32,6 @@ class ComplexProfileConverter:
         self.max_piston_position = 75
 
     def head_template(self):
-        no_skipping = not MeticulousConfig[CONFIG_USER][MACHINE_ALLOW_STAGE_SKIPPING]
         self.head_next_node_id = 16
         self.stages_head = [
             {
@@ -77,9 +76,7 @@ class ComplexProfileConverter:
                             },
                         ],
                         "triggers": (
-                            [{"kind": "exit", "next_node_id": 1}]
-                            if no_skipping
-                            else [
+                            [
                                 {"kind": "exit", "next_node_id": 1},
                                 {
                                     "kind": "user_message_trigger",
@@ -93,23 +90,6 @@ class ComplexProfileConverter:
                         "controllers": [],
                         "triggers": (
                             [
-                                {
-                                    "kind": "pressure_value_trigger",
-                                    "next_node_id": 2,
-                                    "source": "Pressure Raw",
-                                    "operator": ">=",
-                                    "value": 6,
-                                },
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 20,
-                                    "operator": ">=",
-                                    "value": 1.5,
-                                    "next_node_id": 40,
-                                },
-                            ]
-                            if no_skipping
-                            else [
                                 {
                                     "kind": "pressure_value_trigger",
                                     "next_node_id": 2,
@@ -152,15 +132,6 @@ class ComplexProfileConverter:
                                     "operator": "==",
                                     "value": 0,
                                     "next_node_id": 3,
-                                }
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "piston_speed_trigger",
-                                    "operator": "==",
-                                    "value": 0,
-                                    "next_node_id": 3,
                                 },
                                 {
                                     "kind": "user_message_trigger",
@@ -181,22 +152,6 @@ class ComplexProfileConverter:
                         ],
                         "triggers": (
                             [
-                                {
-                                    "kind": "piston_speed_trigger",
-                                    "operator": "==",
-                                    "value": 0,
-                                    "next_node_id": 3,
-                                },
-                                {
-                                    "kind": "pressure_value_trigger",
-                                    "source": "Pressure Raw",
-                                    "operator": ">=",
-                                    "value": 6,
-                                    "next_node_id": 2,
-                                },
-                            ]
-                            if no_skipping
-                            else [
                                 {
                                     "kind": "piston_speed_trigger",
                                     "operator": "==",
@@ -240,22 +195,6 @@ class ComplexProfileConverter:
                                     "value": 1,
                                     "next_node_id": 4,
                                 },
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "piston_speed_trigger",
-                                    "operator": "!=",
-                                    "value": 0,
-                                    "next_node_id": 3,
-                                },
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 21,
-                                    "operator": ">=",
-                                    "value": 1,
-                                    "next_node_id": 4,
-                                },
                                 {
                                     "kind": "user_message_trigger",
                                     "next_node_id": 45,
@@ -268,16 +207,6 @@ class ComplexProfileConverter:
                         "controllers": [],
                         "triggers": (
                             [
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 20,
-                                    "operator": ">=",
-                                    "value": 1,
-                                    "next_node_id": 45,
-                                }
-                            ]
-                            if no_skipping
-                            else [
                                 {
                                     "kind": "timer_trigger",
                                     "timer_reference_id": 20,
@@ -341,23 +270,6 @@ class ComplexProfileConverter:
                                     "operator": ">=",
                                     "value": 300,
                                 },
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 2,
-                                    "next_node_id": 9,
-                                    "operator": ">=",
-                                    "value": 2,
-                                },
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 12,
-                                    "next_node_id": -2,
-                                    "operator": ">=",
-                                    "value": 300,
-                                },
                                 {
                                     "kind": "user_message_trigger",
                                     "next_node_id": 45,
@@ -403,27 +315,6 @@ class ComplexProfileConverter:
                                 },
                                 {
                                     "kind": "user_message_trigger",
-                                    "next_node_id": 17,
-                                },
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "temperature_value_trigger",
-                                    "next_node_id": 5,
-                                    "source": "Water Temperature",
-                                    "operator": ">=",
-                                    "value": self.temperature - self.offset_temperature,
-                                },
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 2,
-                                    "next_node_id": -2,
-                                    "operator": ">=",
-                                    "value": 900,
-                                },
-                                {
-                                    "kind": "user_message_trigger",
                                     "next_node_id": 16,
                                 },
                             ]
@@ -439,14 +330,6 @@ class ComplexProfileConverter:
                         "controllers": [{"kind": "time_reference", "id": 10}],
                         "triggers": (
                             [
-                                {"kind": "exit", "next_node_id": 7},
-                                {
-                                    "kind": "user_message_trigger",
-                                    "next_node_id": 17,
-                                },
-                            ]
-                            if no_skipping
-                            else [
                                 {"kind": "exit", "next_node_id": 7},
                                 {
                                     "kind": "user_message_trigger",
@@ -473,30 +356,6 @@ class ComplexProfileConverter:
                         "controllers": [],
                         "triggers": (
                             [
-                                {
-                                    "kind": "temperature_value_trigger",
-                                    "next_node_id": self.head_next_node_id,
-                                    "source": "Water Temperature",
-                                    "operator": ">=",
-                                    "value": self.temperature + self.offset_temperature,
-                                },
-                                {
-                                    "kind": "temperature_value_trigger",
-                                    "next_node_id": 5,
-                                    "source": "Water Temperature",
-                                    "operator": "<=",
-                                    "value": self.temperature - self.offset_temperature,
-                                },
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 5,
-                                    "next_node_id": self.head_next_node_id,
-                                    "operator": ">=",
-                                    "value": 5,
-                                },
-                            ]
-                            if no_skipping
-                            else [
                                 {
                                     "kind": "temperature_value_trigger",
                                     "next_node_id": self.head_next_node_id,
@@ -600,19 +459,6 @@ class ComplexProfileConverter:
                                     "value": -MeticulousConfig[CONFIG_USER][
                                         PROFILE_PARTIAL_RETRACTION
                                     ],
-                                }
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "piston_position_trigger",
-                                    "next_node_id": 21,
-                                    "source": "Piston Position Raw",
-                                    "position_reference_id": 1,
-                                    "operator": "<=",
-                                    "value": -MeticulousConfig[CONFIG_USER][
-                                        PROFILE_PARTIAL_RETRACTION
-                                    ],
                                 },
                                 {
                                     "kind": "user_message_trigger",
@@ -680,17 +526,6 @@ class ComplexProfileConverter:
                                     "source": "Piston Position Raw",
                                     "operator": ">=",
                                     "value": 4,
-                                }
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "piston_position_trigger",
-                                    "position_reference_id": 4,
-                                    "next_node_id": self.end_node_head,
-                                    "source": "Piston Position Raw",
-                                    "operator": ">=",
-                                    "value": 4,
                                 },
                                 {
                                     "kind": "user_message_trigger",
@@ -706,8 +541,6 @@ class ComplexProfileConverter:
         return self.stages_head
 
     def tail_template(self):
-        no_skipping = not MeticulousConfig[CONFIG_USER][MACHINE_ALLOW_STAGE_SKIPPING]
-
         if self.click_to_purge:
             self.tail_next_node_id = 30
         else:
@@ -801,17 +634,6 @@ class ComplexProfileConverter:
                                     "source": "Weight Raw",
                                     "operator": "<=",
                                     "value": -5,
-                                }
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "weight_value_trigger",
-                                    "weight_reference_id": 4,
-                                    "next_node_id": 49,
-                                    "source": "Weight Raw",
-                                    "operator": "<=",
-                                    "value": -5,
                                 },
                                 {
                                     "kind": "user_message_trigger",
@@ -825,16 +647,6 @@ class ComplexProfileConverter:
                         "controllers": [],
                         "triggers": (
                             [
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 15,
-                                    "next_node_id": 31,
-                                    "operator": ">=",
-                                    "value": 5,
-                                }
-                            ]
-                            if no_skipping
-                            else [
                                 {
                                     "kind": "timer_trigger",
                                     "timer_reference_id": 15,
@@ -886,16 +698,6 @@ class ComplexProfileConverter:
                                     "value": 2,
                                     "next_node_id": 34,
                                 },
-                            ]
-                            if no_skipping
-                            else [
-                                {
-                                    "kind": "timer_trigger",
-                                    "timer_reference_id": 22,
-                                    "operator": ">=",
-                                    "value": 2,
-                                    "next_node_id": 34,
-                                },
                                 {
                                     "kind": "user_message_trigger",
                                     "next_node_id": -2,
@@ -908,15 +710,6 @@ class ComplexProfileConverter:
                         "controllers": [],
                         "triggers": (
                             [
-                                {
-                                    "kind": "piston_speed_trigger",
-                                    "operator": "==",
-                                    "value": 0,
-                                    "next_node_id": 35,
-                                }
-                            ]
-                            if no_skipping
-                            else [
                                 {
                                     "kind": "piston_speed_trigger",
                                     "operator": "==",
@@ -935,16 +728,6 @@ class ComplexProfileConverter:
                         "controllers": [],
                         "triggers": (
                             [
-                                {
-                                    "kind": "pressure_value_trigger",
-                                    "source": "Pressure Raw",
-                                    "operator": "<=",
-                                    "value": 0.5,
-                                    "next_node_id": -2,
-                                },
-                            ]
-                            if no_skipping
-                            else [
                                 {
                                     "kind": "pressure_value_trigger",
                                     "source": "Pressure Raw",

--- a/profile_converter/profile_converter.py
+++ b/profile_converter/profile_converter.py
@@ -82,10 +82,8 @@ class ComplexProfileConverter:
                             else [
                                 {"kind": "exit", "next_node_id": 1},
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 45,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -127,10 +125,8 @@ class ComplexProfileConverter:
                                     "next_node_id": 40,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 45,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -167,10 +163,8 @@ class ComplexProfileConverter:
                                     "next_node_id": 3,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 45,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -217,10 +211,8 @@ class ComplexProfileConverter:
                                     "next_node_id": 2,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 45,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -265,10 +257,8 @@ class ComplexProfileConverter:
                                     "next_node_id": 4,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 45,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -296,10 +286,8 @@ class ComplexProfileConverter:
                                     "next_node_id": 45,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 45,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -329,10 +317,8 @@ class ComplexProfileConverter:
                                 "value": False,
                             },
                             {
-                                "kind": "button_trigger",
+                                "kind": "user_message_trigger",
                                 "next_node_id": 15,
-                                "gesture": "Single Tap",
-                                "source": "Encoder Button",
                             },
                         ],
                     },
@@ -373,10 +359,8 @@ class ComplexProfileConverter:
                                     "value": 300,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 45,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -420,8 +404,6 @@ class ComplexProfileConverter:
                                 {
                                     "kind": "user_message_trigger",
                                     "next_node_id": 17,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                             if no_skipping
@@ -441,10 +423,8 @@ class ComplexProfileConverter:
                                     "value": 900,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 16,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -463,18 +443,14 @@ class ComplexProfileConverter:
                                 {
                                     "kind": "user_message_trigger",
                                     "next_node_id": 17,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                             if no_skipping
                             else [
                                 {"kind": "exit", "next_node_id": 7},
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": self.head_next_node_id,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -543,10 +519,8 @@ class ComplexProfileConverter:
                                     "value": 5,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": self.head_next_node_id,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -570,8 +544,6 @@ class ComplexProfileConverter:
                             {
                                 "kind": "user_message_trigger",
                                 "next_node_id": 17,
-                                "gesture": "Single Tap",
-                                "source": "Encoder Button",
                             },
                             {
                                 "kind": "timer_trigger",
@@ -643,10 +615,8 @@ class ComplexProfileConverter:
                                     ],
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 21,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -723,10 +693,8 @@ class ComplexProfileConverter:
                                     "value": 4,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": self.end_node_head,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -813,8 +781,6 @@ class ComplexProfileConverter:
                             {
                                 "kind": "user_message_trigger",
                                 "next_node_id": 31,
-                                "gesture": "Single Tap",
-                                "source": "Encoder Button",
                             }
                         ],
                     }
@@ -848,9 +814,7 @@ class ComplexProfileConverter:
                                     "value": -5,
                                 },
                                 {
-                                    "kind": "button_trigger",
-                                    "source": "Encoder Button",
-                                    "gesture": "Single Tap",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 31,
                                 },
                             ]
@@ -879,9 +843,7 @@ class ComplexProfileConverter:
                                     "value": 5,
                                 },
                                 {
-                                    "kind": "button_trigger",
-                                    "source": "Encoder Button",
-                                    "gesture": "Single Tap",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": 31,
                                 },
                             ]
@@ -935,10 +897,8 @@ class ComplexProfileConverter:
                                     "next_node_id": 34,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": -2,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -964,10 +924,8 @@ class ComplexProfileConverter:
                                     "next_node_id": 35,
                                 },
                                 {
-                                    "kind": "button_trigger",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": -2,
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
                                 },
                             ]
                         ),
@@ -995,9 +953,7 @@ class ComplexProfileConverter:
                                     "next_node_id": -2,
                                 },
                                 {
-                                    "kind": "button_trigger",
-                                    "gesture": "Single Tap",
-                                    "source": "Encoder Button",
+                                    "kind": "user_message_trigger",
                                     "next_node_id": -2,
                                 },
                             ]

--- a/profile_converter/simplified_json.py
+++ b/profile_converter/simplified_json.py
@@ -420,9 +420,8 @@ class SimplifiedJson:
                 case _:
                     print(f"Type: {type_main_controller} not found.")
 
-            button_trigger = ButtonTrigger(
-                ButtonSourceType.ENCODER_BUTTON, next_node_id=next_stage_node_id
-            )
+            continue_trigger = UserMessageTrigger(next_node_id=next_stage_node_id)
+
             weight_final_trigger = WeightTrigger(
                 SourceType.PREDICTIVE,
                 TriggerOperatorType.GREATER_THAN_OR_EQUAL,
@@ -434,16 +433,16 @@ class SimplifiedJson:
             for limit_node in all_nodes[2:]:
                 limit_node["triggers"].append(main_trigger)
                 if allow_skipping:
-                    limit_node["triggers"].append(button_trigger.get_trigger())
+                    limit_node["triggers"].append(continue_trigger.get_trigger())
                 limit_node["triggers"].append(weight_final_trigger.get_trigger())
 
             if allow_skipping:
-                main_node.add_trigger(button_trigger)
+                main_node.add_trigger(continue_trigger)
             main_node.add_trigger(weight_final_trigger)
 
             if stage_index == len(self.parameters.get("stages")) - 1:
                 if allow_skipping:
-                    button_trigger.set_next_node_id(init_node_tail)
+                    continue_trigger.set_next_node_id(init_node_tail)
                 weight_final_trigger.set_next_node_id(init_node_tail)
                 for exit_trigger in exit_triggers:
                     exit_trigger["next_node_id"] = init_node_tail

--- a/profile_converter/simplified_json.py
+++ b/profile_converter/simplified_json.py
@@ -78,8 +78,6 @@ class SimplifiedJson:
         global current_curve_id
         global current_reference_id
 
-        allow_skipping = MeticulousConfig[CONFIG_USER][MACHINE_ALLOW_STAGE_SKIPPING]
-
         current_node_id = end_node_head
         # Use the comments with * as debugging tools.
         complex_stages = []
@@ -432,17 +430,14 @@ class SimplifiedJson:
 
             for limit_node in all_nodes[2:]:
                 limit_node["triggers"].append(main_trigger)
-                if allow_skipping:
-                    limit_node["triggers"].append(continue_trigger.get_trigger())
+                limit_node["triggers"].append(continue_trigger.get_trigger())
                 limit_node["triggers"].append(weight_final_trigger.get_trigger())
 
-            if allow_skipping:
-                main_node.add_trigger(continue_trigger)
+            main_node.add_trigger(continue_trigger)
             main_node.add_trigger(weight_final_trigger)
 
             if stage_index == len(self.parameters.get("stages")) - 1:
-                if allow_skipping:
-                    continue_trigger.set_next_node_id(init_node_tail)
+                continue_trigger.set_next_node_id(init_node_tail)
                 weight_final_trigger.set_next_node_id(init_node_tail)
                 for exit_trigger in exit_triggers:
                     exit_trigger["next_node_id"] = init_node_tail

--- a/profile_converter/triggers.py
+++ b/profile_converter/triggers.py
@@ -315,6 +315,16 @@ class ButtonTrigger(Triggers):
         self.data["gesture"] = source_type[SourceType.GESTURE][gesture]
 
 
+class UserMessageTrigger(Triggers):
+    def __init__(
+        self,
+        next_node_id: int = 0,
+    ):
+        super().__init__()
+        self.data["kind"] = trigger_type[TriggerType.USER_MESSAGE]
+        self.data["next_node_id"] = next_node_id
+
+
 class SpeedTrigger(OperatorTriggers):
     def __init__(
         self,


### PR DESCRIPTION
The dial app context menu has the "skip this step" option, which when used issues the backend to send the "continue" action to the ESP, which was received but had no effect as the profile does not recognizes it as a node trigger. This commit changes the `button_trigger` to the `user_message_trigger` in the `profile_converter` and `simplifiedJson.toComplex` elements so the "continue" command does trigger an exit of the current node