### PR TITLE
Redact Wi-Fi credentials and BLE payloads from backend logs

### DIFF
--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -24,6 +24,11 @@ from config import CONFIG_WIFI, WIFI_MODE, WIFI_MODE_AP, MeticulousConfig
 from hostname import HostnameManager
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
+from sensitive_logging import (
+    credential_metadata,
+    exception_metadata,
+    payload_metadata,
+)
 from wifi import WifiManager, WifiWpaPskCredentials
 
 logger = MeticulousLogger.getLogger(__name__)
@@ -527,17 +532,17 @@ class GATTServer:
         try:
             ssid = ssid.decode("utf-8")
         except Exception as e:
-            logger.error(f"Failed to decode SSID: {e}")
+            logger.error(f"Failed to decode SSID ({exception_metadata(e)})")
             return None
 
         try:
             passwd = passwd.decode("utf-8")
         except Exception as e:
-            logger.error(f"Failed to decode password: {e}")
+            logger.error(f"Failed to decode password ({exception_metadata(e)})")
             return None
 
         try:
-            logger.info(f"Connecting to '{ssid}' with password: '{passwd}'")
+            logger.info(f"Connecting to Wi-Fi ({credential_metadata(ssid, passwd)})")
             credentials = WifiWpaPskCredentials(ssid=ssid, password=passwd)
             if WifiManager.connectToWifi(credentials):
                 networkConfig = WifiManager.getCurrentConfig()
@@ -552,8 +557,11 @@ class GATTServer:
                 return localServer
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to WiFi: {e}, ssid={ssid} passwd={passwd}")
-            logger.exception("WiFi connection failed", exc_info=e, stack_info=True)
+            logger.error(
+                "Failed to connect to Wi-Fi "
+                f"({exception_metadata(e)}; {credential_metadata(ssid, passwd)})",
+                stack_info=True,
+            )
             return None
 
     def get_wifi_networks() -> Optional[list[str]]:
@@ -626,7 +634,7 @@ class GATTServer:
             else:
                 GATTServer.getServer().updateAuthentication()
                 value = GATTServer.getServer().improv_server.handle_read(characteristic.uuid)
-            logger.info(f"BLE READ  {char_name} -> {len(value)} bytes: {value.hex()}")
+            logger.info(f"BLE READ  {char_name} -> {payload_metadata(value)}")
             return value
 
         logger.info(f"BLE READ  {char_name} (non-improv)")
@@ -639,7 +647,7 @@ class GATTServer:
         except ValueError:
             pass
 
-        logger.info(f"BLE WRITE {char_name} <- {len(value)} bytes: {value.hex()}")
+        logger.info(f"BLE WRITE {char_name} <- {payload_metadata(value)}")
 
         if characteristic.service_uuid == ImprovUUID.SERVICE_UUID.value:
             (
@@ -653,9 +661,7 @@ class GATTServer:
                 except ValueError:
                     pass
                 for resp_value in target_values:
-                    logger.info(
-                        f"BLE RESP  {target_name} -> {len(resp_value)} bytes: {resp_value.hex()}"
-                    )
+                    logger.info(f"BLE RESP  {target_name} -> {payload_metadata(resp_value)}")
                     GATTServer.getServer().bless_gatt_server.get_characteristic(
                         target_uuid,
                     ).value = resp_value

--- a/sensitive_logging.py
+++ b/sensitive_logging.py
@@ -1,0 +1,30 @@
+"""Helpers for logging connectivity failures without exposing credentials."""
+
+import os
+from collections.abc import Sequence
+
+
+def credential_metadata(ssid: str, password: str) -> str:
+    return (
+        f"ssid_bytes={len(ssid.encode('utf-8'))}, "
+        f"password_bytes={len(password.encode('utf-8'))}"
+    )
+
+
+def payload_metadata(payload) -> str:
+    if isinstance(payload, (list, tuple)):
+        size = sum(len(part) for part in payload)
+    else:
+        size = len(payload)
+    return f"{size} bytes"
+
+
+def exception_metadata(error: BaseException) -> str:
+    return type(error).__name__
+
+
+def command_metadata(command: Sequence[object]) -> str:
+    if not command:
+        return "<empty command>"
+    executable = os.path.basename(str(command[0]))
+    return f"{executable} ({max(0, len(command) - 1)} args)"

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -114,6 +114,7 @@ try:
     import ble_gatt as ble_gatt_under_test  # noqa: E402
 
     GATTServer = ble_gatt_under_test.GATTServer
+    ImprovUUID = ble_gatt_under_test.ImprovUUID
 finally:
     sys.platform = original_platform
     _restore_modules()
@@ -129,6 +130,7 @@ finally:
 @pytest.fixture(autouse=True)
 def reset_singleton():
     """Reset the GATTServer singleton between tests."""
+    mock_logger.reset_mock()
     GATTServer._singletonServer = None
     yield
     GATTServer._singletonServer = None
@@ -387,3 +389,56 @@ class TestAdvertisementUpdateRecovery:
             bus.unexport.assert_any_call(failed_advertisement.path, failed_advertisement)
         finally:
             server.loop.close()
+class TestCredentialLogRedaction:
+    @staticmethod
+    def logged_output():
+        return repr(mock_logger.method_calls)
+
+    def test_wifi_connect_does_not_log_ssid_or_password(self, mock_wifi_manager):
+        ssid = "SENTINEL-PRIVATE-NETWORK"
+        password = "SENTINEL-SECRET-PASSWORD"
+
+        result = GATTServer.wifi_connect(
+            bytearray(ssid.encode("utf-8")),
+            bytearray(password.encode("utf-8")),
+        )
+
+        assert result is not None
+        logged = self.logged_output()
+        assert ssid not in logged
+        assert password not in logged
+        assert "ssid_bytes=" in logged
+        assert "password_bytes=" in logged
+
+    def test_wifi_connect_exception_does_not_log_exception_credentials(
+        self, mock_wifi_manager
+    ):
+        password = "SENTINEL-EXCEPTION-SECRET"
+        mock_wifi_manager.connectToWifi.side_effect = RuntimeError(
+            f"NetworkManager rejected {password}"
+        )
+
+        result = GATTServer.wifi_connect(
+            bytearray(b"PrivateNetwork"), bytearray(password.encode("utf-8"))
+        )
+
+        assert result is None
+        logged = self.logged_output()
+        assert password not in logged
+        assert "RuntimeError" in logged
+
+    def test_ble_write_does_not_log_raw_payload(self, mock_wifi_manager):
+        server = GATTServer.getServer()
+        server.improv_server = MagicMock()
+        server.improv_server.handle_write.return_value = (None, None)
+        characteristic = MagicMock()
+        characteristic.service_uuid = ImprovUUID.SERVICE_UUID.value
+        characteristic.uuid = ImprovUUID.RPC_COMMAND_UUID.value
+        payload = bytearray(b"SENTINEL-RAW-BLE-CREDENTIAL-PACKET")
+
+        GATTServer.write_request(characteristic, payload)
+
+        logged = self.logged_output()
+        assert payload.decode() not in logged
+        assert payload.hex() not in logged
+        assert f"{len(payload)} bytes" in logged

--- a/tests/test_sensitive_logging.py
+++ b/tests/test_sensitive_logging.py
@@ -1,0 +1,55 @@
+from sensitive_logging import (
+    command_metadata,
+    credential_metadata,
+    exception_metadata,
+    payload_metadata,
+)
+
+
+def test_credential_metadata_never_contains_unicode_credentials():
+    ssid = "Private-网络"
+    password = "SENTINEL-密码-pässword"
+
+    metadata = credential_metadata(ssid, password)
+
+    assert ssid not in metadata
+    assert password not in metadata
+    assert metadata == "ssid_bytes=14, password_bytes=25"
+
+
+def test_payload_metadata_never_contains_raw_packet_bytes():
+    payload = bytearray(b"SENTINEL-RAW-BLE-CREDENTIAL-PACKET")
+
+    metadata = payload_metadata(payload)
+
+    assert payload.decode() not in metadata
+    assert payload.hex() not in metadata
+    assert metadata == f"{len(payload)} bytes"
+
+
+def test_command_metadata_never_contains_psk_arguments():
+    password = "SENTINEL-WIFI-PSK"
+    command = [
+        "nmcli",
+        "connection",
+        "modify",
+        "private-network",
+        "802-11-wireless-security.psk",
+        password,
+    ]
+
+    metadata = command_metadata(command)
+
+    assert password not in metadata
+    assert "private-network" not in metadata
+    assert metadata == "nmcli (5 args)"
+
+
+def test_exception_metadata_never_contains_exception_message():
+    password = "SENTINEL-EXCEPTION-PASSWORD"
+    error = RuntimeError(f"connection failed with password {password}")
+
+    metadata = exception_metadata(error)
+
+    assert password not in metadata
+    assert metadata == "RuntimeError"

--- a/wifi.py
+++ b/wifi.py
@@ -33,6 +33,7 @@ from machine import Machine
 
 from log import MeticulousLogger
 from named_thread import NamedThread
+from sensitive_logging import command_metadata, exception_metadata
 
 logger = MeticulousLogger.getLogger(__name__)
 
@@ -707,7 +708,9 @@ class WifiManager:
                 timeout=timeout,
             )
         except Exception as e:
-            logger.warning(f"Failed to run command {command}: {e}")
+            logger.warning(
+                f"Failed to run {command_metadata(command)} ({exception_metadata(e)})"
+            )
             return None
 
     def gatewayReachable(gateway: IPAddress):


### PR DESCRIPTION
## Summary

Prevent Wi-Fi credentials and raw Bluetooth provisioning payloads from being written to backend logs or Sentry logging breadcrumbs.

- Replace plaintext SSID/password logging with UTF-8 byte counts.
- Remove hexadecimal BLE read, write, and response payload dumps.
- Avoid logging exception messages from the credential-bearing connection path.
- Avoid logging failed subprocess command arguments, which can contain NetworkManager PSKs.
- Preserve useful operation names, payload sizes, argument counts, stack locations, and exception types.

## Root cause

The BLE Improv connection callback logged decoded SSIDs and passwords directly. The generic BLE handlers also logged complete packet payloads as hexadecimal, including `SEND_WIFI_SETTINGS` credential packets. In addition, subprocess failures could log an entire `nmcli` argument list containing a PSK.

These logs are included in downloadable machine archives and can also become logging breadcrumbs, so credential material must never be emitted.

## Safety

This change does not alter BLE parsing, Wi-Fi connection behavior, NetworkManager commands, retry timing, radio state, or API responses. It changes logging output only.

Regression tests use sentinel Unicode passwords, exception messages containing credentials, raw BLE credential payloads, and PSKs embedded in command arguments. They verify that only non-sensitive metadata remains.

## Validation

- Focused credential/BLE suite: 27 passed.
- Full backend suite: 142 passed; the same 2 pre-existing macOS-only bug-report tests fail because Linux `pyprctl` is unavailable and the test database is not initialized.
- Targeted `flake8`: passed, with the repository's existing DBus annotation `F821` exception.
- `black --check` for new files: passed.
- `py_compile`: passed.
- `git diff --check`: passed.
- Source scan confirms the raw `.hex()` payload logs and plaintext password formats are gone.

## Related work

This PR is intentionally independent of #364. Both touch `ble_gatt.py` and its tests, so whichever lands second should be rebased, but neither behavior depends on the other.
