### PR TITLE
fix: direct access to the backend through port 8080

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -329,7 +329,7 @@ def main():
         debug=DEBUG,
     )
 
-    app.listen(PORT)
+    app.listen(PORT, aaddress='127.0.0.1')
 
     sio.start_background_task(live)
 


### PR DESCRIPTION
We allow only access to the backend through the NGINX proxy, so we bind the backend to listen only to the 127.0.0.1 address. This tightens the secure endpoints like root-password to be only accessible through NGINX.

Prior to this we could access to the restricted endpoints by requesting to the 8080 port directly, this would not set the X-Real-IP header and would not be handled correctly. While that misshandle could be fixed in the handler, having less paths to reach the backend would make rules easier to enforce