### PR TITLE
test: catch invalid kwargs passed to app.listen() in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Check code formatting with black
       run: uv run black --check .
 
+    - name: Type check with mypy
+      run: uv run mypy .
+
   test:
     runs-on: ubuntu-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,17 @@ dev = [
     "flake8==7.2.0",
     "black==26.3.1",
     "pytest>=8.0.0",
+    "mypy>=1.10.0",
 ]
 
 [tool.black]
 line-length = 96
 target-version = ["py311"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+# Start permissive — tighten over time
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true

--- a/tests/test_backend_listen.py
+++ b/tests/test_backend_listen.py
@@ -1,0 +1,56 @@
+"""
+Regression test for invalid kwargs passed to app.listen() in backend.py.
+
+ffebc909 introduced a typo ('aaddress' instead of 'address') that caused a
+TypeError at startup. This test parses backend.py with the AST and validates
+every .listen() call's keyword arguments against tornado.httpserver.HTTPServer's
+actual __init__ signature, which is where forwarded **kwargs land.
+"""
+import ast
+import inspect
+import pathlib
+
+import tornado.httpserver
+
+
+def _httpserver_valid_kwargs() -> set[str]:
+    sig = inspect.signature(tornado.httpserver.HTTPServer.__init__)
+    params = sig.parameters
+    return {
+        name
+        for name, p in params.items()
+        if name != "self" and p.kind
+        not in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        )
+    }
+
+
+def test_backend_listen_kwargs_are_valid():
+    """Verify every app.listen() call in backend.py uses only valid kwargs."""
+    backend_path = pathlib.Path(__file__).parent.parent / "backend.py"
+    source = backend_path.read_text()
+    tree = ast.parse(source, filename=str(backend_path))
+
+    valid_kwargs = _httpserver_valid_kwargs()
+    # 'address' is handled by Application.listen() itself before forwarding
+    valid_kwargs.add("address")
+
+    errors = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "listen"):
+            continue
+        for kw in node.keywords:
+            if kw.arg is None:
+                continue  # **kwargs unpacking — skip
+            if kw.arg not in valid_kwargs:
+                errors.append(
+                    f"backend.py:{node.lineno}: invalid kwarg '{kw.arg}' "
+                    f"passed to .listen() — valid options: {sorted(valid_kwargs)}"
+                )
+
+    assert not errors, "\n".join(errors)

--- a/tests/test_backend_listen.py
+++ b/tests/test_backend_listen.py
@@ -2,55 +2,71 @@
 Regression test for invalid kwargs passed to app.listen() in backend.py.
 
 ffebc909 introduced a typo ('aaddress' instead of 'address') that caused a
-TypeError at startup. This test parses backend.py with the AST and validates
-every .listen() call's keyword arguments against tornado.httpserver.HTTPServer's
-actual __init__ signature, which is where forwarded **kwargs land.
+TypeError at startup. This test actually runs backend.main() — with hardware,
+BLE, networking, and the event loop mocked — but lets app.listen() execute
+for real. Because Application.listen() constructs HTTPServer(**kwargs) before
+touching the socket layer, any invalid kwarg raises TypeError before our
+bind_sockets mock is ever reached.
 """
-import ast
-import inspect
-import pathlib
 
-import tornado.httpserver
-
-
-def _httpserver_valid_kwargs() -> set[str]:
-    sig = inspect.signature(tornado.httpserver.HTTPServer.__init__)
-    params = sig.parameters
-    return {
-        name
-        for name, p in params.items()
-        if name != "self" and p.kind
-        not in (
-            inspect.Parameter.VAR_POSITIONAL,
-            inspect.Parameter.VAR_KEYWORD,
-        )
-    }
+import contextlib
+import sys
+from unittest.mock import MagicMock, patch
 
 
-def test_backend_listen_kwargs_are_valid():
-    """Verify every app.listen() call in backend.py uses only valid kwargs."""
-    backend_path = pathlib.Path(__file__).parent.parent / "backend.py"
-    source = backend_path.read_text()
-    tree = ast.parse(source, filename=str(backend_path))
+_PATCHES = [
+    # Block actual socket binding — but HTTPServer(**kwargs) runs first,
+    # so a bad kwarg raises TypeError before this mock is called.
+    patch("tornado.netutil.bind_sockets", return_value=[]),
+    # Prevent the event loop from blocking indefinitely.
+    patch("tornado.ioloop.IOLoop.current"),
+    # parse_command_line() would try to parse pytest's argv as Tornado flags.
+    patch("backend.parse_command_line"),
+    # Hardware / system dependencies
+    patch("machine.Machine.init"),
+    patch("machine.Machine.emulated", new=False),
+    patch("ble_gatt.GATTServer.getServer", return_value=MagicMock()),
+    patch("wifi.WifiManager.init"),
+    patch("wifi.WifiManager.networking_available", return_value=False),
+    patch("notifications.NotificationManager.init"),
+    patch("profiles.ProfileManager.init"),
+    patch("sounds.SoundPlayer.init"),
+    patch("timezone_manager.TimezoneManager.init"),
+    patch("telemetry_service.TelemetryService.init"),
+    patch("config.MeticulousConfig.setSIO"),
+    patch("imager.DiscImager.flash_if_required"),
+    patch("dbus_monitor.DBusMonitor.init"),
+    patch("dbus_monitor.DBusMonitor.enableUSBTest"),
+    patch("hostname.HostnameManager.init"),
+    patch("ota.UpdateManager.init"),
+    patch("ota.UpdateManager.getRepositoryInfo", return_value={}),
+    patch("ota.UpdateManager.getBuildTimestamp", return_value=""),
+    patch("ota.UpdateManager.getImageChannel", return_value=""),
+    patch("ota.UpdateManager.getImageVersion", return_value=""),
+    patch("ssh_manager.SSHManager.init"),
+    patch("system_services.SystemServices.init"),
+    patch("usb.USBManager.init"),
+    patch("api.alarms.AlarmManager.init"),
+    # Prevent the stdin-reading background thread from starting.
+    patch("backend.NamedThread"),
+    patch("pyprctl.set_name"),
+]
 
-    valid_kwargs = _httpserver_valid_kwargs()
-    # 'address' is handled by Application.listen() itself before forwarding
-    valid_kwargs.add("address")
 
-    errors = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if not (isinstance(func, ast.Attribute) and func.attr == "listen"):
-            continue
-        for kw in node.keywords:
-            if kw.arg is None:
-                continue  # **kwargs unpacking — skip
-            if kw.arg not in valid_kwargs:
-                errors.append(
-                    f"backend.py:{node.lineno}: invalid kwarg '{kw.arg}' "
-                    f"passed to .listen() — valid options: {sorted(valid_kwargs)}"
-                )
+def test_main_starts_without_error():
+    """backend.main() must reach and survive app.listen() with no TypeError.
 
-    assert not errors, "\n".join(errors)
+    Any invalid kwarg (e.g. 'aaddress' instead of 'address') raises TypeError
+    inside HTTPServer.__init__() before the socket mock is reached, so this
+    test catches the regression by actually executing the startup path.
+    """
+    # Remove cached module so module-level code re-runs under our patches.
+    sys.modules.pop("backend", None)
+
+    with contextlib.ExitStack() as stack:
+        for p in _PATCHES:
+            stack.enter_context(p)
+
+        import backend
+
+        backend.main()


### PR DESCRIPTION
## Summary

- Adds a mock-based startup test (\`tests/test_backend_listen.py\`) that actually calls \`backend.main()\` with all hardware and blocking I/O mocked at the socket layer, but lets \`app.listen()\` execute for real
- Adds \`mypy\` to the dev dependency group and CI lint job for broader static type safety
- Motivated by commit ffebc909 (\`fix: direct access to the backend through port 8080\`) which introduced a typo — \`aaddress='127.0.0.1'\` instead of \`address='127.0.0.1'\` — that caused a \`TypeError\` at startup and broke the nightly build loaded on 2026-06-27

## How the test works

\`Application.listen()\` constructs \`HTTPServer(**kwargs)\` before touching the socket layer. Any invalid kwarg raises \`TypeError\` inside \`HTTPServer.__init__()\` before \`bind_sockets\` is ever called. So the test:

1. Mocks \`tornado.netutil.bind_sockets\` (prevents actual port binding) and \`IOLoop.current().start()\` (prevents blocking)
2. Mocks all hardware subsystems: \`Machine\`, BLE (\`GATTServer\`), WiFi, DBus, SSH, USB, etc.
3. Calls \`backend.main()\` for real — including \`app.listen()\`

If the \`aaddress\` typo were present, the test would fail with:
\`\`\`
TypeError: HTTPServer.__init__() got an unexpected keyword argument 'aaddress'
\`\`\`

This approach is more robust than AST-based source parsing because it survives refactoring — the protection holds regardless of whether \`listen()\` is called directly or through a helper function.

## Why mypy alone isn't enough

\`Application.listen()\` is typed as \`(port, address="", **kwargs: Any)\`. Unknown kwargs like \`aaddress\` are silently absorbed into \`**kwargs: Any\` and forwarded to \`HTTPServer()\`, where they raise \`TypeError\` at runtime. Static type checkers cannot trace through \`**kwargs: Any\`.

## Test plan

- [ ] \`uv run pytest tests/test_backend_listen.py -v\` passes on current code
- [ ] CI lint job runs \`mypy .\` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)