### PR TITLE
Make update channel follow image channel

### DIFF
--- a/ota.py
+++ b/ota.py
@@ -34,25 +34,25 @@ class UpdateManager:
 
     @staticmethod
     def init():
-
         build_channel = UpdateManager.getImageChannel()
         if build_channel is None:
             logger.error("Could not get build channel")
             return
 
+        update_channel = MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL]
         if MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] == "":
             if build_channel in ["stable", "factory"]:
-                MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] = build_channel
+                update_channel = build_channel
             else:
-                MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] = "stable"
-            MeticulousConfig.save()
-            logger.warning(f"Set update channel to {build_channel} based on image")
-
-        UpdateManager.setChannel(MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL])
+                update_channel = "stable"
 
         build_time = UpdateManager.getBuildTimestamp()
         if build_time is None:
             logger.error("Could not get build timestamp")
+            if MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] != update_channel:
+                MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] = update_channel
+                MeticulousConfig.save()
+            UpdateManager.setChannel(MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL])
             return
 
         this_build_time = build_time.strftime("%Y%m%d_%H%M%S")
@@ -62,9 +62,10 @@ class UpdateManager:
             last_known_version = MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS][-1]
             is_changed = last_known_version != this_version_string
         except IndexError:
-            is_changed = 1
+            is_changed = True
             last_known_version = "NONE"
 
+        UpdateManager.is_changed = is_changed
         print(f"Last known version image: {last_known_version}")
         print(f"This image version: {this_version_string}")
 
@@ -72,6 +73,20 @@ class UpdateManager:
             logger.info(
                 f"System was updated to {this_version_string} from {last_known_version}"
             )
+            update_channel = build_channel
+
+        if MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] != update_channel:
+            previous_channel = MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL]
+            MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] = update_channel
+            MeticulousConfig.save()
+            logger.warning(
+                f"Set update channel to {update_channel} based on image "
+                f"(previous: {previous_channel})"
+            )
+
+        UpdateManager.setChannel(MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL])
+
+        if is_changed:
             MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS].append(this_version_string)
             while len(MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS]) > 30:
                 MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS].pop(0)

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -1,0 +1,86 @@
+import copy
+from datetime import datetime, timezone
+
+import pytest
+
+from config import (
+    CONFIG_SYSTEM,
+    CONFIG_USER,
+    LAST_SYSTEM_VERSIONS,
+    MeticulousConfig,
+    UPDATE_CHANNEL,
+)
+from ota import UpdateManager
+
+
+@pytest.fixture(autouse=True)
+def restore_config_and_update_manager():
+    original_config = copy.deepcopy(dict(MeticulousConfig))
+    original_state = {
+        "ROOTFS_BUILD_DATE": UpdateManager.ROOTFS_BUILD_DATE,
+        "CHANNEL": UpdateManager.CHANNEL,
+        "REPO_INFO": UpdateManager.REPO_INFO,
+        "VERSION": UpdateManager.VERSION,
+        "is_changed": UpdateManager.is_changed,
+    }
+
+    yield
+
+    MeticulousConfig.clear()
+    MeticulousConfig.update(original_config)
+    for attr, value in original_state.items():
+        setattr(UpdateManager, attr, value)
+
+
+def test_init_updates_channel_to_new_image_channel(monkeypatch):
+    set_channel_calls = []
+    save_calls = []
+
+    MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] = "stable"
+    MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS] = ["stable-20260528_120000"]
+
+    monkeypatch.setattr(UpdateManager, "getImageChannel", lambda: "iw612")
+    monkeypatch.setattr(
+        UpdateManager,
+        "getBuildTimestamp",
+        lambda: datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        UpdateManager, "setChannel", lambda channel: set_channel_calls.append(channel)
+    )
+    monkeypatch.setattr(MeticulousConfig, "save", lambda: save_calls.append(True))
+
+    UpdateManager.init()
+
+    assert MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] == "iw612"
+    assert MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS][-1] == "iw612-20260529_120000"
+    assert set_channel_calls == ["iw612"]
+    assert UpdateManager.is_changed is True
+    assert len(save_calls) == 2
+
+
+def test_init_keeps_existing_channel_when_image_is_unchanged(monkeypatch):
+    set_channel_calls = []
+    save_calls = []
+
+    MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] = "stable"
+    MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS] = ["stable-20260529_120000"]
+
+    monkeypatch.setattr(UpdateManager, "getImageChannel", lambda: "stable")
+    monkeypatch.setattr(
+        UpdateManager,
+        "getBuildTimestamp",
+        lambda: datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        UpdateManager, "setChannel", lambda channel: set_channel_calls.append(channel)
+    )
+    monkeypatch.setattr(MeticulousConfig, "save", lambda: save_calls.append(True))
+
+    UpdateManager.init()
+
+    assert MeticulousConfig[CONFIG_USER][UPDATE_CHANNEL] == "stable"
+    assert MeticulousConfig[CONFIG_SYSTEM][LAST_SYSTEM_VERSIONS] == ["stable-20260529_120000"]
+    assert set_channel_calls == ["stable"]
+    assert UpdateManager.is_changed is False
+    assert save_calls == []


### PR DESCRIPTION
## Summary
- Update `UpdateManager.init()` so a newly booted image changes the persisted `update_channel` to match the image build channel.
- Keep the existing default-channel behavior when no image change can be detected, then continue writing `/etc/hawkbit/channel` through `setChannel()`.
- Set `UpdateManager.is_changed` from the image-history comparison so first-boot-after-update status reflects the detected change.
- Add unit coverage for changing from `stable` to a new image channel and for leaving the channel alone when the image is unchanged.

## Validation
- `black --check ota.py tests/test_ota.py`
- `git diff --check`
- `.venv-test/bin/python -m pytest tests/test_ota.py tests/test_profile_preprocessor.py`
- `.venv-test/bin/python -m pytest` does not complete in this local venv because unrelated tests need additional machine/test dependencies and BLE import mocking (`dbus_next.aio`, `pytz`).