### PR TITLE
fix: also save machine data in debug file when purging and homing

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -713,6 +713,9 @@ class Machine:
 
             ProfileManager.send_profile_to_esp32(last_profile["profile"])
 
+        if action_event == "home" or action_event == "purge":
+            Machine.profileReady = True
+
         machine_msg = f"action,{action_event}\x03"
         Machine.writeStr(machine_msg)
         return True


### PR DESCRIPTION
Set `Machine.profileReady` flag when requesting a Purge or a Home action. We can treat them as profiles, as they truly are saved like that within the ESP