### PR TITLE
fix: set the esp_reset_request flag before calling _connection.reset()

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -775,7 +775,7 @@ class Machine:
                             "ESP has restarted unexpectedly", "critical"
                         )
                     AlarmManager.set_alarm(
-                        AlarmType.ESP_RESTART, end_time=None, force=False
+                        AlarmType.ESP_RESTART, end_time=None, force=False, quiet=True
                     )
                     ESP_tracing_info = []
 

--- a/machine.py
+++ b/machine.py
@@ -886,11 +886,11 @@ class Machine:
             Machine._connection.port.write(content)
 
     def reset():
+        Machine.esp_restart_request = True
         Machine._connection.reset()
         Machine.infoReady = False
         Machine.profileReady = False
         Machine.startTime = time.time()
-        Machine.esp_restart_request = True
 
     def send_json_with_hash(json_obj):
         json_string = json.dumps(json_obj)


### PR DESCRIPTION
Also do not show the notification of `Digital controller seems to be unresponsive, buttons are disabled.` when the ESP restarts unexpectedly, only report to Sentry