### PR TITLE
Add structured radio recovery diagnostics

### DIFF
--- a/radio_diagnostics.py
+++ b/radio_diagnostics.py
@@ -1,0 +1,76 @@
+"""Structured, credential-free diagnostics for shared radio recovery."""
+
+import json
+
+_SAFE_CODES = {
+    "already_in_progress",
+    "ap",
+    "apply_ap_mode",
+    "client",
+    "completed",
+    "dns_unreachable",
+    "driver_in_band_reset",
+    "failed",
+    "gateway_unreachable",
+    "health_assessed",
+    "healthy",
+    "hotspot_not_active",
+    "hotspot_start_failed",
+    "hotspot_stop_failed",
+    "internet_unreachable",
+    "manual",
+    "missing_ipv4",
+    "networking_unavailable",
+    "not_needed",
+    "not_recoverable",
+    "recovered",
+    "rejected",
+    "restart_connection",
+    "restart_wifi_radio",
+    "restart_wifi_service",
+    "started",
+    "start_hotspot",
+    "step_assessed",
+    "step_exception",
+    "step_started",
+    "wifi_device_unavailable",
+    "wifi_not_connected",
+}
+
+
+def safe_code(value) -> str:
+    candidate = str(value or "unknown").split(":", 1)[0].strip().lower()
+    return candidate if candidate in _SAFE_CODES else "other"
+
+
+def emit_radio_recovery_event(
+    logger,
+    event: str,
+    *,
+    operation_id: str,
+    elapsed_ms: int,
+    reason=None,
+    mode=None,
+    connected=None,
+    has_ipv4=None,
+    action=None,
+    result=None,
+    error=None,
+):
+    payload = {
+        "schema_version": 1,
+        "event": safe_code(event),
+        "operation_id": operation_id,
+        "elapsed_ms": max(0, int(elapsed_ms)),
+    }
+    optional = {
+        "reason": safe_code(reason) if reason is not None else None,
+        "mode": safe_code(mode) if mode is not None else None,
+        "connected": bool(connected) if connected is not None else None,
+        "has_ipv4": bool(has_ipv4) if has_ipv4 is not None else None,
+        "action": safe_code(action) if action is not None else None,
+        "result": safe_code(result) if result is not None else None,
+        "error_type": type(error).__name__ if error is not None else None,
+    }
+    payload.update({key: value for key, value in optional.items() if value is not None})
+    logger.info(f"RADIO_RECOVERY {json.dumps(payload, sort_keys=True)}")

--- a/tests/test_radio_diagnostics.py
+++ b/tests/test_radio_diagnostics.py
@@ -1,0 +1,46 @@
+import json
+from unittest.mock import MagicMock
+
+from radio_diagnostics import emit_radio_recovery_event, safe_code
+
+
+def test_safe_code_rejects_network_names_and_credentials():
+    assert safe_code("gateway_unreachable") == "gateway_unreachable"
+    assert safe_code("hotspot_start_failed: details") == "hotspot_start_failed"
+    assert safe_code("Private SSID / secret-password") == "other"
+
+
+def test_radio_event_contains_only_bounded_structured_metadata():
+    logger = MagicMock()
+    secret = "SENTINEL-PRIVATE-NETWORK-PASSWORD"
+
+    emit_radio_recovery_event(
+        logger,
+        "step_exception",
+        operation_id="abc123",
+        elapsed_ms=1250,
+        reason=secret,
+        mode="client",
+        connected=True,
+        has_ipv4=False,
+        action="restart_wifi_radio",
+        error=RuntimeError(secret),
+    )
+
+    message = logger.info.call_args.args[0]
+    assert secret not in message
+    prefix, encoded = message.split(" ", 1)
+    payload = json.loads(encoded)
+    assert prefix == "RADIO_RECOVERY"
+    assert payload == {
+        "action": "restart_wifi_radio",
+        "connected": True,
+        "elapsed_ms": 1250,
+        "error_type": "RuntimeError",
+        "event": "step_exception",
+        "has_ipv4": False,
+        "mode": "client",
+        "operation_id": "abc123",
+        "reason": "other",
+        "schema_version": 1,
+    }

--- a/wifi.py
+++ b/wifi.py
@@ -6,6 +6,7 @@ import subprocess
 import threading
 import time
 import urllib.request
+import uuid
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Literal
@@ -34,6 +35,7 @@ from machine import Machine
 from log import MeticulousLogger
 from named_thread import NamedThread
 from sensitive_logging import command_metadata, exception_metadata
+from radio_diagnostics import emit_radio_recovery_event
 
 logger = MeticulousLogger.getLogger(__name__)
 
@@ -991,14 +993,30 @@ class WifiManager:
         return WifiManager.repairWifiConnection(reason=health.last_error)
 
     def repairWifiConnection(reason: str = "manual"):
+        operation_id = uuid.uuid4().hex[:12]
+        started_at = time.monotonic()
+
+        def record(event, **data):
+            emit_radio_recovery_event(
+                logger,
+                event,
+                operation_id=operation_id,
+                elapsed_ms=int((time.monotonic() - started_at) * 1000),
+                reason=reason,
+                mode=MeticulousConfig[CONFIG_WIFI][WIFI_MODE],
+                **data,
+            )
+
         if not WifiManager._networking_available:
             WifiManager._last_recovery_result = "failed"
             WifiManager._last_health_error = "networking_unavailable"
+            record("rejected", result="networking_unavailable")
             return False
 
         if WifiManager._repair_in_progress:
             logger.warning("WiFi repair requested while another repair is in progress")
             WifiManager._last_recovery_result = "in_progress"
+            record("rejected", result="already_in_progress")
             return False
 
         current = WifiManager.getCurrentConfig()
@@ -1024,11 +1042,23 @@ class WifiManager:
             WifiManager._last_recovery_attempt = time.time()
             logger.warning(f"Starting WiFi repair workflow. reason={reason}")
             WifiManager.invalidateHealthCache()
+            record(
+                "started",
+                connected=current.connected,
+                has_ipv4=any(ip.ip.version == 4 for ip in current.ips),
+            )
 
             initial_health = WifiManager.getHealthStatus(current, force=True)
+            record(
+                "health_assessed",
+                connected=initial_health.connected,
+                has_ipv4=initial_health.has_ipv4,
+                result=initial_health.last_error or "healthy",
+            )
             if not initial_health.degraded:
                 WifiManager._last_recovery_action = "health_check"
                 WifiManager._last_recovery_result = "not_needed"
+                record("completed", result="not_needed")
                 return True
 
             if not WifiManager.healthErrorIsRecoverable(initial_health.last_error):
@@ -1038,6 +1068,7 @@ class WifiManager:
                 logger.warning(
                     f"WiFi repair skipped for non-recoverable health issue: {initial_health.last_error}"
                 )
+                record("completed", result="not_recoverable")
                 return False
 
             if MeticulousConfig[CONFIG_WIFI][WIFI_MODE] == WIFI_MODE_AP:
@@ -1058,6 +1089,7 @@ class WifiManager:
             for action, step in steps:
                 WifiManager._last_recovery_action = action
                 WifiManager._last_recovery_result = "in_progress"
+                record("step_started", action=action)
                 try:
                     step()
                     if (
@@ -1067,9 +1099,17 @@ class WifiManager:
                         WifiManager.startHotspot()
                 except Exception as e:
                     logger.warning(f"WiFi repair step failed: {action}: {e}")
+                    record("step_exception", action=action, error=e)
 
                 time.sleep(5)
                 health = WifiManager.getHealthStatus(force=True)
+                record(
+                    "step_assessed",
+                    action=action,
+                    connected=health.connected,
+                    has_ipv4=health.has_ipv4,
+                    result=health.last_error or "healthy",
+                )
                 if not health.degraded:
                     logger.warning(f"WiFi repair succeeded with {action}")
                     WifiManager._health_failures = 0
@@ -1077,6 +1117,7 @@ class WifiManager:
                     WifiManager._last_recovery_result = "recovered"
                     WifiManager._zeroconf.restart()
                     WifiManager.update_gatt_advertisement()
+                    record("completed", action=action, result="recovered")
                     return True
 
                 if not WifiManager.healthErrorIsRecoverable(health.last_error):
@@ -1085,6 +1126,7 @@ class WifiManager:
                     logger.warning(
                         f"Stopping WiFi repair after {action}; issue is not recoverable by driver reset: {health.last_error}"
                     )
+                    record("completed", action=action, result="not_recoverable")
                     return False
 
             WifiManager._last_recovery_result = "failed"
@@ -1092,6 +1134,7 @@ class WifiManager:
                 force=True
             ).last_error
             WifiManager.update_gatt_advertisement()
+            record("completed", result="failed")
             return False
         finally:
             WifiManager._repair_in_progress = False


### PR DESCRIPTION
## Summary

Add structured, credential-free diagnostics around the existing Wi-Fi recovery workflow without changing recovery behavior.

Each recovery receives an operation ID and emits `RADIO_RECOVERY` JSON events for:

- rejected requests
- initial connection/IPv4 health
- each escalation step starting
- step exceptions by exception type
- health after each step
- the final recovery outcome

## Why

The current logs show that recovery happened, but they are difficult to correlate across concurrent requests and do not consistently identify which step changed radio health. Before changing critical IW612 reset behavior, real-machine tests need a reliable before/after trace that distinguishes connection restart, Wi-Fi radio toggle, driver reset, and service restart.

## Safety

This PR does not add or remove recovery steps, change their order, alter timing, change health classification, perform additional NetworkManager calls, or modify the BLE service.

Only a fixed allowlist of event/reason/action/result codes can be logged. SSIDs, IP addresses, command output, exception messages, and credentials are excluded. Unknown values become `other`.

## Validation

- Diagnostic schema/privacy tests: 2 passed.
- Backend tests excluding the repository's pre-existing bug-report and BLE test-isolation failures: 102 passed.
- Targeted `flake8`: passed.
- `black --check` for new files: passed.
- `py_compile`: passed.
- `git diff --check`: passed.

The default `nightly` branch is already red in GitHub Actions because of pre-existing DBus annotation lint errors and a bug-report database test failure; this PR does not change those areas.

## Real-machine test use

After deployment, retain the `RADIO_RECOVERY` lines while testing weak signal, blocked gateway ping, IPv6-only or delayed IPv4, intentional disconnect, repeated Repair presses, and router reboot. The operation ID makes it possible to verify whether a benign network condition escalated into an IW612 driver or service reset.
