### PR TITLE
Minimize automatic Sentry event data

### DIFF
--- a/back.py
+++ b/back.py
@@ -3,21 +3,10 @@ from sentry_sdk.integrations.asyncio import AsyncioIntegration
 
 import os
 
+from sentry_privacy import drop_breadcrumb, sanitize_sentry_event
+
 BACKEND = os.getenv("BACKEND", "FIKA").upper()
 SENTRY = os.getenv("SENTRY", "False").lower() in ("true", "1", "y")
-
-
-SHSentryClient = None
-
-
-def before_breadcrumb(crumb, hint):
-    # Dont log subprocess breadcrumbs
-    if crumb["type"] == "subprocess":
-        # If we wanted to allow certain threads we could do it like this:
-        # thread_name = crumb.get("data", {}).get("thread.name", None) -> e.g. MainThread or WifiAutoConnect
-        # thread_name = crumb.get("message", None) -> e.g. 'nmcli device show wlan0'
-        return None
-    return crumb
 
 
 def is_tornado_session_disconnected(event):
@@ -36,33 +25,18 @@ def is_tornado_session_disconnected(event):
     return False
 
 
-# hook the SHSentryClient to the global client
 def before_send(event, hint):
     if is_tornado_session_disconnected(event):
         return None
-    if SHSentryClient is not None:
-        SHSentryClient.capture_event(event=event)
-    return event
+    return sanitize_sentry_event(event, hint)
 
 
 if BACKEND == "FIKA" or SENTRY:
     print("Initializing sentry")
 
-    # mimic the behavior of the global client
-    SHSentryClient = sentry_sdk.Client(
-        dsn="https://66287e18e4d9bb8437bd9b0a963bb882@sentry.meticulousespresso.com/3",
-        # before_breadcrumb=before_breadcrumb,
-    )
-
-    # main sentry instance
     sentry_sdk.init(
-        dsn="https://0b7872daf08aae52a8d654472bc8bb26@o4506723336060928.ingest.us.sentry.io/4507635208224768",
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
+        dsn="https://66287e18e4d9bb8437bd9b0a963bb882@sentry.meticulousespresso.com/3",
         traces_sample_rate=0.0,
-        # Set profiles_sample_rate to 1.0 to profile 100%
-        # of sampled transactions.
-        # We recommend adjusting this value in production.
         profiles_sample_rate=0.0,
         integrations=[
             AsyncioIntegration(),
@@ -70,7 +44,10 @@ if BACKEND == "FIKA" or SENTRY:
         ignore_errors=[
             KeyboardInterrupt,
         ],
-        before_breadcrumb=before_breadcrumb,
+        send_default_pii=False,
+        include_local_variables=False,
+        max_breadcrumbs=0,
+        before_breadcrumb=drop_breadcrumb,
         before_send=before_send,
     )
 

--- a/back.py
+++ b/back.py
@@ -35,7 +35,7 @@ if BACKEND == "FIKA" or SENTRY:
     print("Initializing sentry")
 
     sentry_sdk.init(
-        dsn="https://66287e18e4d9bb8437bd9b0a963bb882@sentry.meticulousespresso.com/3",
+        dsn="https://39a03a6899dcf043dc520bc93d9e966c@sentry.meticulousespresso.com/3",
         traces_sample_rate=0.0,
         profiles_sample_rate=0.0,
         integrations=[

--- a/backend.py
+++ b/backend.py
@@ -22,7 +22,6 @@ from hostname import HostnameManager
 from config import (
     MeticulousConfig,
     CONFIG_SYSTEM,
-    DEVICE_IDENTIFIER,
     MACHINE_SERIAL_NUMBER,
     CONFIG_LOGGING,
     LOGGING_SENSOR_MESSAGES,
@@ -280,9 +279,6 @@ def main():
         sentry_sdk.set_tag("build-channel", UpdateManager.getImageChannel())
         sentry_sdk.set_tag("build-version", UpdateManager.getImageVersion())
 
-        sentry_sdk.set_tag(
-            "machine", "".join(MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER])
-        )
         sentry_sdk.set_tag("serial", MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER])
     except Exception as e:
         logger.error(f"Failed to set sentry context: {e}")

--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -471,13 +471,13 @@ class GATTServer:
         try:
             ssid = ssid.decode("utf-8")
         except Exception as e:
-            logger.error(f"Failed to decode SSID: {e}")
+            logger.error(f"Failed to decode SSID ({type(e).__name__})")
             return None
 
         try:
             passwd = passwd.decode("utf-8")
         except Exception as e:
-            logger.error(f"Failed to decode password: {e}")
+            logger.error(f"Failed to decode password ({type(e).__name__})")
             return None
 
         try:
@@ -496,8 +496,7 @@ class GATTServer:
                 return localServer
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to WiFi: {e}, ssid={ssid} passwd={passwd}")
-            logger.exception("WiFi connection failed", exc_info=e, stack_info=True)
+            logger.error(f"WiFi connection failed ({type(e).__name__})")
             return None
 
     def get_wifi_networks() -> Optional[list[str]]:

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ import copy
 from mergedeep import merge
 
 from log import MeticulousLogger
+from reportable_config import get_reportable_config
 
 from manufacturing import CONFIG_MANUFACTURING, Default_manufacturing_config
 
@@ -301,7 +302,7 @@ class MeticulousConfigDict(dict):
         for line in cs.split("\n"):
             _config_logger.debug(f"CONF: {line}")
 
-        sentry_sdk.set_context("config", self.copy())
+        sentry_sdk.set_context("config", get_reportable_config(self))
 
     # FIXME: Remove once the socket IO server lives in its own file
     def setSIO(self, sio):
@@ -346,7 +347,7 @@ class MeticulousConfigDict(dict):
                 self.save()
 
     def save(self):
-        sentry_sdk.set_context("config", self.copy())
+        sentry_sdk.set_context("config", get_reportable_config(self))
 
         Path(self.__path).parent.mkdir(parents=True, exist_ok=True)
         with open(self.__path, "w") as f:

--- a/hostname.py
+++ b/hostname.py
@@ -59,7 +59,7 @@ class HostnameManager:
             subprocess.run(["systemctl", "restart", "rauc-hawkbit-updater"])
             logger.info("Restarted rauc-hawkbit-updater")
         except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to set hostname: {e}")
+            logger.error(f"Failed to set hostname ({type(e).__name__})")
 
     ADJECTIVES = [
         "aromatic",

--- a/machine.py
+++ b/machine.py
@@ -59,7 +59,7 @@ from sentry_privacy import drop_breadcrumb, sanitize_esp_data, sanitize_sentry_e
 from manufacturing import FORCE_MANUFACTURING_ENABLED_KEY, LAST_BOOT_MODE_KEY
 
 ESPSentryClient = sentry_sdk.Client(
-    dsn="https://ae0d66689e4445a4af7de61ab576d17c@sentry.meticulousespresso.com/6",
+    dsn="https://57bd3ab95e32eda7af5fca189527c235@sentry.meticulousespresso.com/6",
     traces_sample_rate=0.0,
     # Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.

--- a/machine.py
+++ b/machine.py
@@ -53,6 +53,7 @@ from images.notificationImages.base64 import WARNING_TRIANGLE_IMAGE
 import math
 
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
+from sentry_privacy import drop_breadcrumb, sanitize_esp_data, sanitize_sentry_event
 
 
 from manufacturing import FORCE_MANUFACTURING_ENABLED_KEY, LAST_BOOT_MODE_KEY
@@ -67,6 +68,11 @@ ESPSentryClient = sentry_sdk.Client(
     integrations=[
         AsyncioIntegration(),
     ],
+    send_default_pii=False,
+    include_local_variables=False,
+    max_breadcrumbs=0,
+    before_breadcrumb=drop_breadcrumb,
+    before_send=sanitize_sentry_event,
 )
 
 
@@ -478,7 +484,7 @@ class Machine:
                                     logger.warning(full_message)
                                 case "error":
                                     logger.error(
-                                        f"ESP error: {full_message}"
+                                        f"ESP error: {message}"
                                     )  # Sends the error to the backend project in sentry
                             items_filtered = None
                             if len(log_data) > 2:
@@ -493,19 +499,17 @@ class Machine:
                             if send_to_sentry:
                                 with sentry_sdk.new_scope() as scope:
                                     if items_filtered is not None:
-                                        scope.set_context("esp-data", items_filtered)
-                                    scope.set_client(ESPSentryClient)
-                                    if log_level == "error":
-                                        logger.error(full_message)
-                                    else:
-                                        scope.capture_message(
-                                            message=message,
-                                            level=log_level,
+                                        scope.set_context(
+                                            "esp-data", sanitize_esp_data(items_filtered)
                                         )
+                                    scope.set_client(ESPSentryClient)
+                                    scope.capture_message(
+                                        message=message,
+                                        level=log_level,
+                                    )
                         except Exception as e:
                             logger.error(
-                                f"Error '{e}' processing Log from ESP: 'Log,{','.join(log_data)}'",
-                                exc_info=True,
+                                f"Error processing ESP log ({type(e).__name__})",
                             )
                     case [*_]:
                         logger.info(data_str.strip("\r\n"))

--- a/machine.py
+++ b/machine.py
@@ -500,11 +500,24 @@ class Machine:
                                 with sentry_sdk.new_scope() as scope:
                                     if items_filtered is not None:
                                         scope.set_context("esp-data", items_filtered)
+                                    firmware_version = None
+                                    if (
+                                        Machine.esp_info is not None
+                                        and Machine.firmware_running is not None
+                                    ):
+                                        firmware_version = Machine.esp_info.firmwareV.strip()
+                                        if firmware_version:
+                                            scope.set_tag("firmware-version", firmware_version)
                                     scope.set_client(ESPSentryClient)
-                                    scope.capture_message(
-                                        message=message,
-                                        level=log_level,
-                                    )
+                                    event = {
+                                        "message": message,
+                                        "level": log_level,
+                                    }
+                                    if firmware_version:
+                                        event["release"] = (
+                                            f"espresso-firmware@{firmware_version}"
+                                        )
+                                    scope.capture_event(event)
                         except Exception as e:
                             logger.error(
                                 f"Error processing ESP log ({type(e).__name__})",

--- a/machine.py
+++ b/machine.py
@@ -53,7 +53,7 @@ from images.notificationImages.base64 import WARNING_TRIANGLE_IMAGE
 import math
 
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
-from sentry_privacy import drop_breadcrumb, sanitize_esp_data, sanitize_sentry_event
+from sentry_privacy import drop_breadcrumb, sanitize_sentry_event
 
 
 from manufacturing import FORCE_MANUFACTURING_ENABLED_KEY, LAST_BOOT_MODE_KEY
@@ -499,9 +499,7 @@ class Machine:
                             if send_to_sentry:
                                 with sentry_sdk.new_scope() as scope:
                                     if items_filtered is not None:
-                                        scope.set_context(
-                                            "esp-data", sanitize_esp_data(items_filtered)
-                                        )
+                                        scope.set_context("esp-data", items_filtered)
                                     scope.set_client(ESPSentryClient)
                                     scope.capture_message(
                                         message=message,

--- a/reportable_config.py
+++ b/reportable_config.py
@@ -1,0 +1,102 @@
+"""Build privacy-reviewed configuration payloads for diagnostic reporting."""
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any, Callable
+
+
+Validator = Callable[[Any], bool]
+
+
+def _is_bool(value: Any) -> bool:
+    return isinstance(value, bool)
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_string(value: Any) -> bool:
+    return isinstance(value, str)
+
+
+def _is_list(value: Any) -> bool:
+    return isinstance(value, list)
+
+
+_APPROVED_PATHS: tuple[tuple[tuple[str, ...], Validator], ...] = (
+    (("version",), _is_int),
+    (("logging", "log_all_sensor_messages"), _is_bool),
+    (("system", "notifications_ttl"), _is_int),
+    (("system", "serial"), _is_string),
+    (("system", "batch_number"), _is_string),
+    (("system", "build_date"), _is_string),
+    (("system", "color"), _is_string),
+    (("system", "last_system_versions"), _is_list),
+    (("user", "enable_sounds"), _is_bool),
+    (("user", "disallow_firmware_flashing"), _is_bool),
+    (("user", "debug_shot_data_retention_days"), _is_int),
+    (("user", "auto_start_shot"), _is_bool),
+    (("user", "auto_purge_after_shot"), _is_bool),
+    (("user", "partial_retraction"), _is_number),
+    (("user", "heat_on_boot"), _is_bool),
+    (("user", "heating_timeout"), _is_number),
+    (("user", "update_channel"), _is_string),
+    (("user", "idle_screen"), _is_string),
+    (("user", "reverse_scrolling", "home"), _is_bool),
+    (("user", "reverse_scrolling", "keyboard"), _is_bool),
+    (("user", "reverse_scrolling", "menus"), _is_bool),
+    (("user", "clock_format_24_hour"), _is_bool),
+    (("user", "allow_legacy_json"), _is_bool),
+    (("user", "allow_stage_skipping"), _is_bool),
+    (("user", "usb_mode"), _is_string),
+    (("user", "timezone_sync"), _is_string),
+    (("user", "ssh_enabled"), _is_bool),
+    (("wifi", "mode"), _is_string),
+    (("manufacturing", "enabled"), _is_bool),
+    (("manufacturing", "last_boot_mode"), _is_string),
+    (("manufacturing", "skip_stage"), _is_bool),
+)
+
+
+def _read_path(config: Mapping[str, Any], path: tuple[str, ...]) -> tuple[bool, Any]:
+    current: Any = config
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            return False, None
+        current = current[part]
+    return True, current
+
+
+def _write_path(output: dict[str, Any], path: tuple[str, ...], value: Any) -> None:
+    current = output
+    for part in path[:-1]:
+        current = current.setdefault(part, {})
+    current[path[-1]] = deepcopy(value)
+
+
+def get_reportable_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a new mapping containing only approved, type-valid config values."""
+
+    if not isinstance(config, Mapping):
+        return {}
+
+    output: dict[str, Any] = {}
+    for path, validator in _APPROVED_PATHS:
+        found, value = _read_path(config, path)
+        if found and validator(value):
+            _write_path(output, path, value)
+
+    found, sounds_theme = _read_path(config, ("system", "sounds_theme"))
+    if found and isinstance(sounds_theme, str):
+        _write_path(
+            output,
+            ("system", "sounds_theme"),
+            "default" if sounds_theme == "default" else "custom",
+        )
+
+    return output

--- a/sentry_privacy.py
+++ b/sentry_privacy.py
@@ -2,34 +2,10 @@
 
 from collections.abc import Mapping
 from copy import deepcopy
-import re
 from typing import Any
 
 from reportable_config import get_reportable_config
 
-
-ESP_DATA_KEYS = {
-    "temperature",
-    "status",
-    "value_in_curve",
-    "ref_id",
-    "time_series_index",
-    "context",
-    "control_type",
-    "reason",
-    "requested",
-    "applied",
-    "stage_name",
-    "weight",
-    "threshold",
-    "retract_name",
-    "requested_delta_mm",
-    "start_position",
-    "target_position",
-    "current_position",
-    "piston_speed",
-    "stall_timeout_ms",
-}
 
 _SENSITIVE_KEY_PARTS = {
     "password",
@@ -55,8 +31,6 @@ _SENSITIVE_KEY_PARTS = {
     "email",
     "username",
 }
-_TECHNICAL_VALUE = re.compile(r"^[A-Za-z0-9_.:+\- ]{1,128}$")
-_CONTROL_CHARACTER = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def drop_breadcrumb(crumb: dict[str, Any], hint: dict[str, Any]) -> None:
@@ -91,35 +65,6 @@ def _scrub_structured(value: Any) -> Any:
     if isinstance(value, tuple):
         return tuple(_scrub_structured(item) for item in value)
     return value
-
-
-def _bounded_stage_name(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    sanitized = _CONTROL_CHARACTER.sub("", value).strip()
-    if not sanitized:
-        return None
-    return sanitized[:128]
-
-
-def sanitize_esp_data(data: Any) -> dict[str, str]:
-    """Keep only reviewed UART diagnostic fields and safe scalar values."""
-
-    if not isinstance(data, Mapping):
-        return {}
-
-    output: dict[str, str] = {}
-    for key, value in data.items():
-        if key not in ESP_DATA_KEYS or not isinstance(value, str):
-            continue
-        if key == "stage_name":
-            stage_name = _bounded_stage_name(value)
-            if stage_name is not None:
-                output[key] = stage_name
-            continue
-        if _TECHNICAL_VALUE.fullmatch(value):
-            output[key] = value
-    return output
 
 
 def _remove_frame_variables(event: dict[str, Any]) -> None:
@@ -169,7 +114,9 @@ def sanitize_sentry_event(event: dict[str, Any], hint: Any = None) -> dict[str, 
             clean_contexts["config"] = get_reportable_config(raw_config)
         raw_esp_data = contexts.get("esp-data")
         if raw_esp_data is not None:
-            clean_contexts["esp-data"] = sanitize_esp_data(raw_esp_data)
+            # ESP diagnostics are firmware-controlled hardware data. Preserve
+            # every field so new diagnostics do not require a backend update.
+            clean_contexts["esp-data"] = deepcopy(raw_esp_data)
         sanitized["contexts"] = clean_contexts
 
     if "extra" in sanitized:

--- a/sentry_privacy.py
+++ b/sentry_privacy.py
@@ -1,0 +1,179 @@
+"""Privacy controls shared by automatic backend and ESP Sentry events."""
+
+from collections.abc import Mapping
+from copy import deepcopy
+import re
+from typing import Any
+
+from reportable_config import get_reportable_config
+
+
+ESP_DATA_KEYS = {
+    "temperature",
+    "status",
+    "value_in_curve",
+    "ref_id",
+    "time_series_index",
+    "context",
+    "control_type",
+    "reason",
+    "requested",
+    "applied",
+    "stage_name",
+    "weight",
+    "threshold",
+    "retract_name",
+    "requested_delta_mm",
+    "start_position",
+    "target_position",
+    "current_position",
+    "piston_speed",
+    "stall_timeout_ms",
+}
+
+_SENSITIVE_KEY_PARTS = {
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "credential",
+    "authorization",
+    "cookie",
+    "api_key",
+    "auth_key",
+    "root_password",
+    "ssid",
+    "apname",
+    "knownwifis",
+    "ip",
+    "ip_address",
+    "ipaddress",
+    "client_ip",
+    "remote_addr",
+    "hostname",
+    "machine_name",
+    "email",
+    "username",
+}
+_TECHNICAL_VALUE = re.compile(r"^[A-Za-z0-9_.:+\- ]{1,128}$")
+_CONTROL_CHARACTER = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def drop_breadcrumb(crumb: dict[str, Any], hint: dict[str, Any]) -> None:
+    """Disable every automatic breadcrumb."""
+
+    return None
+
+
+def _normalized_key(key: Any) -> str:
+    return str(key).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = _normalized_key(key)
+    return normalized in _SENSITIVE_KEY_PARTS or any(
+        normalized.startswith(f"{part}_")
+        or normalized.endswith(f"_{part}")
+        or f"_{part}_" in normalized
+        for part in _SENSITIVE_KEY_PARTS
+    )
+
+
+def _scrub_structured(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: _scrub_structured(item)
+            for key, item in value.items()
+            if not _is_sensitive_key(key)
+        }
+    if isinstance(value, list):
+        return [_scrub_structured(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_structured(item) for item in value)
+    return value
+
+
+def _bounded_stage_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    sanitized = _CONTROL_CHARACTER.sub("", value).strip()
+    if not sanitized:
+        return None
+    return sanitized[:128]
+
+
+def sanitize_esp_data(data: Any) -> dict[str, str]:
+    """Keep only reviewed UART diagnostic fields and safe scalar values."""
+
+    if not isinstance(data, Mapping):
+        return {}
+
+    output: dict[str, str] = {}
+    for key, value in data.items():
+        if key not in ESP_DATA_KEYS or not isinstance(value, str):
+            continue
+        if key == "stage_name":
+            stage_name = _bounded_stage_name(value)
+            if stage_name is not None:
+                output[key] = stage_name
+            continue
+        if _TECHNICAL_VALUE.fullmatch(value):
+            output[key] = value
+    return output
+
+
+def _remove_frame_variables(event: dict[str, Any]) -> None:
+    exception = event.get("exception")
+    if not isinstance(exception, Mapping):
+        return
+    values = exception.get("values")
+    if not isinstance(values, list):
+        return
+    for exception_value in values:
+        if not isinstance(exception_value, dict):
+            continue
+        stacktrace = exception_value.get("stacktrace")
+        if not isinstance(stacktrace, Mapping):
+            continue
+        frames = stacktrace.get("frames")
+        if not isinstance(frames, list):
+            continue
+        for frame in frames:
+            if isinstance(frame, dict):
+                frame.pop("vars", None)
+
+
+def sanitize_sentry_event(event: dict[str, Any], hint: Any = None) -> dict[str, Any]:
+    """Return a sanitized copy of an automatic Sentry event."""
+
+    sanitized = deepcopy(event)
+    sanitized.pop("breadcrumbs", None)
+    sanitized.pop("request", None)
+    sanitized.pop("user", None)
+    sanitized.pop("server_name", None)
+
+    tags = sanitized.get("tags")
+    if isinstance(tags, Mapping):
+        sanitized["tags"] = {
+            key: value
+            for key, value in tags.items()
+            if _normalized_key(key) not in {"machine", "machine_name", "hostname"}
+            and not _is_sensitive_key(key)
+        }
+
+    contexts = sanitized.get("contexts")
+    if isinstance(contexts, Mapping):
+        clean_contexts = _scrub_structured(contexts)
+        raw_config = contexts.get("config")
+        if isinstance(raw_config, Mapping):
+            clean_contexts["config"] = get_reportable_config(raw_config)
+        raw_esp_data = contexts.get("esp-data")
+        if raw_esp_data is not None:
+            clean_contexts["esp-data"] = sanitize_esp_data(raw_esp_data)
+        sanitized["contexts"] = clean_contexts
+
+    if "extra" in sanitized:
+        sanitized["extra"] = _scrub_structured(sanitized["extra"])
+
+    _remove_frame_variables(sanitized)
+    return sanitized

--- a/ssh_manager.py
+++ b/ssh_manager.py
@@ -64,7 +64,7 @@ class SSHManager:
             logger.info("Successfully generated and set new root password")
             return True
         except Exception as e:
-            logger.error(f"Error generating or setting root password:{e}")
+            logger.error(f"Error generating or setting root password ({type(e).__name__})")
             return False
 
     @staticmethod
@@ -87,7 +87,7 @@ class SSHManager:
             subprocess.run(["chpasswd"], input=f"root:{password}".encode(), check=True)
             return True
         except Exception as e:
-            logger.error(f"Error setting the root password: {e}")
+            logger.error(f"Error setting the root password ({type(e).__name__})")
             return False
 
     @staticmethod

--- a/tests/test_reportable_config.py
+++ b/tests/test_reportable_config.py
@@ -1,0 +1,140 @@
+from reportable_config import get_reportable_config
+
+
+def _leaf_paths(value, prefix=()):
+    if not isinstance(value, dict):
+        return {prefix}
+    return {
+        path
+        for key, item in value.items()
+        for path in _leaf_paths(item, (*prefix, key))
+    }
+
+
+def test_reportable_config_is_allowlist_only_and_does_not_mutate_input():
+    config = {
+        "version": 1,
+        "logging": {"log_all_sensor_messages": True, "unknown": "drop"},
+        "system": {
+            "notifications_ttl": 3600,
+            "sounds_theme": "my-custom-theme",
+            "serial": "M123",
+            "batch_number": "B1",
+            "build_date": "2026-01-02",
+            "color": "silver",
+            "last_system_versions": ["1.0", "0.9"],
+            "machine_name": ["Private", "Name"],
+            "root_password": "secret",
+            "auth_key": "secret",
+        },
+        "user": {
+            "enable_sounds": True,
+            "disallow_firmware_flashing": False,
+            "debug_shot_data_retention_days": 31,
+            "auto_start_shot": False,
+            "auto_purge_after_shot": True,
+            "partial_retraction": 45.0,
+            "heat_on_boot": True,
+            "heating_timeout": 10,
+            "update_channel": "stable",
+            "idle_screen": "default",
+            "reverse_scrolling": {
+                "home": True,
+                "keyboard": False,
+                "menus": True,
+                "future": True,
+            },
+            "clock_format_24_hour": True,
+            "allow_legacy_json": False,
+            "allow_stage_skipping": False,
+            "usb_mode": "host",
+            "timezone_sync": "automatic",
+            "ssh_enabled": False,
+            "disable_ui_features": True,
+            "time_zone": "America/Mexico_City",
+        },
+        "wifi": {
+            "mode": "CLIENT",
+            "APName": "Private SSID",
+            "APPassword": "secret",
+            "KnownWifis": {"Private SSID": {"password": "secret"}},
+        },
+        "manufacturing": {
+            "enabled": False,
+            "last_boot_mode": "normal",
+            "skip_stage": False,
+        },
+        "future": {"secret": "drop"},
+    }
+
+    reportable = get_reportable_config(config)
+
+    assert reportable["system"]["sounds_theme"] == "custom"
+    assert reportable["wifi"] == {"mode": "CLIENT"}
+    assert reportable["manufacturing"] == {
+        "enabled": False,
+        "last_boot_mode": "normal",
+        "skip_stage": False,
+    }
+    assert "machine_name" not in reportable["system"]
+    assert "root_password" not in reportable["system"]
+    assert "disable_ui_features" not in reportable["user"]
+    assert "time_zone" not in reportable["user"]
+    assert "future" not in reportable
+    assert _leaf_paths(reportable) == {
+        ("version",),
+        ("logging", "log_all_sensor_messages"),
+        ("system", "notifications_ttl"),
+        ("system", "sounds_theme"),
+        ("system", "serial"),
+        ("system", "batch_number"),
+        ("system", "build_date"),
+        ("system", "color"),
+        ("system", "last_system_versions"),
+        ("user", "enable_sounds"),
+        ("user", "disallow_firmware_flashing"),
+        ("user", "debug_shot_data_retention_days"),
+        ("user", "auto_start_shot"),
+        ("user", "auto_purge_after_shot"),
+        ("user", "partial_retraction"),
+        ("user", "heat_on_boot"),
+        ("user", "heating_timeout"),
+        ("user", "update_channel"),
+        ("user", "idle_screen"),
+        ("user", "reverse_scrolling", "home"),
+        ("user", "reverse_scrolling", "keyboard"),
+        ("user", "reverse_scrolling", "menus"),
+        ("user", "clock_format_24_hour"),
+        ("user", "allow_legacy_json"),
+        ("user", "allow_stage_skipping"),
+        ("user", "usb_mode"),
+        ("user", "timezone_sync"),
+        ("user", "ssh_enabled"),
+        ("wifi", "mode"),
+        ("manufacturing", "enabled"),
+        ("manufacturing", "last_boot_mode"),
+        ("manufacturing", "skip_stage"),
+    }
+
+    reportable["system"]["last_system_versions"].append("changed")
+    assert config["system"]["last_system_versions"] == ["1.0", "0.9"]
+
+
+def test_reportable_config_normalizes_default_theme():
+    assert get_reportable_config({"system": {"sounds_theme": "default"}}) == {
+        "system": {"sounds_theme": "default"}
+    }
+
+
+def test_reportable_config_omits_invalid_types_and_non_mapping_input():
+    assert (
+        get_reportable_config(
+            {
+                "version": True,
+                "system": {"notifications_ttl": "3600", "sounds_theme": None},
+                "user": {"enable_sounds": 1, "partial_retraction": True},
+            }
+        )
+        == {}
+    )
+    assert get_reportable_config(None) == {}

--- a/tests/test_sentry_privacy.py
+++ b/tests/test_sentry_privacy.py
@@ -27,7 +27,10 @@ def test_sanitize_event_removes_automatic_personal_context():
             "machine": "private-machine",
             "hostname": "private-host",
             "serial": "M123",
+            "build-version": "2026M1330-stable",
+            "firmware-version": "1.2.3-4-gabc123",
         },
+        "release": "espresso-firmware@1.2.3-4-gabc123",
         "contexts": {
             "config": {
                 "version": 1,
@@ -76,7 +79,12 @@ def test_sanitize_event_removes_automatic_personal_context():
     assert "user" not in sanitized
     assert "request" not in sanitized
     assert "breadcrumbs" not in sanitized
-    assert sanitized["tags"] == {"serial": "M123"}
+    assert sanitized["tags"] == {
+        "serial": "M123",
+        "build-version": "2026M1330-stable",
+        "firmware-version": "1.2.3-4-gabc123",
+    }
+    assert sanitized["release"] == "espresso-firmware@1.2.3-4-gabc123"
     assert sanitized["contexts"]["config"] == {
         "version": 1,
         "system": {"serial": "M123", "sounds_theme": "custom"},

--- a/tests/test_sentry_privacy.py
+++ b/tests/test_sentry_privacy.py
@@ -1,0 +1,102 @@
+from sentry_privacy import sanitize_esp_data, sanitize_sentry_event
+
+
+def test_sanitize_esp_data_keeps_allowlist_and_bounds_stage_name():
+    sanitized = sanitize_esp_data(
+        {
+            "stage_name": " Infusion\x00" + ("x" * 200),
+            "context": "applied_setpoint",
+            "requested": "12.5",
+            "password": "secret",
+            "future": "value",
+            "reason": "bad,value",
+        }
+    )
+
+    assert sanitized["stage_name"].startswith("Infusion")
+    assert len(sanitized["stage_name"]) == 128
+    assert sanitized["context"] == "applied_setpoint"
+    assert sanitized["requested"] == "12.5"
+    assert "password" not in sanitized
+    assert "future" not in sanitized
+    assert "reason" not in sanitized
+
+
+def test_sanitize_event_removes_automatic_personal_context():
+    event = {
+        "server_name": "private-host",
+        "user": {"id": "person"},
+        "request": {
+            "headers": {"Authorization": "Bearer secret"},
+            "cookies": {"session": "secret"},
+        },
+        "breadcrumbs": {"values": [{"message": "Private SSID"}]},
+        "tags": {
+            "machine": "private-machine",
+            "hostname": "private-host",
+            "serial": "M123",
+        },
+        "contexts": {
+            "config": {
+                "version": 1,
+                "system": {
+                    "serial": "M123",
+                    "sounds_theme": "private-theme",
+                    "root_password": "secret",
+                },
+                "wifi": {"mode": "CLIENT", "APName": "Private SSID"},
+            },
+            "esp-data": {
+                "stage_name": "Infusion",
+                "requested": "10.0",
+                "password": "secret",
+            },
+            "runtime": {
+                "hostname": "private-host",
+                "ip": "192.0.2.1",
+                "version": "3.11",
+            },
+        },
+        "extra": {
+            "authorization": "secret",
+            "password_hash": "secret",
+            "diagnostic": {"value": 2},
+        },
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "connect",
+                                "vars": {"password": "secret"},
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+
+    sanitized = sanitize_sentry_event(event)
+
+    assert "server_name" not in sanitized
+    assert "user" not in sanitized
+    assert "request" not in sanitized
+    assert "breadcrumbs" not in sanitized
+    assert sanitized["tags"] == {"serial": "M123"}
+    assert sanitized["contexts"]["config"] == {
+        "version": 1,
+        "system": {"serial": "M123", "sounds_theme": "custom"},
+        "wifi": {"mode": "CLIENT"},
+    }
+    assert sanitized["contexts"]["esp-data"] == {
+        "stage_name": "Infusion",
+        "requested": "10.0",
+    }
+    assert sanitized["contexts"]["runtime"] == {"version": "3.11"}
+    assert sanitized["extra"] == {"diagnostic": {"value": 2}}
+    assert "vars" not in sanitized["exception"]["values"][0]["stacktrace"]["frames"][0]
+
+    assert event["server_name"] == "private-host"
+    assert "vars" in event["exception"]["values"][0]["stacktrace"]["frames"][0]

--- a/tests/test_sentry_privacy.py
+++ b/tests/test_sentry_privacy.py
@@ -1,25 +1,17 @@
-from sentry_privacy import sanitize_esp_data, sanitize_sentry_event
+from sentry_privacy import sanitize_sentry_event
 
 
-def test_sanitize_esp_data_keeps_allowlist_and_bounds_stage_name():
-    sanitized = sanitize_esp_data(
-        {
-            "stage_name": " Infusion\x00" + ("x" * 200),
-            "context": "applied_setpoint",
-            "requested": "12.5",
-            "password": "secret",
-            "future": "value",
-            "reason": "bad,value",
-        }
-    )
+def test_sanitize_event_preserves_complete_esp_diagnostics():
+    esp_data = {
+        "stage_name": "Infusion " + ("x" * 200),
+        "future_sensor": "raw=value/with,punctuation",
+        "diagnostic_code": "HW-42",
+    }
 
-    assert sanitized["stage_name"].startswith("Infusion")
-    assert len(sanitized["stage_name"]) == 128
-    assert sanitized["context"] == "applied_setpoint"
-    assert sanitized["requested"] == "12.5"
-    assert "password" not in sanitized
-    assert "future" not in sanitized
-    assert "reason" not in sanitized
+    sanitized = sanitize_sentry_event({"contexts": {"esp-data": esp_data}})
+
+    assert sanitized["contexts"]["esp-data"] == esp_data
+    assert sanitized["contexts"]["esp-data"] is not esp_data
 
 
 def test_sanitize_event_removes_automatic_personal_context():
@@ -49,7 +41,7 @@ def test_sanitize_event_removes_automatic_personal_context():
             "esp-data": {
                 "stage_name": "Infusion",
                 "requested": "10.0",
-                "password": "secret",
+                "future_sensor": "raw=value/with,punctuation",
             },
             "runtime": {
                 "hostname": "private-host",
@@ -93,6 +85,7 @@ def test_sanitize_event_removes_automatic_personal_context():
     assert sanitized["contexts"]["esp-data"] == {
         "stage_name": "Infusion",
         "requested": "10.0",
+        "future_sensor": "raw=value/with,punctuation",
     }
     assert sanitized["contexts"]["runtime"] == {"version": "3.11"}
     assert sanitized["extra"] == {"diagnostic": {"value": 2}}

--- a/wifi.py
+++ b/wifi.py
@@ -285,7 +285,7 @@ class WifiManager:
                                 continue
                         except Exception as e:
                             logger.error(
-                                f"failure validating known ({network.ssid}) WI-FI security: {e}"
+                                f"Failure validating known WI-FI security ({type(e).__name__})"
                             )
 
                     if type(credentials) is str:
@@ -473,14 +473,14 @@ class WifiManager:
                 if "802-11-wireless-security.key-mgmt: property is missing" in error_msg:
                     needs_fix = True
                 else:
-                    logger.error(f"Failed to connect to wifi: {e}")
+                    logger.error(f"Failed to connect to wifi ({type(e).__name__})")
                     WifiManager.update_gatt_advertisement()
                     return False
             if needs_fix:
                 try:
                     WifiManager.fixWifiConnection(ssid, wifi_type)
                 except Exception as e:
-                    logger.error(f"Failed to connect to wifi: {e}")
+                    logger.error(f"Failed to connect to wifi ({type(e).__name__})")
                     WifiManager.update_gatt_advertisement()
                     return False
 


### PR DESCRIPTION
## Summary
- Send automatic backend and ESP events only to the self-hosted Sentry projects.
- Use newly issued client keys for the backend and firmware projects so machines with the disabled legacy keys remain blocked.
- Add a reusable `config.yml` allowlist and normalize `sounds_theme` to `default` or `custom`.
- Disable breadcrumbs, local variables, default PII, and the machine-name tag; sanitize general event contexts while preserving complete firmware-controlled ESP messages and `key=value` diagnostics.
- Preserve the inherited image build tags on firmware events, add the running `firmware-version` tag, and set the native release to `espresso-firmware@<firmware-version>`.
- Remove evident Wi-Fi, password, hostname, and SSH values from backend-generated automatic error messages while retaining useful exceptions and errors.

## ESP diagnostic review
- Reviewed all 9 explicit `sentry=true` sources and all 3 firmware `ERROR` sources in the current branch.
- Found hardware/runtime diagnostics such as temperatures, sensor values, setpoints, weights, positions, timeouts, stage names, and exception details.
- Found no SSIDs, passwords, tokens, credentials, authorization data, cookies, emails, usernames, hostnames, or IP addresses in those sources.

## Related PRs
- [Dial automatic events](https://github.com/MeticulousHome/meticulous-dial/pull/562)
- [Linux crash reporter](https://github.com/MeticulousHome/systemd-crash-reporter/pull/8)
- [ESP diagnostics](https://github.com/MeticulousHome/EspressoFirmware/pull/489)

## Validation
- `python -m pytest tests/test_config.py tests/test_reportable_config.py tests/test_sentry_privacy.py tests/test_machine_message_parsing.py -q` — 51 passed
- Python compilation checks for the changed modules
- Focused Black and Flake8 checks for the privacy helper and tests