### PR TITLE
Prevent Wi-Fi repair from disabling Bluetooth provisioning

### DIFF
--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -122,6 +122,7 @@ class GATTServer:
 
     MIN_BOOT_TIME = 60
     MACHINE_IDENT_UUID = "7f01d7b8-121e-11ef-a097-b3b1396fea81"
+    ADVERTISEMENT_UPDATE_RETRY_DELAYS = (1, 3, 8)
 
     _singletonServer = None
 
@@ -261,6 +262,56 @@ class GATTServer:
             logger.exception("Connection check failed", exc_info=e, stack_info=True)
             return False
 
+    @staticmethod
+    def _advertisement_is_missing(error: Exception) -> bool:
+        message = str(error).lower()
+        return "does not exist" in message or "unknown object" in message
+
+    async def _replace_ble_advertisement(self):
+        app = self.bless_gatt_server.app
+        iface = self.bless_gatt_server.adapter.get_interface("org.bluez.LEAdvertisingManager1")
+
+        advertisement = app.advertisements.pop() if app.advertisements else None
+        if advertisement is not None:
+            try:
+                await iface.call_unregister_advertisement(advertisement.path)
+            except Exception as error:
+                if self._advertisement_is_missing(error):
+                    logger.warning("Previous BLE advertisement no longer exists; rebuilding it")
+                else:
+                    app.advertisements.append(advertisement)
+                    raise
+
+            try:
+                self.bless_gatt_server.bus.unexport(advertisement.path, advertisement)
+            except Exception as error:
+                logger.warning(f"Could not unexport previous BLE advertisement: {error}")
+
+        new_advertisement = BlueZLEAdvertisement(Type.PERIPHERAL, 0, app)
+        new_advertisement._manufacturer_data = {
+            0xFFFF: Variant("ay", self.manufacturer_data),
+        }
+
+        exported = False
+        try:
+            self.bless_gatt_server.bus.export(new_advertisement.path, new_advertisement)
+            exported = True
+            await iface.call_register_advertisement(new_advertisement.path, {})
+        except Exception:
+            if exported:
+                try:
+                    self.bless_gatt_server.bus.unexport(
+                        new_advertisement.path, new_advertisement
+                    )
+                except Exception as cleanup_error:
+                    logger.warning(
+                        "Could not clean up failed BLE advertisement: "
+                        f"{cleanup_error}"
+                    )
+            raise
+
+        app.advertisements.append(new_advertisement)
+
     async def _update_data_loop(self):
         self.update_trigger.clear()
         while True:
@@ -270,27 +321,32 @@ class GATTServer:
                 logger.info("BLE GATT Server not initialized yet")
                 continue
 
-            logger.info(f"Updating BLE anouncment: {self.manufacturer_data}")
-            # self.manufacturer_data = b"000000000000000000000000000"
+            logger.info(f"Updating BLE announcement: {self.manufacturer_data}")
+            retry_delays = self.ADVERTISEMENT_UPDATE_RETRY_DELAYS
+            total_attempts = len(retry_delays) + 1
 
-            advertisement = self.bless_gatt_server.app.advertisements.pop()
-            iface = self.bless_gatt_server.adapter.get_interface(
-                "org.bluez.LEAdvertisingManager1"
-            )
-            newAdvertisement = BlueZLEAdvertisement(
-                Type.PERIPHERAL, 0, self.bless_gatt_server.app
-            )
+            for attempt in range(total_attempts):
+                try:
+                    await self._replace_ble_advertisement()
+                    break
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    if attempt == total_attempts - 1:
+                        logger.exception(
+                            "BLE advertisement update failed after retries; "
+                            "GATT server remains running",
+                            exc_info=error,
+                            stack_info=True,
+                        )
+                        break
 
-            await iface.call_unregister_advertisement(advertisement.path)  # type: ignore
-            self.bless_gatt_server.bus.unexport(advertisement.path, advertisement)
-
-            newAdvertisement._manufacturer_data = {
-                0xFFFF: Variant("ay", self.manufacturer_data),
-            }
-            self.bless_gatt_server.app.advertisements.append(newAdvertisement)
-
-            self.bless_gatt_server.bus.export(newAdvertisement.path, newAdvertisement)
-            await iface.call_register_advertisement(newAdvertisement.path, {})
+                    delay = retry_delays[attempt]
+                    logger.warning(
+                        "BLE advertisement update failed; retrying in "
+                        f"{delay}s ({attempt + 1}/{total_attempts}): {error}"
+                    )
+                    await asyncio.sleep(delay)
 
     async def _ble_gatt_server_loop(self):  # noqa: C901
         # FIXME remove once migrated away from the variscite-wifi.service towards

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -3,10 +3,11 @@
 These tests mock out WifiManager so they can run without system dependencies.
 """
 
+import asyncio
 import sys
 from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv6Address
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -33,8 +34,6 @@ class FakeNetworkConfig:
 _mocked_modules = {
     "bless": MagicMock(),
     "bless.backends.bluezdbus.dbus.advertisement": MagicMock(),
-    "dbus_next": MagicMock(),
-    "dbus_next.errors": MagicMock(),
     "psutil": MagicMock(),
     "config": MagicMock(),
     "hostname": MagicMock(),
@@ -65,18 +64,34 @@ _mocked_modules["bless"].GATTCharacteristicProperties.write = 4
 _mocked_modules["bless"].GATTCharacteristicProperties.write_without_response = 8
 
 
+_MISSING_MODULE = object()
+_original_modules = {}
+
+
+def _install_mock(mod_name, mock):
+    if mod_name not in _original_modules:
+        _original_modules[mod_name] = sys.modules.get(mod_name, _MISSING_MODULE)
+    sys.modules[mod_name] = mock
+
+
 def _setup_mocks():
     """Patch sys.modules so ble_gatt can be imported."""
     for mod_name, mock in _mocked_modules.items():
-        if mod_name not in sys.modules:
-            sys.modules[mod_name] = mock
+        _install_mock(mod_name, mock)
+
+
+def _restore_modules():
+    for mod_name, original in reversed(list(_original_modules.items())):
+        if original is _MISSING_MODULE:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = original
 
 
 _setup_mocks()
 
 # Mock wifi module before import
 wifi_mock = MagicMock()
-sys.modules["wifi"] = wifi_mock
 
 
 # Create the WifiWpaPskCredentials class the code actually uses
@@ -88,9 +103,24 @@ class WifiWpaPskCredentials:
 
 wifi_mock.WifiWpaPskCredentials = WifiWpaPskCredentials
 wifi_mock.WifiManager = MagicMock()
+_install_mock("wifi", wifi_mock)
 
-# Now we can import ble_gatt
-from ble_gatt import GATTServer  # noqa: E402
+# Now we can import ble_gatt. Its production platform guard is intentionally
+# bypassed because this test has already replaced every hardware dependency.
+original_ble_gatt_module = sys.modules.get("ble_gatt", _MISSING_MODULE)
+original_platform = sys.platform
+sys.platform = "linux"
+try:
+    import ble_gatt as ble_gatt_under_test  # noqa: E402
+
+    GATTServer = ble_gatt_under_test.GATTServer
+finally:
+    sys.platform = original_platform
+    _restore_modules()
+    if original_ble_gatt_module is _MISSING_MODULE:
+        sys.modules.pop("ble_gatt", None)
+    else:
+        sys.modules["ble_gatt"] = original_ble_gatt_module
 
 
 # ---------------------------------------------------------------------------
@@ -276,3 +306,84 @@ class TestWifiConnectEdgeCases:
         assert result is not None
         call_args = mock_wifi_manager.connectToWifi.call_args[0][0]
         assert call_args.password == "p@$$w0rd!#%^&*()"
+
+
+# ---------------------------------------------------------------------------
+# BLE advertisement update recovery
+# ---------------------------------------------------------------------------
+class TestAdvertisementUpdateRecovery:
+    def test_transient_registration_failure_does_not_stop_gatt(self, mock_wifi_manager):
+        server = GATTServer()
+        server.ADVERTISEMENT_UPDATE_RETRY_DELAYS = (0,)
+        server.bless_gatt_server = MagicMock()
+        server.bless_gatt_server.app = MagicMock()
+        server._replace_ble_advertisement = AsyncMock(
+            side_effect=[RuntimeError("Failed to register advertisement"), None]
+        )
+        server.stop = MagicMock()
+
+        async def exercise_update_loop():
+            task = asyncio.create_task(server._update_data_loop())
+            await asyncio.sleep(0)
+            server.update_trigger.set()
+
+            for _ in range(20):
+                if server._replace_ble_advertisement.await_count == 2:
+                    break
+                await asyncio.sleep(0)
+
+            assert server._replace_ble_advertisement.await_count == 2
+            assert not task.done()
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        try:
+            asyncio.run(exercise_update_loop())
+            server.stop.assert_not_called()
+        finally:
+            server.loop.close()
+
+    def test_failed_registration_is_cleaned_up_for_retry(self, mock_wifi_manager):
+        server = GATTServer()
+        old_advertisement = MagicMock(path="/advertisement/0")
+        failed_advertisement = MagicMock(path="/advertisement/0")
+        recovered_advertisement = MagicMock(path="/advertisement/0")
+
+        app = MagicMock()
+        app.advertisements = [old_advertisement]
+        iface = MagicMock()
+        iface.call_unregister_advertisement = AsyncMock()
+        iface.call_register_advertisement = AsyncMock(
+            side_effect=[RuntimeError("Failed to register advertisement"), None]
+        )
+        bus = MagicMock()
+
+        server.bless_gatt_server = MagicMock()
+        server.bless_gatt_server.app = app
+        server.bless_gatt_server.adapter.get_interface.return_value = iface
+        server.bless_gatt_server.bus = bus
+
+        async def fail_then_recover():
+            with pytest.raises(RuntimeError, match="Failed to register advertisement"):
+                await server._replace_ble_advertisement()
+
+            assert app.advertisements == []
+            await server._replace_ble_advertisement()
+
+        try:
+            with patch.object(
+                ble_gatt_under_test,
+                "BlueZLEAdvertisement",
+                side_effect=[failed_advertisement, recovered_advertisement],
+            ):
+                asyncio.run(fail_then_recover())
+
+            assert app.advertisements == [recovered_advertisement]
+            iface.call_unregister_advertisement.assert_awaited_once_with(old_advertisement.path)
+            assert iface.call_register_advertisement.await_count == 2
+            bus.unexport.assert_any_call(old_advertisement.path, old_advertisement)
+            bus.unexport.assert_any_call(failed_advertisement.path, failed_advertisement)
+        finally:
+            server.loop.close()

--- a/tests/test_wifi_repair.py
+++ b/tests/test_wifi_repair.py
@@ -1,0 +1,157 @@
+"""Regression tests for Wi-Fi repair safety guards.
+
+The production module has hardware-only dependencies, so these tests load it
+under an isolated module name with small system dependency stubs.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+
+def _module(name: str, **attributes):
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _load_wifi_module(monkeypatch):
+    config_values = {
+        "wifi": {
+            "mode": "client",
+            "ap_name": "Meticulous",
+            "ap_password": "",
+            "known_wifis": {},
+        },
+        "user": {"hostname_override": None},
+    }
+    config_module = _module(
+        "config",
+        CONFIG_WIFI="wifi",
+        CONFIG_USER="user",
+        HOSTNAME_OVERRIDE="hostname_override",
+        WIFI_AP_NAME="ap_name",
+        WIFI_AP_PASSWORD="ap_password",
+        WIFI_KNOWN_WIFIS="known_wifis",
+        WIFI_MODE="mode",
+        WIFI_MODE_AP="ap",
+        WIFI_MODE_CLIENT="client",
+        MeticulousConfig=config_values,
+    )
+
+    api_module = _module("api")
+    api_module.__path__ = []
+    zeroconf_module = _module("api.zeroconf_announcement", ZeroConfAnnouncement=MagicMock)
+    log_module = _module("log", MeticulousLogger=MagicMock())
+    log_module.MeticulousLogger.getLogger.return_value = MagicMock()
+
+    stub_modules = {
+        "api": api_module,
+        "api.zeroconf_announcement": zeroconf_module,
+        "config": config_module,
+        "hostname": _module("hostname", HostnameManager=MagicMock()),
+        "log": log_module,
+        "machine": _module("machine", Machine=MagicMock()),
+        "named_thread": _module("named_thread", NamedThread=MagicMock()),
+        "netaddr": _module("netaddr", IPAddress=MagicMock(), IPNetwork=MagicMock()),
+        "nmcli": MagicMock(),
+        "sentry_sdk": MagicMock(),
+        "timezone_manager": _module("timezone_manager", TimezoneManager=MagicMock()),
+    }
+    for name, module in stub_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_name = "wifi_repair_under_test"
+    module_path = Path(__file__).resolve().parents[1] / "wifi.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _wifi_config(module, *, connected, connection_name):
+    return module.WifiSystemConfig(
+        connected=connected,
+        connection_name=connection_name,
+        gateway=None,
+        routes=[],
+        ips=[],
+        dns=[],
+        mac="",
+        hostname="meticulous",
+        domains=[],
+    )
+
+
+def test_repair_without_saved_client_connection_never_resets_hardware(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    current = _wifi_config(module, connected=False, connection_name=None)
+
+    with (
+        patch.object(manager, "getCurrentConfig", return_value=current),
+        patch.object(manager, "getNetworkManagerWifiConnections", return_value={}),
+        patch.object(manager, "suppressAutoConnect") as suppress_auto_connect,
+        patch.object(manager, "restartActiveConnection") as restart_connection,
+        patch.object(manager, "restartWifiRadio") as restart_radio,
+        patch.object(manager, "driverInBandReset") as reset_driver,
+        patch.object(manager, "restartWifiService") as restart_service,
+    ):
+        result = manager.repairWifiConnection(reason="manual")
+
+    assert result is False
+    assert manager._last_health_error == "no_saved_wifi_connection"
+    assert manager._last_recovery_action == "health_check"
+    assert manager._last_recovery_result == "not_recoverable"
+    suppress_auto_connect.assert_not_called()
+    restart_connection.assert_not_called()
+    restart_radio.assert_not_called()
+    reset_driver.assert_not_called()
+    restart_service.assert_not_called()
+
+
+def test_disconnected_saved_connection_keeps_existing_repair_path(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    current = _wifi_config(module, connected=False, connection_name=None)
+    healthy = MagicMock(degraded=False)
+
+    with (
+        patch.object(manager, "getCurrentConfig", return_value=current),
+        patch.object(
+            manager,
+            "getNetworkManagerWifiConnections",
+            return_value={"Home": {"ssid": "Home"}},
+        ),
+        patch.object(manager, "getHealthStatus", return_value=healthy) as get_health,
+        patch.object(manager, "suppressAutoConnect"),
+        patch.object(manager, "invalidateHealthCache"),
+    ):
+        result = manager.repairWifiConnection(reason="manual")
+
+    assert result is True
+    get_health.assert_called_once_with(current, force=True)
+    assert manager._last_recovery_result == "not_needed"
+
+
+def test_repair_health_check_still_runs_for_active_connection(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    current = _wifi_config(module, connected=True, connection_name="Home")
+    healthy = MagicMock(degraded=False)
+
+    with (
+        patch.object(manager, "getCurrentConfig", return_value=current),
+        patch.object(manager, "getHealthStatus", return_value=healthy) as get_health,
+        patch.object(manager, "suppressAutoConnect"),
+        patch.object(manager, "invalidateHealthCache"),
+    ):
+        result = manager.repairWifiConnection(reason="manual")
+
+    assert result is True
+    get_health.assert_called_once_with(current, force=True)
+    assert manager._last_recovery_result == "not_needed"

--- a/wifi.py
+++ b/wifi.py
@@ -796,6 +796,12 @@ class WifiManager:
                 )
             case "wifi_not_connected":
                 return "The machine is not connected to Wi-Fi."
+            case "no_saved_wifi_connection":
+                return (
+                    "There is no saved Wi-Fi connection to repair. "
+                    "Choose a Wi-Fi network on the machine or connect it from "
+                    "the Meticulous app."
+                )
             case "wifi_device_unavailable":
                 return "Wi-Fi is still starting. Wait a moment and try again."
             case "hotspot_not_active":
@@ -992,11 +998,27 @@ class WifiManager:
             WifiManager._last_recovery_result = "in_progress"
             return False
 
+        current = WifiManager.getCurrentConfig()
+        if (
+            MeticulousConfig[CONFIG_WIFI][WIFI_MODE] != WIFI_MODE_AP
+            and not current.connected
+            and not WifiManager.getNetworkManagerWifiConnections()
+        ):
+            WifiManager._last_recovery_attempt = time.time()
+            WifiManager._last_recovery_action = "health_check"
+            WifiManager._last_recovery_result = "not_recoverable"
+            WifiManager._last_health_error = "no_saved_wifi_connection"
+            WifiManager.invalidateHealthCache()
+            logger.warning(
+                "WiFi repair skipped because there are no saved client connections. "
+                "Refusing to reset the shared WiFi/Bluetooth radio."
+            )
+            return False
+
         WifiManager._repair_in_progress = True
         WifiManager.suppressAutoConnect(180, f"wifi repair in progress: {reason}")
         try:
             WifiManager._last_recovery_attempt = time.time()
-            current = WifiManager.getCurrentConfig()
             logger.warning(f"Starting WiFi repair workflow. reason={reason}")
             WifiManager.invalidateHealthCache()
 


### PR DESCRIPTION
## Incident

Deleting the final saved Wi-Fi network and selecting Wi-Fi repair caused the backend to reset the shared IW612 Wi-Fi/Bluetooth module. BLE advertisement re-registration then failed, terminating the GATT server until a power cycle.

Machine logs showed the sequence:

1. The last Wi-Fi profile was deleted.
2. The repair workflow escalated through radio, driver, and service resets despite there being no saved network to recover.
3. BlueZ returned `Failed to register advertisement`.
4. The unhandled advertisement task exception stopped the BLE GATT server.
5. NetworkManager subsequently reported no Wi-Fi device, and neither transport self-recovered.

Raw logs are intentionally not attached because the current backend logs Wi-Fi credentials in plaintext and in BLE packet hex.

## Changes

- Refuse destructive client-mode repair when the machine is disconnected and has no saved Wi-Fi profiles.
- Return an actionable message directing the user to choose a network or connect from the app.
- Clean up failed BLE advertisement registrations and retry with bounded backoff.
- Keep the GATT server running when advertisement replacement exhausts its retries.
- Add regression coverage for the captured failure and for preservation of existing saved-network repair behavior.
- Isolate BLE test mocks so they do not pollute later test modules.

## Safety boundaries

- No firmware changes.
- No changes to normal Bluetooth provisioning or Wi-Fi join behavior.
- Saved-network and hotspot recovery paths remain unchanged.
- No new automatic service restart or hardware-reset behavior.
- No deployment or machine update is included.

## Validation

- [x] `.venv/bin/pytest tests/test_wifi_repair.py tests/test_ble_gatt_wifi.py -q` — 25 passed
- [x] `.venv/bin/pytest -q --ignore=tests/test_bug_report_api.py` — 125 passed
- [x] Flake8 passed for the changed production and test files, excluding the repository's existing DBus annotation F821 findings
- [x] Python compilation passed for all changed Python files
- [x] `git diff --check` passed

The repository's current `nightly` CI baseline is already red due to pre-existing DBus annotation lint and test-infrastructure/formatting failures. This PR intentionally does not mix broad CI cleanup into the critical connectivity fix.

## Required physical-machine testing

- [ ] Confirm normal startup and an existing Wi-Fi connection.
- [ ] Delete the final saved Wi-Fi network.
- [ ] Select Repair once and confirm it immediately reports that no network is saved.
- [ ] Confirm the Wi-Fi driver/service reset sequence is not invoked.
- [ ] Confirm Bluetooth remains visible and connectable.
- [ ] Provision through the iPhone app.
- [ ] Confirm Wi-Fi handoff, profiles, socket connection, and live telemetry.
- [ ] Exercise Repair with a saved network and verify the existing recovery path is unchanged.
- [ ] Repeat the deletion and provisioning cycle several times.
- [ ] Power-cycle and confirm normal reconnection.

## Rollback

Reinstall the previous nightly backend package/image and power-cycle the test machine.
