### PR TITLE
fix: purge and home are registered as brewing

### DIFF
--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -370,8 +370,8 @@ class ShotData:
         if profile is not None:
             if profile not in [
                 MachineStatus.IDLE,
-                MachineStatus.PURGE,
-                MachineStatus.HOME,
+                MachineStatusToProfile[MachineStatus.PURGE],
+                MachineStatusToProfile[MachineStatus.HOME],
             ]:
                 state = MachineState.BREWING
             else:

--- a/machine.py
+++ b/machine.py
@@ -688,7 +688,12 @@ class Machine:
         if (
             Machine.data_sensors.state == "brewing"
             and Machine.data_sensors.status
-            not in ["heating", "Pour water and click to continue", "click to start"]
+            not in [
+                "heating",
+                "Pour water and click to continue",
+                "click to start",
+                "purge",
+            ]
         ):
             Machine.action("home")
         else:


### PR DESCRIPTION
When setting the machine state to brewing we first check against the value of the status if it is homing or purging, if it is, we dont set it as brewing, but the profile reported by the ESP and the values in the comparison array were not alligned causing it to always be set as brewing and messing with the cancellation command.

We now use the MachineStatusToProfile dictionary to get the correct values

**Update**
If the user cancells the starting or ending profile purge, the piston will stop in place instead of going home