### PR TITLE
Add smoke validation state endpoint

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -51,6 +51,7 @@ class API:
         from . import machine as _machine  # noqa
         from . import serial as _serial  # noqa
         from . import password_handler as _password_handler  # noqa
+        from . import smoke_validation as _smoke_validation  # noqa
 
         routes = []
         logger.info("API Routes registered:")

--- a/api/smoke_validation.py
+++ b/api/smoke_validation.py
@@ -1,0 +1,21 @@
+from .api import API, APIVersion
+from .base_handler import LocalAccessHandler
+from log import MeticulousLogger
+from smoke_validation import SmokeValidationManager
+
+logger = MeticulousLogger.getLogger(__name__)
+
+
+class SmokeValidationHandler(LocalAccessHandler):
+    async def get(self):
+        from machine import Machine
+
+        try:
+            self.write(SmokeValidationManager.get_status(Machine))
+        except Exception as exc:
+            logger.warning("Failed to build smoke validation status", exc_info=exc)
+            self.set_status(500)
+            self.write({"status": "error", "error": str(exc)})
+
+
+API.register_handler(APIVersion.V1, r"/smoke-validation", SmokeValidationHandler)

--- a/machine.py
+++ b/machine.py
@@ -47,6 +47,7 @@ from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
 from shot_debug_manager import ShotDebugManager
 from shot_manager import ShotManager
+from smoke_validation import SmokeValidationManager
 from sounds import SoundPlayer, Sounds
 from api.alarms import AlarmManager, AlarmType
 from images.notificationImages.base64 import WARNING_TRIANGLE_IMAGE
@@ -480,6 +481,7 @@ class Machine:
                                     logger.error(
                                         f"ESP error: {full_message}"
                                     )  # Sends the error to the backend project in sentry
+                            SmokeValidationManager.observe_esp_log(message)
                             items_filtered = None
                             if len(log_data) > 2:
                                 get_log_items(log_data=log_data)
@@ -603,6 +605,7 @@ class Machine:
                         )
 
                     old_status = Machine.data_sensors.status
+                    SmokeValidationManager.observe_status(old_status, time_flag)
                     Machine.infoReady = True
 
                 if sensor is not None:

--- a/smoke_validation.py
+++ b/smoke_validation.py
@@ -1,0 +1,196 @@
+import json
+import os
+import shutil
+import subprocess
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from config import CONFIG_PATH
+from esp_serial.data import MachineStatus
+from log import MeticulousLogger
+
+logger = MeticulousLogger.getLogger(__name__)
+
+DEFAULT_STATE_FILE = Path(CONFIG_PATH).joinpath("smoke-validation.json")
+STATE_FILE = Path(os.getenv("SMOKE_VALIDATION_STATE_FILE", DEFAULT_STATE_FILE))
+VERSION_FILE = Path(os.getenv("SMOKE_VALIDATION_VERSION_FILE", "/opt/image-build-version"))
+PUBLISH_SERVICE = "meticulous-smoke-report.service"
+PUBLISH_COMMAND = "/usr/local/bin/meticulous-smoke-report"
+
+
+class SmokeValidationManager:
+    _lock = threading.Lock()
+    _shot_sequence = {
+        "active": False,
+        "saw_heating": False,
+        "saw_extraction": False,
+        "saw_retracting": False,
+        "saw_purge": False,
+    }
+
+    @staticmethod
+    def _now():
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _current_version():
+        try:
+            version = VERSION_FILE.read_text(encoding="utf-8").strip()
+            return version or "unknown"
+        except FileNotFoundError:
+            return "unknown"
+        except Exception as exc:
+            logger.warning(f"Failed to read image version for smoke validation: {exc}")
+            return "unknown"
+
+    @classmethod
+    def _default_state(cls):
+        version = cls._current_version()
+        return {
+            "image_version": version,
+            "post_update_shot_completed": False,
+            "post_update_shot_completed_at": None,
+            "post_update_shot_completed_version": None,
+        }
+
+    @classmethod
+    def _read_state(cls):
+        try:
+            state = json.loads(STATE_FILE.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            state = cls._default_state()
+        except Exception as exc:
+            logger.warning(f"Failed to read smoke validation state: {exc}")
+            state = cls._default_state()
+
+        current_version = cls._current_version()
+        if state.get("image_version") != current_version:
+            state = {
+                **state,
+                "image_version": current_version,
+                "post_update_shot_completed": False,
+                "post_update_shot_completed_at": None,
+                "post_update_shot_completed_version": None,
+            }
+            cls._write_state(state)
+        return state
+
+    @staticmethod
+    def _write_state(state):
+        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = STATE_FILE.with_suffix(".tmp")
+        temp_path.write_text(
+            json.dumps(state, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temp_path.replace(STATE_FILE)
+
+    @classmethod
+    def get_state(cls):
+        with cls._lock:
+            return cls._read_state()
+
+    @classmethod
+    def get_status(cls, machine):
+        state = cls.get_state()
+        machine_status = getattr(machine, "data_sensors", None)
+        esp_info = getattr(machine, "esp_info", None)
+
+        return {
+            "backend_initialized": True,
+            "esp32_responding": bool(getattr(machine, "infoReady", False) and esp_info),
+            "machine_state": getattr(machine_status, "state", None),
+            "machine_status": getattr(machine_status, "status", None),
+            "firmware_version": getattr(esp_info, "firmwareV", None),
+            "image_version": state["image_version"],
+            "post_update_shot_completed": state["post_update_shot_completed"],
+            "post_update_shot_completed_at": state["post_update_shot_completed_at"],
+            "post_update_shot_completed_version": state["post_update_shot_completed_version"],
+        }
+
+    @classmethod
+    def observe_status(cls, status, extracting):
+        if status == MachineStatus.HEATING:
+            cls._shot_sequence = {
+                "active": True,
+                "saw_heating": True,
+                "saw_extraction": False,
+                "saw_retracting": False,
+                "saw_purge": False,
+            }
+            return
+
+        if not cls._shot_sequence["active"]:
+            return
+
+        if extracting:
+            cls._shot_sequence["saw_extraction"] = True
+        if status == MachineStatus.RETRACTING:
+            cls._shot_sequence["saw_retracting"] = True
+        if status == MachineStatus.PURGE:
+            cls._shot_sequence["saw_purge"] = True
+        if status == MachineStatus.IDLE:
+            cls._shot_sequence = {key: False for key in cls._shot_sequence}
+
+    @classmethod
+    def observe_esp_log(cls, message):
+        if message != "coffee profile finished. Heater will be kept on until timeout.":
+            return
+
+        sequence = cls._shot_sequence.copy()
+        cls._shot_sequence = {key: False for key in cls._shot_sequence}
+        if all(
+            sequence.get(key)
+            for key in ("saw_heating", "saw_extraction", "saw_retracting", "saw_purge")
+        ):
+            cls.mark_post_update_shot_completed()
+        else:
+            logger.info(f"Shot smoke validation sequence incomplete: {sequence}")
+
+    @classmethod
+    def mark_post_update_shot_completed(cls):
+        with cls._lock:
+            state = cls._read_state()
+            current_version = cls._current_version()
+            if (
+                state.get("post_update_shot_completed") is True
+                and state.get("post_update_shot_completed_version") == current_version
+            ):
+                return False
+
+            state["image_version"] = current_version
+            state["post_update_shot_completed"] = True
+            state["post_update_shot_completed_at"] = cls._now()
+            state["post_update_shot_completed_version"] = current_version
+            cls._write_state(state)
+
+        logger.info(f"Post-update shot smoke validation completed for {current_version}")
+        cls.request_publish()
+        return True
+
+    @staticmethod
+    def request_publish():
+        if os.path.exists(PUBLISH_COMMAND):
+            try:
+                subprocess.Popen(
+                    [PUBLISH_COMMAND, "--shot"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to request Hawkbit shot smoke validation publish: {exc}"
+                )
+            return
+
+        if shutil.which("systemctl") is None:
+            return
+        try:
+            subprocess.Popen(
+                ["systemctl", "start", PUBLISH_SERVICE],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception as exc:
+            logger.warning(f"Failed to request Hawkbit smoke validation publish: {exc}")

--- a/smoke_validation.py
+++ b/smoke_validation.py
@@ -124,12 +124,21 @@ class SmokeValidationManager:
         if not cls._shot_sequence["active"]:
             return
 
-        if extracting:
+        is_extraction_stage = extracting and status not in (
+            MachineStatus.HEATING,
+            MachineStatus.RETRACTING,
+            MachineStatus.PURGE,
+        )
+
+        if is_extraction_stage:
             cls._shot_sequence["saw_extraction"] = True
-        if status == MachineStatus.RETRACTING:
+
+        if status == MachineStatus.RETRACTING and cls._shot_sequence["saw_extraction"]:
             cls._shot_sequence["saw_retracting"] = True
-        if status == MachineStatus.PURGE:
+
+        if status == MachineStatus.PURGE and cls._shot_sequence["saw_retracting"]:
             cls._shot_sequence["saw_purge"] = True
+
         if status == MachineStatus.IDLE:
             cls._shot_sequence = {key: False for key in cls._shot_sequence}
 

--- a/tests/test_smoke_validation.py
+++ b/tests/test_smoke_validation.py
@@ -1,0 +1,61 @@
+import smoke_validation as sv
+from smoke_validation import SmokeValidationManager
+
+FINAL_COFFEE_LOG = "coffee profile finished. Heater will be kept on until timeout."
+
+
+def configure_state(monkeypatch, tmp_path):
+    state_file = tmp_path / "smoke-validation.json"
+    version_file = tmp_path / "image-build-version"
+    version_file.write_text("2026M1234-nightly\n", encoding="utf-8")
+    monkeypatch.setattr(sv, "STATE_FILE", state_file)
+    monkeypatch.setattr(sv, "VERSION_FILE", version_file)
+    monkeypatch.setattr(sv, "PUBLISH_COMMAND", str(tmp_path / "missing-publisher"))
+    monkeypatch.setattr(sv.shutil, "which", lambda _: None)
+    SmokeValidationManager._shot_sequence = {
+        "active": False,
+        "saw_heating": False,
+        "saw_extraction": False,
+        "saw_retracting": False,
+        "saw_purge": False,
+    }
+    return version_file
+
+
+def test_post_update_shot_state_resets_when_image_version_changes(monkeypatch, tmp_path):
+    version_file = configure_state(monkeypatch, tmp_path)
+
+    assert SmokeValidationManager.mark_post_update_shot_completed() is True
+    state = SmokeValidationManager.get_state()
+    assert state["post_update_shot_completed"] is True
+    assert state["post_update_shot_completed_version"] == "2026M1234-nightly"
+
+    version_file.write_text("2026M1235-nightly\n", encoding="utf-8")
+    state = SmokeValidationManager.get_state()
+    assert state["image_version"] == "2026M1235-nightly"
+    assert state["post_update_shot_completed"] is False
+    assert state["post_update_shot_completed_at"] is None
+    assert state["post_update_shot_completed_version"] is None
+
+
+def test_final_coffee_log_marks_completed_after_full_sequence(monkeypatch, tmp_path):
+    configure_state(monkeypatch, tmp_path)
+
+    SmokeValidationManager.observe_status("heating", extracting=False)
+    SmokeValidationManager.observe_status("Preinfusion", extracting=True)
+    SmokeValidationManager.observe_status("retracting", extracting=True)
+    SmokeValidationManager.observe_status("purge", extracting=False)
+    SmokeValidationManager.observe_esp_log(FINAL_COFFEE_LOG)
+
+    assert SmokeValidationManager.get_state()["post_update_shot_completed"] is True
+
+
+def test_final_coffee_log_does_not_mark_completed_without_purge(monkeypatch, tmp_path):
+    configure_state(monkeypatch, tmp_path)
+
+    SmokeValidationManager.observe_status("heating", extracting=False)
+    SmokeValidationManager.observe_status("Preinfusion", extracting=True)
+    SmokeValidationManager.observe_status("retracting", extracting=True)
+    SmokeValidationManager.observe_esp_log(FINAL_COFFEE_LOG)
+
+    assert SmokeValidationManager.get_state()["post_update_shot_completed"] is False

--- a/tests/test_smoke_validation.py
+++ b/tests/test_smoke_validation.py
@@ -50,6 +50,20 @@ def test_final_coffee_log_marks_completed_after_full_sequence(monkeypatch, tmp_p
     assert SmokeValidationManager.get_state()["post_update_shot_completed"] is True
 
 
+def test_final_coffee_log_allows_pre_extraction_retracting_and_purge(monkeypatch, tmp_path):
+    configure_state(monkeypatch, tmp_path)
+
+    SmokeValidationManager.observe_status("heating", extracting=False)
+    SmokeValidationManager.observe_status("retracting", extracting=True)
+    SmokeValidationManager.observe_status("purge", extracting=False)
+    SmokeValidationManager.observe_status("Preinfusion", extracting=True)
+    SmokeValidationManager.observe_status("retracting", extracting=True)
+    SmokeValidationManager.observe_status("purge", extracting=False)
+    SmokeValidationManager.observe_esp_log(FINAL_COFFEE_LOG)
+
+    assert SmokeValidationManager.get_state()["post_update_shot_completed"] is True
+
+
 def test_final_coffee_log_does_not_mark_completed_without_purge(monkeypatch, tmp_path):
     configure_state(monkeypatch, tmp_path)
 

--- a/tests/test_smoke_validation.py
+++ b/tests/test_smoke_validation.py
@@ -59,3 +59,15 @@ def test_final_coffee_log_does_not_mark_completed_without_purge(monkeypatch, tmp
     SmokeValidationManager.observe_esp_log(FINAL_COFFEE_LOG)
 
     assert SmokeValidationManager.get_state()["post_update_shot_completed"] is False
+
+
+def test_final_coffee_log_requires_ordered_retracting_and_purge(monkeypatch, tmp_path):
+    configure_state(monkeypatch, tmp_path)
+
+    SmokeValidationManager.observe_status("heating", extracting=False)
+    SmokeValidationManager.observe_status("purge", extracting=False)
+    SmokeValidationManager.observe_status("retracting", extracting=True)
+    SmokeValidationManager.observe_status("Preinfusion", extracting=True)
+    SmokeValidationManager.observe_esp_log(FINAL_COFFEE_LOG)
+
+    assert SmokeValidationManager.get_state()["post_update_shot_completed"] is False


### PR DESCRIPTION
## Summary
- Add a local smoke validation endpoint hosted by `meticulous-backend.service` at `/api/v1/smoke-validation`.
- Track persistent post-update shot completion state per image version, resetting automatically when `/opt/image-build-version` changes or when user config is factory-reset.
- Mark the post-update shot condition only after the backend observes the ordered coffee lifecycle: heating, extraction/stages, post-extraction retracting, post-extraction purge, and the final coffee-profile-finished firmware log.

## High-level conditions
- `backend_initialized` means the backend process has initialized far enough to serve the local Tornado API endpoint.
- `esp32_responding` means the backend has received and parsed an `ESPInfo` message from the ESP32, so serial communication and firmware info response are working.
- `post_update_shot_completed` means this installed image version has completed at least one full coffee-shot lifecycle after update. The backend requires the sequence in order: heating starts the candidate shot, an extraction/stage status must occur, `retracting` only counts after extraction, `purge` only counts after that post-extraction retracting, and the firmware completion log must arrive after those states. Cleanup states before extraction, such as an initial piston retract or purge, are allowed and ignored for completion.

## Related PRs
- Dial home readiness: https://github.com/MeticulousHome/meticulous-dial/pull/555
- Hawkbit attribute publisher: https://github.com/MeticulousHome/meticulous-machine/pull/78

## Validation
- `uv run pytest tests/test_smoke_validation.py`
- `python3 -m py_compile smoke_validation.py api/smoke_validation.py machine.py tests/test_smoke_validation.py`
- `git diff --check`
