### PR TITLE
Fix/emulated reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y build-essential libcairo2-dev libxt-dev libgirepository1.
     libsystemd-dev libparted-dev libglib2.0-dev libffi-dev python3-dev pkg-config \
     python3 \
     python3-setuptools \
-    dbus systemd git curl
+    dbus systemd git curl zstd
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -364,7 +364,39 @@ async def _capture_incomplete_debug_shot(draft_dir: Path) -> str | None:
     )
 
 
+def _machine_is_emulated() -> bool:
+    from machine import Machine
+
+    return bool(Machine.emulated)
+
+
+def _emulated_machine_logs(reference_time: int | None = None) -> str:
+    timestamp = datetime.now(timezone.utc).isoformat()
+    reference_text = (
+        f"reference_time={reference_time}" if reference_time is not None else "latest"
+    )
+    return (
+        f"{timestamp} INFO meticulous-backend Emulated machine logs generated "
+        f"for bug report ({reference_text}).\n"
+    )
+
+
+def _emulated_machine_status() -> str:
+    return json.dumps(
+        {
+            "emulated": True,
+            "status": "ok",
+            "source": "meticulous-backend",
+            "timestamp": _now_seconds(),
+        },
+        ensure_ascii=False,
+    )
+
+
 async def _fetch_machine_logs(reference_time: int | None = None) -> str:
+    if _machine_is_emulated():
+        return _emulated_machine_logs(reference_time)
+
     url = WATCHER_LOGS_URL
     if reference_time is not None:
         ceiling = min(_now_seconds(), reference_time + (3 * 60 * 60))
@@ -373,13 +405,16 @@ async def _fetch_machine_logs(reference_time: int | None = None) -> str:
         separator = "&" if "?" in url else "?"
         url = f"{url}{separator}since={start_hours}&until={end_hours}"
     client = tornado.httpclient.AsyncHTTPClient()
-    response = await client.fetch(url, request_timeout=60)
+    response = await client.fetch(url, request_timeout=240)
     return response.body.decode("utf-8", errors="replace")
 
 
 async def _fetch_machine_status() -> str:
+    if _machine_is_emulated():
+        return _emulated_machine_status()
+
     client = tornado.httpclient.AsyncHTTPClient()
-    response = await client.fetch(WATCHER_STATUS_URL, request_timeout=60)
+    response = await client.fetch(WATCHER_STATUS_URL, request_timeout=120)
     return response.body.decode("utf-8", errors="replace")
 
 

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -405,7 +405,7 @@ async def _fetch_machine_logs(reference_time: int | None = None) -> str:
         separator = "&" if "?" in url else "?"
         url = f"{url}{separator}since={start_hours}&until={end_hours}"
     client = tornado.httpclient.AsyncHTTPClient()
-    response = await client.fetch(url, request_timeout=240)
+    response = await client.fetch(url, request_timeout=600)
     return response.body.decode("utf-8", errors="replace")
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,9 @@ services:
       - ./default_profiles:/app/default_profiles
       - ./reports:/app/reports
       - /tmp/met_image-build-channel:/opt/image-build-channel
+    logging:
+      driver: "local"
+      options:
+        max-size: "150m"     # Max size of a single log file before it rotates
+        max-file: "3"       # Maximum number of rotated files to keep
+        compress: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     expose:
       - 8080
     user: "${USER_ID:-root}:${GROUP_ID:-0}"
+    command: ["/bin/bash", "/app/start_container.sh"]
     environment:
       - BACKEND=emulation
       - EMULATION_SPEED=100
@@ -25,6 +26,7 @@ services:
       - DEFAULT_PROFILES=/app/default_profiles
       - REPORTS_DIR=/app/reports
     volumes:
+      - .:/app
       - ./config:/app/config
       - ./logs:/app/logs
       - ./profiles:/app/profiles
@@ -32,3 +34,4 @@ services:
       - ./images:/app/images
       - ./default_profiles:/app/default_profiles
       - ./reports:/app/reports
+      - /tmp/met_image-build-channel:/opt/image-build-channel

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
-export IMAGE_CHANNEL="factory"
+set -eu
+
+IMAGE_CHANNEL="${IMAGE_CHANNEL:-factory}"
 echo ${IMAGE_CHANNEL} > /tmp/met_image-build-channel
-docker compose run --remove-orphans --build -p 8080:8080 -v /tmp/met_image-build-channel:/opt/image-build-channel -v $(pwd):/app backend
+docker compose up --remove-orphans --build --wait

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -99,6 +99,37 @@ def test_fetch_report_files_uses_parent_debug_file_names(report_module, monkeypa
     )
 
 
+def test_fetch_machine_logs_uses_emulated_response_without_watcher(report_module, monkeypatch):
+    monkeypatch.setattr(report_module, "_machine_is_emulated", lambda: True)
+
+    def fail_fetch(*args, **kwargs):
+        raise AssertionError("Emulated machine logs should not call watcher")
+
+    monkeypatch.setattr(report_module.tornado.httpclient.AsyncHTTPClient, "fetch", fail_fetch)
+
+    logs = asyncio.run(report_module._fetch_machine_logs(reference_time=123))
+
+    assert "Emulated machine logs generated for bug report" in logs
+    assert "reference_time=123" in logs
+
+
+def test_fetch_machine_status_uses_emulated_response_without_watcher(
+    report_module, monkeypatch
+):
+    monkeypatch.setattr(report_module, "_machine_is_emulated", lambda: True)
+
+    def fail_fetch(*args, **kwargs):
+        raise AssertionError("Emulated machine status should not call watcher")
+
+    monkeypatch.setattr(report_module.tornado.httpclient.AsyncHTTPClient, "fetch", fail_fetch)
+
+    status = json.loads(asyncio.run(report_module._fetch_machine_status()))
+
+    assert status["emulated"] is True
+    assert status["status"] == "ok"
+    assert status["source"] == "meticulous-backend"
+
+
 def test_fetch_report_files_includes_active_incomplete_debug_shot_first(
     report_module, monkeypatch
 ):


### PR DESCRIPTION
This PR will allow fetching emulated machine status and machine logs when the report endpoints, mainly the /reports/create endpoint, are hit on an emulated backend.

Also increases the timeout of the machine log fetching client request to 600s (requested) and 120s for the machine status request