### PR TITLE
Cap automatic timezone fetch retries on stable

### DIFF
--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -27,6 +27,8 @@ class TimezoneManager:
 
     __system_timezone: str = ""
     __system_synced: bool = False
+    __timezone_fetch_attempts: int = 0
+    _MAX_TIMEZONE_FETCH_ATTEMPTS: int = 5
 
     @staticmethod
     def init():
@@ -249,10 +251,17 @@ class TimezoneManager:
     def tz_background_update():
         tz_config = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
         if tz_config == "automatic" and not TimezoneManager.__system_synced:
+            if TimezoneManager.__timezone_fetch_attempts >= TimezoneManager._MAX_TIMEZONE_FETCH_ATTEMPTS:
+                return
+            TimezoneManager.__timezone_fetch_attempts += 1
             try:
                 logger.info("Timezone is set to automatic, fetching timezone in the background")
                 loop = asyncio.get_event_loop()
                 loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+                # Clear the attempt counter on a successful request so that, if
+                # __system_synced is ever reset, an unstable network gets a fresh
+                # batch of attempts instead of inheriting an exhausted counter.
+                TimezoneManager.__timezone_fetch_attempts = 0
             except Exception as e:
                 logger.error(f"Error while fetching timezone in the background: {e}")
 


### PR DESCRIPTION
## What changed

- Backports the timezone retry limit from commit `93788000fbc1dd023c419888955fb1be8d8de646` to `stable`.
- Caps automatic timezone fetch retries at five attempts per boot.
- Resets the retry counter after a successful timezone request.

## Why

Prevents an unstable or unavailable network from causing unbounded automatic timezone fetch attempts on the stable channel.

## Validation

- `timezone_manager.py` passes Python bytecode compilation (`python -m py_compile timezone_manager.py`).
- The cherry-pick applied cleanly against `origin/stable`.
- Automated tests were not run locally because `uv` and `pytest` are unavailable in this environment.

## Source

Cherry-picked merge commit `93788000fbc1dd023c419888955fb1be8d8de646` with parent 1 as the mainline.
