### PR TITLE
Fix firmware version refresh before ESP32 flashing

### DIFF
--- a/api/update.py
+++ b/api/update.py
@@ -69,6 +69,8 @@ class UpdateFirmwareWithZipHandler(BaseHandler):
             self.write("failure during upload")
             return
 
+        Machine.refreshAvailableFirmware()
+
         upgradeThread = NamedThread("FWUpgrade", target=Machine.startUpdate)
         upgradeThread.start()
 

--- a/machine.py
+++ b/machine.py
@@ -231,12 +231,17 @@ class Machine:
         else:
             logger.info("The ESP is alive")
 
-    def init(sio):
-        Machine.esp_restart_request = True
-        Machine._sio = sio
+    def refreshAvailableFirmware():
         Machine.firmware_available = Machine._parseVersionString(
             ESPToolWrapper.get_version_from_firmware()
         )
+        logger.info(f"Backend available firmware version: {Machine.firmware_available}")
+        return Machine.firmware_available
+
+    def init(sio):
+        Machine.esp_restart_request = True
+        Machine._sio = sio
+        Machine.refreshAvailableFirmware()
 
         # If we dont have a serial we still want to be able to show ... something
         serial = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]


### PR DESCRIPTION
## Summary
- Refresh the backend's cached available ESP32 firmware version after a firmware upload succeeds.
- Reuse the same refresh path during machine startup so the comparison logic stays in one place.

## Root Cause
The firmware upload endpoint replaced the files under `/opt/meticulous-firmware`, then started flashing while `Machine.firmware_available` still held the version parsed at backend startup. After the ESP32 rebooted into the uploaded firmware, the backend compared it against the stale startup version and triggered another flash.

## Validation
- Ran `python3 -m py_compile api/update.py machine.py`.
- Reproduced on `192.168.0.109` by flashing `0.2.24-363-g78e2154`; logs showed the backend still had `0.2.24-356-g63cba39` cached and re-entered flashing.
- Applied the fix on the machine and flashed `0.2.24-364-g660155a`; logs showed one flash, matching running/available versions, and zero `outdated, upgrading` entries afterward.