### PR TITLE
Start backend API before Wi-Fi init

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -120,6 +120,7 @@ def calibrate(sid, data=True):
 
 
 send_data_thread = None
+wifi_init_thread = None
 
 
 async def live():
@@ -177,6 +178,14 @@ def send_data_loop():
 
     loop.run_until_complete(send_data())
     loop.close()
+
+
+def start_wifi_manager_in_background():
+    global wifi_init_thread
+
+    logger.info("Starting Wi-Fi initialization in background")
+    wifi_init_thread = NamedThread("WifiInit", target=WifiManager.init)
+    wifi_init_thread.start()
 
 
 async def send_data():  # noqa: C901
@@ -302,7 +311,9 @@ def main():
 
     GATTServer.getServer().start()
 
-    WifiManager.init()
+    if Machine.emulated:
+        WifiManager.init()
+
     NotificationManager.init(sio)
     ProfileManager.init(sio)
     SoundPlayer.init(emulation=Machine.emulated)
@@ -330,6 +341,8 @@ def main():
     )
 
     app.listen(PORT)
+    if not Machine.emulated:
+        start_wifi_manager_in_background()
 
     sio.start_background_task(live)
 


### PR DESCRIPTION
## Summary
- Move real-machine Wi-Fi initialization out of the backend startup critical path.
- Keep emulation Wi-Fi initialization synchronous so the existing emulation route decision still works.
- Start Wi-Fi in a background thread only after Tornado is listening, so local API/profile endpoints can come up even if NetworkManager/hotspot startup is slow or stuck.

## High-level behavior
For the dial to leave the pulsing white dot, the backend must finish initializing the local services that do not depend on the network, register the API routes, and call `app.listen(PORT)`. Previously, `WifiManager.init()` could block before profile routes were registered; a weak or failing Wi-Fi path could therefore leave the dial waiting on `/api/v1/profile/list` even though the machine had otherwise booted.

With this change, machine boot no longer waits for Wi-Fi before exposing the local backend API. Wi-Fi may still be initializing or recovering in the background, but the dial can load profiles and reach the home screen once the non-network backend path is ready.

## Validation
- `python3 -m py_compile backend.py`
- `git diff --check`

## Notes
- This targets the suspected white-dot startup path from the dial-delay investigation, especially cases where `WifiManager.init()` starts hotspot recovery and blocks before API route registration.
- Hardware validation is still needed on a machine with weak/unstable Wi-Fi to confirm the dial reaches home while Wi-Fi recovery continues.