### PR TITLE
fix: deleteWifi not returning a value causes an error to be displayed

### DIFF
--- a/wifi.py
+++ b/wifi.py
@@ -341,9 +341,14 @@ class WifiManager:
     @staticmethod
     def deleteWifi(ssid: str) -> bool:
         if ssid in MeticulousConfig[CONFIG_WIFI][WIFI_KNOWN_WIFIS]:
-            nmcli.connection.delete(ssid)
             del MeticulousConfig[CONFIG_WIFI][WIFI_KNOWN_WIFIS][ssid]
             MeticulousConfig.save()
+            for connection in nmcli.connection():
+                if connection.name == ssid:
+                    nmcli.connection.delete(ssid)
+                    return True
+            return False
+        return False
 
     @staticmethod
     def fixWifiConnection(ssid, wifi_type: WifiType):


### PR DESCRIPTION
Also added a check to see if the `network manager` has the `SSID` registered already before deleting it. If it is not in there, `False` is returned