### PR TITLE
Remove Fluent Bit service controls

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -11,7 +11,6 @@ from config import (
     TIME_ZONE,
     AUTOMATIC_TIMEZONE_SYNC,
     SSH_ENABLED,
-    TELEMETRY_SERVICE_ENABLED,
     PROFILE_ORDER,
     PROFILE_AUTO_PURGE,
     PROFILE_PARTIAL_RETRACTION,
@@ -19,7 +18,6 @@ from config import (
 
 from heater_actuator import HeaterActuator
 from ssh_manager import SSHManager
-from system_services import SystemServices
 from profiles import ProfileManager
 
 from .base_handler import BaseHandler
@@ -135,29 +133,6 @@ class SettingsHandler(BaseHandler):
                             {
                                 "status": "error",
                                 "setting": SSH_ENABLED,
-                                "details": "Internal server error",
-                            }
-                        )
-
-                # Handle Telemetry Service (fluent-bit) settings
-                if setting_target == TELEMETRY_SERVICE_ENABLED:
-                    try:
-                        if not SystemServices.set_service_state("fluent-bit.service", value):
-                            self.set_status(500)
-                            self.write(
-                                {
-                                    "status": "error",
-                                    "setting": TELEMETRY_SERVICE_ENABLED,
-                                    "details": "Failed to update fluent-bit service state",
-                                }
-                            )
-                    except Exception as e:
-                        logger.error(f"Error managing fluent-bit service: {e}")
-                        self.set_status(500)
-                        self.write(
-                            {
-                                "status": "error",
-                                "setting": TELEMETRY_SERVICE_ENABLED,
                                 "details": "Internal server error",
                             }
                         )

--- a/config.py
+++ b/config.py
@@ -99,10 +99,6 @@ SOUNDS_DEFAULT_THEME = "default"
 SSH_ENABLED = "ssh_enabled"
 SSH_DEFAULT_ENABLED = True
 
-# Telemetry Service (fluent-bit) configuration
-TELEMETRY_SERVICE_ENABLED = "telemetry_service_enabled"
-TELEMETRY_SERVICE_DEFAULT_ENABLED = True
-
 # Firmware pinning
 DISALLOW_FIRMWARE_FLASHING = "disallow_firmware_flashing"
 DISALLOW_FIRMWARE_FLASHING_DEFAULT = False
@@ -241,7 +237,6 @@ DefaultConfiguration_V1 = {
         TIME_ZONE: DEFAULT_TIME_ZONE,
         MACHINE_DEBUG_SENDING: MACHINE_DEBUG_SENDING_DEFAULT,
         SSH_ENABLED: SSH_DEFAULT_ENABLED,
-        TELEMETRY_SERVICE_ENABLED: TELEMETRY_SERVICE_DEFAULT_ENABLED,
         PROFILE_ORDER: PROFILE_ORDER_DEFAULT,
         HOSTNAME_OVERRIDE: HOSTNAME_OVERRIDE_DEFAULT,
         CLOCK_FORMAT_24_HOUR: CLOCK_FORMAT_24_HOUR_DEFAULT,
@@ -332,6 +327,8 @@ class MeticulousConfigDict(dict):
                     if disk_version is not None and disk_version > self["version"]:
                         _config_logger.warning("Config on disk is newer than this software")
                     merge(self, disk_config)
+                    # Remove the retired remote telemetry setting from existing configs.
+                    self[CONFIG_USER].pop("telemetry_service_enabled", None)
                     # migrate partial_retraction config data from int to float
                     retraction = self[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     if isinstance(retraction, int):

--- a/system_services.py
+++ b/system_services.py
@@ -1,12 +1,7 @@
 from pydbus import SystemBus
 
 from machine import Machine
-from config import (
-    MeticulousConfig,
-    CONFIG_USER,
-    SSH_ENABLED,
-    TELEMETRY_SERVICE_ENABLED,
-)
+from config import MeticulousConfig, CONFIG_USER, SSH_ENABLED
 
 from log import MeticulousLogger
 
@@ -52,9 +47,3 @@ class SystemServices:
         ssh_enabled = MeticulousConfig[CONFIG_USER].get(SSH_ENABLED, True)
         logger.info(f"Syncing ssh.service state: {'enabled' if ssh_enabled else 'disabled'}")
         SystemServices.set_service_state("ssh.service", ssh_enabled)
-
-        telemetry_enabled = MeticulousConfig[CONFIG_USER].get(TELEMETRY_SERVICE_ENABLED, True)
-        logger.info(
-            f"Syncing fluent-bit.service state: {'enabled' if telemetry_enabled else 'disabled'}"
-        )
-        SystemServices.set_service_state("fluent-bit.service", telemetry_enabled)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+import copy
+
+import yaml
+
+from config import CONFIG_USER, DefaultConfiguration_V1, MeticulousConfigDict
+
+
+def test_load_removes_retired_telemetry_setting(tmp_path):
+    config_path = tmp_path / "config.yml"
+    disk_config = copy.deepcopy(DefaultConfiguration_V1)
+    disk_config[CONFIG_USER]["telemetry_service_enabled"] = True
+    config_path.write_text(yaml.safe_dump(disk_config), encoding="utf-8")
+
+    config = MeticulousConfigDict(config_path, copy.deepcopy(DefaultConfiguration_V1))
+
+    assert "telemetry_service_enabled" not in config[CONFIG_USER]
+    persisted_config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert "telemetry_service_enabled" not in persisted_config[CONFIG_USER]


### PR DESCRIPTION
## Summary
- Remove the Fluent Bit setting from the machine user configuration and settings API.
- Stop synchronizing `fluent-bit.service` during backend startup.
- Remove the retired `telemetry_service_enabled` key from existing persisted configurations.
- Coordinate with the machine-image and Dial changes that retire Fluent Bit.

Companion PRs:
- https://github.com/MeticulousHome/meticulous-machine/pull/92
- https://github.com/MeticulousHome/meticulous-dial/pull/560

This prevents the backend from re-enabling the retired device log and metrics forwarding service. It does not change the backend's separate Sentry SDK integration or crash reporting.

## Validation
- `.venv/Scripts/python.exe -m pytest tests/test_config.py`
- `.venv/Scripts/python.exe -m black --check config.py system_services.py api/settings.py tests/test_config.py`
- `python -m py_compile config.py system_services.py api/settings.py tests/test_config.py`
- `git diff --check`
- Full GitHub Actions remains red on pre-existing `stable` failures unrelated to this change: `ble_gatt.py` has four F821 errors, and `tests/test_ble_gatt_wifi.py` mocks `dbus_next` as a non-package before importing `dbus_next.aio`. The current `stable` commit fails with the same messages.