### PR TITLE
chore(config): Pathlib syntax updates

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ _config_logger = MeticulousLogger.getLogger(__name__)
 
 CONFIG_PATH = os.getenv("CONFIG_PATH", "/meticulous-user/config")
 
-# Config Compontents
+# Config Components
 CONFIG_LOGGING = "logging"
 CONFIG_SYSTEM = "system"
 CONFIG_USER = "user"
@@ -158,14 +158,14 @@ LOGGING_SENSOR_MESSAGES = "log_all_sensor_messages"
 LOGGING_DEFAULT_SENSOR_MESSAGES = False
 
 #
-# WIFI related config items
+# Wi-Fi related config items
 #
-# Wifi Config items
+# Wi-Fi Config items
 WIFI_MODE = "mode"
 WIFI_MODE_AP = "AP"
 WIFI_MODE_CLIENT = "CLIENT"
 
-# Wifi access point configuration
+# Wi-Fi access point configuration
 WIFI_AP_NAME = "APName"
 WIFI_DEFAULT_AP_NAME = "MeticulousEspresso"
 WIFI_AP_PASSWORD = "APPassword"


### PR DESCRIPTION
There are 3 main commits that can be optionally browsed 1-by-1 for easier review.

1. Use Path objects better in MeticulousConfigDict
  a. I decided to make `self.__path` an actual Path object instead of a string.
  b. It's no longer listed as an optional argument.
  c. I updated multiple syntax areas to use modern pathlib syntax.
  d. NOTE: I did NOT modify the global variable `CONFIG_PATH` to be a Path object.  It remains a string, primarily because it's imported by numerous other files and I wanted to keep the scope small.
2. Don't use a mutable dictionary as a default argument value (this is just a small bugbear).  The fix was to just make this a non-optional argument, same as the path.
3. isort imports