### PR TITLE
chore: remove usb_mode setting from api, config dict and yml file

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -5,7 +5,6 @@ from config import (
     MeticulousConfig,
     UPDATE_CHANNEL,
     MACHINE_HEATING_TIMEOUT,
-    USB_MODE,
     USB_MODES,
     TIMEZONE_SYNC,
     TIME_ZONE,
@@ -173,9 +172,6 @@ class SettingsHandler(BaseHandler):
 
                 if setting_target == MACHINE_HEATING_TIMEOUT:
                     self.update_heater_timeout(value)
-
-                if setting_target == USB_MODE:
-                    self.update_usb_mode(value)
 
                 if setting_target == UPDATE_CHANNEL:
                     UpdateManager.setChannel(value)

--- a/config.py
+++ b/config.py
@@ -236,7 +236,6 @@ DefaultConfiguration_V1 = {
         REVERSE_SCROLLING: REVERSE_SCROLLING_DEFAULT,
         ALLOW_LEGACY_JSON: ALLOW_LEGACY_JSON_DEFAULT,
         MACHINE_ALLOW_STAGE_SKIPPING: MACHINE_ALLOW_STAGE_SKIPPING_DEFAULT,
-        USB_MODE: USB_MODE_DEFAULT,
         TIMEZONE_SYNC: DEFAULT_TIMEZONE_SYNC,
         TIME_ZONE: DEFAULT_TIME_ZONE,
         MACHINE_DEBUG_SENDING: MACHINE_DEBUG_SENDING_DEFAULT,
@@ -335,7 +334,15 @@ class MeticulousConfigDict(dict):
                     # migrate partial_retraction config data from int to float
                     retraction = self[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     if isinstance(retraction, int):
-                        self[CONFIG_USER][PROFILE_PARTIAL_RETRACTION] = float(retraction)
+                        self[CONFIG_USER][PROFILE_PARTIAL_RETRACTION] = float(
+                            retraction
+                        )
+                    # remove usb_mode setting from yml file
+                    if self[CONFIG_USER].get(USB_MODE) is not None:
+                        _config_logger.info(
+                            "usb_mode attribute found in config, removing"
+                        )
+                        self[CONFIG_USER].pop(USB_MODE)
                     _config_logger.info("Successfully loaded config from disk")
                     self.__configError = False
                 except Exception as e:

--- a/usb.py
+++ b/usb.py
@@ -1,4 +1,4 @@
-from config import CONFIG_USER, USB_MODE, USB_MODES, MeticulousConfig
+from config import USB_MODES
 
 from log import MeticulousLogger
 from machine import Machine
@@ -17,8 +17,10 @@ class USBManager:
         USBManager.usbPdController = PTN5150H()
         logger.info("USB PD Controller initialized")
         try:
-            USB_MODES(MeticulousConfig[CONFIG_USER][USB_MODE])
-            USBManager.setUSBMode(MeticulousConfig[CONFIG_USER][USB_MODE])
+            USB_MODES(
+                USB_MODES.HOST.value
+            )  # hardcode as host (DTS sets it as host only)
+            USBManager.setUSBMode(USB_MODES.HOST.value)
         except RuntimeError as error:
             logger.error(f"error initializing USB Manager: f{error}, starting USB as client")
             USBManager.setUSBMode(USB_MODES.CLIENT.value)


### PR DESCRIPTION
Remove the option to change the `USB MODE`. On this linux system's DTB the USB is now only allowed to be Host, so there is no reason to keep the setting as modifiable