### PR TITLE
fix: add missing gst-play-1.0 dependency for playsound3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm
 
 RUN apt-get update -y && apt-get dist-upgrade -y
-RUN apt-get install -y build-essential libcairo2-dev libxt-dev libgirepository1.0-dev libgstreamer1.0-dev bluez \
+RUN apt-get install -y build-essential libcairo2-dev libxt-dev libgirepository1.0-dev libgstreamer1.0-dev gstreamer1.0-plugins-base-apps bluez \
     libsystemd-dev libparted-dev libglib2.0-dev libffi-dev python3-dev pkg-config \
     python3 \
     python3-setuptools \

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -5,6 +5,6 @@ Maintainer: Meticulous Home <info@meticuloushome.com>
 Description: Meticulous Espresso Machine Backend
  Backend service for the Meticulous espresso machine.
  Includes a pre-built Python virtual environment with all dependencies.
-Depends: python3, libcairo2, libgirepository-1.0-1, libgstreamer1.0-0, libsystemd0, libparted2, libglib2.0-0, libffi8, bluez, dbus, gir1.2-glib-2.0, gir1.2-freedesktop, gstreamer1.0-plugins-base
+Depends: python3, libcairo2, libgirepository-1.0-1, libgstreamer1.0-0, libsystemd0, libparted2, libglib2.0-0, libffi8, bluez, dbus, gir1.2-glib-2.0, gir1.2-freedesktop, gstreamer1.0-plugins-base, gstreamer1.0-plugins-base-apps
 Section: misc
 Priority: optional


### PR DESCRIPTION
## Summary
- The upgrade to `playsound3` in 09b49e1 requires `gst-play-1.0` to play sounds on Linux
- This binary is provided by `gstreamer1.0-plugins-base-apps`, which was not included in the Dockerfile or deb package dependencies
- Without it, `playsound3` fails with `"No supported audio backends on this system!"`

## Root cause
Commit `09b49e1` (sound: upgrade to playsound3) replaced the in-process GStreamer Python bindings (`gi.repository.Gst`) with `playsound3`, which shells out to `gst-play-1.0`. That binary lives in `gstreamer1.0-plugins-base-apps`, which is separate from the already-included `gstreamer1.0-plugins-base`.

## Changes
- Added `gstreamer1.0-plugins-base-apps` to `Dockerfile` apt install
- Added `gstreamer1.0-plugins-base-apps` to `debian/DEBIAN/control` Depends

## Test plan
- [x] Verified on device: `apt install gstreamer1.0-plugins-base-apps` resolves the issue
- [x] Confirmed `gst-play-1.0` plays mp3 files through PulseAudio successfully