### PR TITLE
Cap automatic timezone fetch retries at 5 attempts per boot

### DIFF
--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -27,6 +27,8 @@ class TimezoneManager:
 
     __system_timezone: str = ""
     __system_synced: bool = False
+    __timezone_fetch_attempts: int = 0
+    _MAX_TIMEZONE_FETCH_ATTEMPTS: int = 5
 
     @staticmethod
     def init():
@@ -249,6 +251,9 @@ class TimezoneManager:
     def tz_background_update():
         tz_config = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
         if tz_config == "automatic" and not TimezoneManager.__system_synced:
+            if TimezoneManager.__timezone_fetch_attempts >= TimezoneManager._MAX_TIMEZONE_FETCH_ATTEMPTS:
+                return
+            TimezoneManager.__timezone_fetch_attempts += 1
             try:
                 logger.info("Timezone is set to automatic, fetching timezone in the background")
                 loop = asyncio.get_event_loop()

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -258,6 +258,10 @@ class TimezoneManager:
                 logger.info("Timezone is set to automatic, fetching timezone in the background")
                 loop = asyncio.get_event_loop()
                 loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+                # Clear the attempt counter on a successful request so that, if
+                # __system_synced is ever reset, an unstable network gets a fresh
+                # batch of attempts instead of inheriting an exhausted counter.
+                TimezoneManager.__timezone_fetch_attempts = 0
             except Exception as e:
                 logger.error(f"Error while fetching timezone in the background: {e}")
 


### PR DESCRIPTION
## Summary

- `tz_background_update()` is called every 10 seconds by the WiFi background loop whenever the machine has a connection.
- On any network failure (DNS error, SSL error, TCP timeout), the exception was caught and logged, but `__system_synced` was never set — so the next iteration retried unconditionally, forever.
- On machines where `analytics.meticulousespresso.com` is unreachable (e.g. blocked by a local DNS filter like Pi-hole, or SSL cert mismatch on the client), this produced ~8,600 Sentry events/day/machine and was the dominant source of DNS traffic to `sentry.meticulousespresso.com` reported by beta users (one user measured 880k hits in 10 weeks from a single machine).
- Sentry baseline (last 7d): **69,892 events** on beta, **6,978** on stable — all from this loop.

## Root cause

```python
# before: no stop condition on failure
except Exception as e:
    logger.error(f"Error while fetching timezone in the background: {e}")
    # __system_synced stays False → retries indefinitely
```

## Fix

Added a `__timezone_fetch_attempts` counter and a cap of 5 attempts per boot. A successful sync still sets `__system_synced = True` and stops further attempts normally. The 5 failure events that do reach Sentry per boot are still useful for diagnosing connectivity issues.

## Validation

- Sentry event count for `"Error while fetching timezone in the background"` should drop ~99% after this ships to beta. Baseline query: [Sentry Discover](https://meticulous-home.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=title%3A%22Error+while+fetching+timezone+in+the+background%22+OR+message%3A%22Error+while+fetching+timezone+in+the+background%22&field=tags%5Bbuild-channel%5D&field=tags%5Bbuild-version%5D&field=count%28%29&sort=-count%28%29&statsPeriod=7d&mode=aggregate&yAxis=count%28%29)
- Machines where `analytics.meticulousespresso.com` resolves correctly are unaffected — the first successful response sets `__system_synced = True` as before.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)