### PR TITLE
Enroll the ESP32 OTA device UUID from VAR-SOM

### DIFF
--- a/device_identity.py
+++ b/device_identity.py
@@ -1,0 +1,58 @@
+import os
+import re
+import tempfile
+from pathlib import Path
+
+
+DEVICE_UUID_CACHE_PATH = Path(
+    os.getenv(
+        "DEVICE_UUID_CACHE_PATH",
+        "/meticulous-user/.device-identity/device-uuid",
+    )
+)
+
+DEVICE_UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def is_valid_device_uuid(device_uuid: str) -> bool:
+    return bool(DEVICE_UUID_PATTERN.fullmatch(device_uuid))
+
+
+def update_device_uuid_cache(device_uuid: str) -> bool:
+    """Persist the ESP-owned UUID and return whether the cache changed."""
+    if not is_valid_device_uuid(device_uuid):
+        raise ValueError("Invalid ESP device UUID")
+
+    try:
+        cached_uuid = DEVICE_UUID_CACHE_PATH.read_text(encoding="ascii").strip()
+    except FileNotFoundError:
+        cached_uuid = ""
+
+    if cached_uuid == device_uuid:
+        DEVICE_UUID_CACHE_PATH.parent.chmod(0o700)
+        DEVICE_UUID_CACHE_PATH.chmod(0o600)
+        return False
+
+    cache_directory = DEVICE_UUID_CACHE_PATH.parent
+    cache_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    cache_directory.chmod(0o700)
+
+    file_descriptor, temporary_path_string = tempfile.mkstemp(
+        prefix=".device-uuid.",
+        dir=cache_directory,
+        text=True,
+    )
+    temporary_path = Path(temporary_path_string)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="ascii") as temporary_file:
+            temporary_file.write(f"{device_uuid}\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        temporary_path.chmod(0o600)
+        os.replace(temporary_path, DEVICE_UUID_CACHE_PATH)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+    return True

--- a/device_identity.py
+++ b/device_identity.py
@@ -1,6 +1,7 @@
 import os
 import re
 import tempfile
+import uuid
 from pathlib import Path
 
 
@@ -20,6 +21,24 @@ def is_valid_device_uuid(device_uuid: str) -> bool:
     return bool(DEVICE_UUID_PATTERN.fullmatch(device_uuid))
 
 
+def generate_device_uuid() -> str:
+    """Generate a canonical UUIDv4 using the VAR-SOM OS entropy source."""
+    return str(uuid.uuid4())
+
+
+def get_device_uuid_assignment(
+    reported_uuid: str,
+    protocol_supported: bool,
+    pending_assignment: str | None,
+) -> str | None:
+    """Return the UUID to assign without consulting the VAR-SOM cache."""
+    if is_valid_device_uuid(reported_uuid) or not protocol_supported:
+        return None
+    if pending_assignment and is_valid_device_uuid(pending_assignment):
+        return pending_assignment
+    return generate_device_uuid()
+
+
 def update_device_uuid_cache(device_uuid: str) -> bool:
     """Persist the ESP-owned UUID and return whether the cache changed."""
     if not is_valid_device_uuid(device_uuid):
@@ -27,7 +46,7 @@ def update_device_uuid_cache(device_uuid: str) -> bool:
 
     try:
         cached_uuid = DEVICE_UUID_CACHE_PATH.read_text(encoding="ascii").strip()
-    except FileNotFoundError:
+    except (FileNotFoundError, UnicodeError):
         cached_uuid = ""
 
     if cached_uuid == device_uuid:

--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -175,6 +175,7 @@ class ESPInfo:
     partialRetraction: float = 45.0
     autoPurgeAfterShot: bool = False
     deviceUUID: str = ""
+    deviceUUIDSupported: bool = False
 
     def from_args(args):
         espPinout = 0
@@ -197,6 +198,7 @@ class ESPInfo:
                     float(args[8]),
                     args[9].lower() == "true",
                     args[10],
+                    True,
                 )
             elif len(args) >= 10:
                 info = ESPInfo(
@@ -254,8 +256,9 @@ class ESPInfo:
             self.scaleModule,
             str(self.partialRetraction),
             "true" if self.autoPurgeAfterShot else "false",
-            self.deviceUUID,
         ]
+        if self.deviceUUIDSupported:
+            args.append(self.deviceUUID)
         return args
 
     def to_sio(self):

--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -174,6 +174,7 @@ class ESPInfo:
     scaleModule: str = ""
     partialRetraction: float = 45.0
     autoPurgeAfterShot: bool = False
+    deviceUUID: str = ""
 
     def from_args(args):
         espPinout = 0
@@ -183,7 +184,21 @@ class ESPInfo:
         except Exception:
             pass
         try:
-            if len(args) >= 10:
+            if len(args) >= 11:
+                info = ESPInfo(
+                    args[0],
+                    espPinout,
+                    float(args[2]),
+                    args[3],
+                    args[4],
+                    args[5],
+                    args[6],
+                    args[7],
+                    float(args[8]),
+                    args[9].lower() == "true",
+                    args[10],
+                )
+            elif len(args) >= 10:
                 info = ESPInfo(
                     args[0],
                     espPinout,
@@ -239,6 +254,7 @@ class ESPInfo:
             self.scaleModule,
             str(self.partialRetraction),
             "true" if self.autoPurgeAfterShot else "false",
+            self.deviceUUID,
         ]
         return args
 

--- a/machine.py
+++ b/machine.py
@@ -43,6 +43,7 @@ from esp_serial.data import (
     HeaterTimeoutInfo,
 )
 from esp_serial.esp_tool_wrapper import ESPToolWrapper
+from device_identity import is_valid_device_uuid, update_device_uuid_cache
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
 from shot_debug_manager import ShotDebugManager
@@ -644,10 +645,9 @@ class Machine:
                         MeticulousConfig[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     )
                     Machine.setPartialRetraction(backend_partial_retraction)
-                    backend_auto_purge = bool(
-                        MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE]
-                    )
+                    backend_auto_purge = bool(MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE])
                     Machine.setAutoPurgeAfterShot(backend_auto_purge)
+                    Machine.syncDeviceUUID(info.deviceUUID)
 
                     if (
                         info.serialNumber != ""
@@ -952,6 +952,44 @@ Build Date: {build_date}
 
         MeticulousConfig.save()
         # TODO FIXME IMPLEMENT THIS!!!!
+
+    def syncDeviceUUID(device_uuid: str):
+        if not device_uuid:
+            return
+
+        if not is_valid_device_uuid(device_uuid):
+            logger.error("ESP32 reported an invalid device UUID")
+            return
+
+        try:
+            cache_changed = update_device_uuid_cache(device_uuid)
+        except OSError:
+            logger.exception("Failed to update OTA device UUID cache")
+            return
+
+        if not cache_changed:
+            return
+
+        logger.info("Updated OTA device UUID cache from ESP32")
+        if Machine.emulated:
+            return
+
+        try:
+            restart_result = subprocess.run(
+                ["systemctl", "try-restart", "rauc-hawkbit-updater.service"],
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            logger.exception(
+                "Could not restart rauc-hawkbit-updater after updating device UUID cache"
+            )
+            return
+
+        if restart_result.returncode != 0:
+            logger.warning(
+                "Could not restart rauc-hawkbit-updater after updating device UUID cache"
+            )
 
     def setPartialRetraction(partial_retraction: float):
         desired_value = float(partial_retraction)

--- a/machine.py
+++ b/machine.py
@@ -43,7 +43,11 @@ from esp_serial.data import (
     HeaterTimeoutInfo,
 )
 from esp_serial.esp_tool_wrapper import ESPToolWrapper
-from device_identity import is_valid_device_uuid, update_device_uuid_cache
+from device_identity import (
+    get_device_uuid_assignment,
+    is_valid_device_uuid,
+    update_device_uuid_cache,
+)
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
 from shot_debug_manager import ShotDebugManager
@@ -159,6 +163,7 @@ class Machine:
     aborted_by_motor_consumtion = False
 
     esp_restart_request = False
+    pending_device_uuid_assignment: str | None = None
 
     @staticmethod
     def get_somrev():
@@ -385,6 +390,7 @@ class Machine:
                     info_requested = False
                     Machine.infoReady = False
                     Machine.profileReady = False
+                    Machine.pending_device_uuid_assignment = None
                     is_valid_message = False
                     collect_tracing_info = False
 
@@ -430,6 +436,13 @@ class Machine:
                         sensor = SensorData.from_args(sensorArgs)
                     case ["ESPInfo", *infoArgs]:
                         info = ESPInfo.from_args(infoArgs)
+                    case ["device_uuid_response", response]:
+                        if response == "ERROR_WRITE_FAILED":
+                            logger.error("ESP32 failed to persist its assigned device UUID")
+                        elif response.startswith("ERROR_"):
+                            logger.error("ESP32 rejected the device UUID assignment")
+                        else:
+                            logger.info("ESP32 accepted the device UUID assignment command")
                     case ["Notify", *notifyArgs]:
                         notify = MachineNotify(
                             notifyArgs[0], ",".join(notifyArgs[1:]).replace(";", "\n")
@@ -647,7 +660,7 @@ class Machine:
                     Machine.setPartialRetraction(backend_partial_retraction)
                     backend_auto_purge = bool(MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE])
                     Machine.setAutoPurgeAfterShot(backend_auto_purge)
-                    Machine.syncDeviceUUID(info.deviceUUID)
+                    Machine.syncDeviceUUID(info.deviceUUID, info.deviceUUIDSupported)
 
                     if (
                         info.serialNumber != ""
@@ -953,12 +966,25 @@ Build Date: {build_date}
         MeticulousConfig.save()
         # TODO FIXME IMPLEMENT THIS!!!!
 
-    def syncDeviceUUID(device_uuid: str):
-        if not device_uuid:
+    def syncDeviceUUID(device_uuid: str, device_uuid_supported: bool):
+        if is_valid_device_uuid(device_uuid):
+            Machine.pending_device_uuid_assignment = None
+        elif not device_uuid_supported:
+            Machine.pending_device_uuid_assignment = None
             return
+        else:
+            if device_uuid:
+                logger.error("ESP32 reported an invalid device UUID")
 
-        if not is_valid_device_uuid(device_uuid):
-            logger.error("ESP32 reported an invalid device UUID")
+            Machine.pending_device_uuid_assignment = get_device_uuid_assignment(
+                device_uuid,
+                device_uuid_supported,
+                Machine.pending_device_uuid_assignment,
+            )
+
+            Machine.writeStr(
+                "device_uuid,assign," + Machine.pending_device_uuid_assignment + "\x03"
+            )
             return
 
         try:

--- a/tests/test_device_identity.py
+++ b/tests/test_device_identity.py
@@ -24,6 +24,34 @@ def test_validates_canonical_uuid_v4():
     assert not device_identity.is_valid_device_uuid("123e4567-e89b-32d3-a456-426614174000")
 
 
+def test_generates_canonical_uuid_v4():
+    assert device_identity.is_valid_device_uuid(device_identity.generate_device_uuid())
+
+
+def test_valid_esp_uuid_never_requests_assignment():
+    assert device_identity.get_device_uuid_assignment(FIRST_UUID, True, SECOND_UUID) is None
+
+
+def test_unsupported_firmware_never_requests_assignment():
+    assert device_identity.get_device_uuid_assignment("", False, None) is None
+
+
+def test_missing_uuid_reuses_pending_assignment_without_reading_cache():
+    assert device_identity.get_device_uuid_assignment("", True, SECOND_UUID) == SECOND_UUID
+
+
+def test_missing_uuid_generates_new_assignment():
+    assignment = device_identity.get_device_uuid_assignment("", True, None)
+
+    assert device_identity.is_valid_device_uuid(assignment)
+
+
+def test_invalid_pending_assignment_is_replaced():
+    assignment = device_identity.get_device_uuid_assignment("", True, "invalid")
+
+    assert device_identity.is_valid_device_uuid(assignment)
+
+
 def test_creates_and_reuses_cache(cache_path):
     assert device_identity.update_device_uuid_cache(FIRST_UUID)
     assert cache_path.read_text(encoding="ascii") == f"{FIRST_UUID}\n"
@@ -45,6 +73,14 @@ def test_esp_uuid_overwrites_different_var_som_cache(cache_path):
 
     assert device_identity.update_device_uuid_cache(SECOND_UUID)
     assert cache_path.read_text(encoding="ascii") == f"{SECOND_UUID}\n"
+
+
+def test_esp_uuid_overwrites_non_ascii_var_som_cache(cache_path):
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"\xff\xfe")
+
+    assert device_identity.update_device_uuid_cache(FIRST_UUID)
+    assert cache_path.read_text(encoding="ascii") == f"{FIRST_UUID}\n"
 
 
 def test_rejects_invalid_uuid_without_changing_cache(cache_path):

--- a/tests/test_device_identity.py
+++ b/tests/test_device_identity.py
@@ -1,0 +1,57 @@
+import os
+import stat
+
+import pytest
+
+import device_identity
+
+
+FIRST_UUID = "123e4567-e89b-42d3-a456-426614174000"
+SECOND_UUID = "987e6543-e21b-45d3-b654-426614174999"
+
+
+@pytest.fixture
+def cache_path(tmp_path, monkeypatch):
+    path = tmp_path / ".device-identity" / "device-uuid"
+    monkeypatch.setattr(device_identity, "DEVICE_UUID_CACHE_PATH", path)
+    return path
+
+
+def test_validates_canonical_uuid_v4():
+    assert device_identity.is_valid_device_uuid(FIRST_UUID)
+    assert not device_identity.is_valid_device_uuid("")
+    assert not device_identity.is_valid_device_uuid(FIRST_UUID.upper())
+    assert not device_identity.is_valid_device_uuid("123e4567-e89b-32d3-a456-426614174000")
+
+
+def test_creates_and_reuses_cache(cache_path):
+    assert device_identity.update_device_uuid_cache(FIRST_UUID)
+    assert cache_path.read_text(encoding="ascii") == f"{FIRST_UUID}\n"
+    if os.name != "nt":
+        assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+    cache_path.parent.chmod(0o755)
+    cache_path.chmod(0o644)
+    assert not device_identity.update_device_uuid_cache(FIRST_UUID)
+    if os.name != "nt":
+        assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+
+def test_esp_uuid_overwrites_different_var_som_cache(cache_path):
+    cache_path.parent.mkdir()
+    cache_path.write_text(f"{FIRST_UUID}\n", encoding="ascii")
+
+    assert device_identity.update_device_uuid_cache(SECOND_UUID)
+    assert cache_path.read_text(encoding="ascii") == f"{SECOND_UUID}\n"
+
+
+def test_rejects_invalid_uuid_without_changing_cache(cache_path):
+    cache_path.parent.mkdir()
+    cache_path.write_text(f"{FIRST_UUID}\n", encoding="ascii")
+
+    with pytest.raises(ValueError):
+        device_identity.update_device_uuid_cache("invalid")
+
+    assert cache_path.read_text(encoding="ascii") == f"{FIRST_UUID}\n"

--- a/tests/test_machine_message_parsing.py
+++ b/tests/test_machine_message_parsing.py
@@ -266,13 +266,47 @@ class TestESPInfo:
         assert sio["serial_number"] == "SN123"
 
     def test_roundtrip_to_args(self):
-        args = ["1.2.3", "2", "24.5", "black", "SN123", "B456", "2024-01-01", "scale1"]
+        args = [
+            "1.2.3",
+            "2",
+            "24.5",
+            "black",
+            "SN123",
+            "B456",
+            "2024-01-01",
+            "scale1",
+            "45.0",
+            "false",
+            "123e4567-e89b-42d3-a456-426614174000",
+        ]
         info = ESPInfo.from_args(args)
         output = info.to_args()
         reparsed = ESPInfo.from_args(output)
         assert reparsed.firmwareV == info.firmwareV
         assert reparsed.mainVoltage == info.mainVoltage
         assert reparsed.color == info.color
+        assert reparsed.deviceUUID == info.deviceUUID
+
+    def test_parse_device_uuid_without_exposing_it_to_sio(self):
+        device_uuid = "123e4567-e89b-42d3-a456-426614174000"
+        args = [
+            "1.2.3",
+            "2",
+            "24.5",
+            "black",
+            "SN123",
+            "B456",
+            "2024-01-01",
+            "scale1",
+            "45.0",
+            "false",
+            device_uuid,
+        ]
+
+        info = ESPInfo.from_args(args)
+
+        assert info.deviceUUID == device_uuid
+        assert "device_uuid" not in info.to_sio()
 
 
 class TestButtonEventData:

--- a/tests/test_machine_message_parsing.py
+++ b/tests/test_machine_message_parsing.py
@@ -240,6 +240,7 @@ class TestESPInfo:
         assert info.batchNumber == "B456"
         assert info.buildDate == "2024-01-01"
         assert info.scaleModule == "scale1"
+        assert not info.deviceUUIDSupported
 
     def test_parse_minimal(self):
         args = ["0.9.1", "1", "23.0"]
@@ -286,6 +287,7 @@ class TestESPInfo:
         assert reparsed.mainVoltage == info.mainVoltage
         assert reparsed.color == info.color
         assert reparsed.deviceUUID == info.deviceUUID
+        assert reparsed.deviceUUIDSupported
 
     def test_parse_device_uuid_without_exposing_it_to_sio(self):
         device_uuid = "123e4567-e89b-42d3-a456-426614174000"
@@ -306,7 +308,28 @@ class TestESPInfo:
         info = ESPInfo.from_args(args)
 
         assert info.deviceUUID == device_uuid
+        assert info.deviceUUIDSupported
         assert "device_uuid" not in info.to_sio()
+
+    def test_empty_device_uuid_still_reports_protocol_support(self):
+        args = [
+            "1.2.3",
+            "2",
+            "24.5",
+            "black",
+            "SN123",
+            "B456",
+            "2024-01-01",
+            "scale1",
+            "45.0",
+            "false",
+            "",
+        ]
+
+        info = ESPInfo.from_args(args)
+
+        assert info.deviceUUID == ""
+        assert info.deviceUUIDSupported
 
 
 class TestButtonEventData:


### PR DESCRIPTION
## Summary

- detect UUID protocol support separately from the UUID value so older firmware remains compatible
- when compatible firmware reports no valid UUID, generate a fresh UUIDv4 from the VAR-SOM Linux entropy source and send it through the dedicated write-once UART command
- never restore a previously cached VAR-SOM UUID into an empty or corrupt ESP32
- keep a pending assignment only for retries on the same boot and clear it when a new ESP32 boot is detected
- cache and publish identity only after the ESP32 reports a valid UUID back through `ESPInfo`
- atomically overwrite any different or corrupt VAR-SOM cache with the ESP32-confirmed value and restart the Hawkbit updater only when that cache changes
- keep the UUID out of the Socket.IO machine payload

This makes the VAR-SOM the enrollment authority only. A valid UUID already stored by the ESP32 always wins and becomes the long-term source of truth.

## Related PRs

- MeticulousHome/EspressoFirmware#490 — accept and persist write-once UUID assignments
- MeticulousHome/meticulous-machine#94 — publish the confirmed candidate as a Hawkbit device attribute

## Validation

- `python -m black --check device_identity.py esp_serial/data.py machine.py tests/test_device_identity.py tests/test_machine_message_parsing.py`
- `python -m flake8 device_identity.py esp_serial/data.py machine.py tests/test_device_identity.py tests/test_machine_message_parsing.py`
- `python -m pytest tests/test_device_identity.py tests/test_machine_message_parsing.py -q` — 58 passed
- `git diff --check`

GitHub Actions currently also reports failures on files unchanged by this PR: existing flake8 errors in `ble_gatt.py` and the existing `dbus_next.aio` collection failure. The current `stable` SHA has the same failing Build workflow.