### PR TITLE
[codex] Sync auto purge setting to firmware

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -13,6 +13,7 @@ from config import (
     SSH_ENABLED,
     TELEMETRY_SERVICE_ENABLED,
     PROFILE_ORDER,
+    PROFILE_AUTO_PURGE,
     PROFILE_PARTIAL_RETRACTION,
 )
 
@@ -184,6 +185,9 @@ class SettingsHandler(BaseHandler):
 
                 if setting_target == PROFILE_PARTIAL_RETRACTION:
                     Machine.setPartialRetraction(value)
+
+                if setting_target == PROFILE_AUTO_PURGE:
+                    Machine.setAutoPurgeAfterShot(value)
 
                 # If we made it here without exception we can update the setting
                 workConfig[setting_target] = value

--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -173,6 +173,7 @@ class ESPInfo:
     buildDate: str = ""
     scaleModule: str = ""
     partialRetraction: float = 45.0
+    autoPurgeAfterShot: bool = False
 
     def from_args(args):
         espPinout = 0
@@ -182,7 +183,20 @@ class ESPInfo:
         except Exception:
             pass
         try:
-            if len(args) >= 9:
+            if len(args) >= 10:
+                info = ESPInfo(
+                    args[0],
+                    espPinout,
+                    float(args[2]),
+                    args[3],
+                    args[4],
+                    args[5],
+                    args[6],
+                    args[7],
+                    float(args[8]),
+                    args[9].lower() == "true",
+                )
+            elif len(args) >= 9:
                 info = ESPInfo(
                     args[0],
                     espPinout,
@@ -224,6 +238,7 @@ class ESPInfo:
             self.buildDate,
             self.scaleModule,
             str(self.partialRetraction),
+            "true" if self.autoPurgeAfterShot else "false",
         ]
         return args
 
@@ -239,6 +254,7 @@ class ESPInfo:
             "build_date": self.buildDate,
             "scale_module": self.scaleModule,
             "partial_retraction": self.partialRetraction,
+            "auto_purge_after_shot": self.autoPurgeAfterShot,
         }
 
 

--- a/machine.py
+++ b/machine.py
@@ -25,6 +25,7 @@ from config import (
     MACHINE_BUILD_DATE,
     MACHINE_BATCH_NUMBER,
     MACHINE_HEAT_ON_BOOT,
+    PROFILE_AUTO_PURGE,
     PROFILE_PARTIAL_RETRACTION,
     MeticulousConfig,
 )
@@ -96,6 +97,7 @@ class esp_nvs_keys(Enum):
     batch_number = "batch_number_key"
     build_date = "build_date_key"
     partial_retraction = "partial_retraction_key"
+    auto_purge_after_shot = "auto_purge_after_shot_key"
 
 
 class Machine:
@@ -622,6 +624,10 @@ class Machine:
                         MeticulousConfig[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     )
                     Machine.setPartialRetraction(backend_partial_retraction)
+                    backend_auto_purge = bool(
+                        MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE]
+                    )
+                    Machine.setAutoPurgeAfterShot(backend_auto_purge)
 
                     if (
                         info.serialNumber != ""
@@ -961,6 +967,40 @@ Build Date: {build_date}
 
         if Machine.esp_info is not None:
             Machine.esp_info.partialRetraction = desired_value
+
+    def setAutoPurgeAfterShot(auto_purge_after_shot: bool):
+        desired_value = bool(auto_purge_after_shot)
+
+        if (
+            Machine.esp_info is not None
+            and Machine.esp_info.autoPurgeAfterShot == desired_value
+        ):
+            return
+
+        if (
+            Machine._connection is None
+            or Machine._connection.port is None
+            or Machine._stopESPcomm
+        ):
+            logger.warning(
+                "Cannot sync auto_purge_after_shot to ESP32 because serial connection "
+                "is not ready"
+            )
+            return
+
+        write_request = "nvs_request,write,"
+        payload = (
+            write_request
+            + esp_nvs_keys.auto_purge_after_shot.value
+            + ","
+            + ("true" if desired_value else "false")
+            + "\x03"
+        )
+        Machine.write(payload.encode("utf-8"))
+        logger.info("Synced auto_purge_after_shot to ESP32: " + f"requested={desired_value}")
+
+        if Machine.esp_info is not None:
+            Machine.esp_info.autoPurgeAfterShot = desired_value
 
     def _parseVersionString(version_str: str):
         release = None


### PR DESCRIPTION
## Summary
- Parse and expose the firmware `ESPInfo` auto-purge field.
- Add `auto_purge_after_shot_key` to backend ESP NVS keys.
- Sync `auto_purge_after_shot` to firmware on ESPInfo refresh and when the setting changes through the settings API.

## Why
Firmware now owns the runtime decision for automatic final purge, so backend needs to keep the ESP32 NVS value aligned with the existing backend setting.

## Validation
- `git diff --check HEAD~1..HEAD`
- `/opt/homebrew/bin/python3.11 -m py_compile api/settings.py machine.py esp_serial/data.py`
- Manual `ESPInfo` parse/roundtrip smoke test for `auto_purge_after_shot`