### PR TITLE
Improve ESP32 failure observability

### DIFF
--- a/esp_observability.py
+++ b/esp_observability.py
@@ -1,0 +1,359 @@
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ESPCommunicationPhase(Enum):
+    NORMAL = "normal"
+    EXPECTED_RESET = "expected_reset"
+    FLASHING = "flashing"
+    WAITING_FOR_BOOT = "waiting_for_boot"
+    WAITING_FOR_PROTOCOL = "waiting_for_protocol"
+
+
+@dataclass(frozen=True)
+class ESPDiagnostic:
+    title: str
+    level: str
+    fingerprint: str
+    tags: dict[str, str] = field(default_factory=dict)
+    context: dict[str, object] = field(default_factory=dict)
+
+
+class ESPObservability:
+    VALID_MESSAGE_TIMEOUT_SECONDS = 2.0
+    UPDATE_RECOVERY_TIMEOUT_SECONDS = 30.0
+    RESET_RECOVERY_TIMEOUT_SECONDS = 15.0
+    BOOT_LOOP_WINDOW_SECONDS = 60.0
+    BOOT_LOOP_THRESHOLD = 3
+    MAX_PANIC_LINES = 80
+    MAX_PANIC_BYTES = 8192
+
+    PANIC_MARKERS = (
+        "guru meditation error",
+        "register dump",
+        "backtrace",
+        "assert failed",
+        "stack smashing protect failure",
+        "heap corruption",
+    )
+
+    def __init__(self, now: float = 0.0):
+        self.phase = ESPCommunicationPhase.EXPECTED_RESET
+        self.last_valid_message = now
+        self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
+        self.expected_firmware = None
+        self._update_active = False
+        self.previous_firmware = None
+        self.boot_seen = False
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self.timeout_reported = False
+        self._collecting_panic = False
+        self._panic_lines: list[str] = []
+        self._panic_bytes = 0
+        self._recent_unexpected_boots: deque[float] = deque()
+
+    @property
+    def update_in_progress(self) -> bool:
+        return self._update_active and self.phase in {
+            ESPCommunicationPhase.FLASHING,
+            ESPCommunicationPhase.WAITING_FOR_BOOT,
+            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+        }
+
+    def begin_expected_reset(self, now: float) -> None:
+        self.phase = ESPCommunicationPhase.EXPECTED_RESET
+        self._update_active = False
+        self.boot_seen = False
+        self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self.timeout_reported = False
+
+    def begin_update(
+        self, expected_firmware: str | None, previous_firmware: str | None, now: float
+    ) -> None:
+        self.phase = ESPCommunicationPhase.FLASHING
+        self._update_active = True
+        self.expected_firmware = self._clean_version(expected_firmware)
+        self.previous_firmware = self._clean_version(previous_firmware)
+        self.boot_seen = False
+        self.recovery_deadline = None
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self.timeout_reported = False
+        self._clear_panic()
+
+    def finish_flashing(self, now: float) -> None:
+        self.phase = ESPCommunicationPhase.WAITING_FOR_BOOT
+        self.recovery_deadline = now + self.UPDATE_RECOVERY_TIMEOUT_SECONDS
+
+    def fail_flashing(self, detail: str, stage: str, now: float) -> ESPDiagnostic:
+        event = ESPDiagnostic(
+            title="ESP32 firmware update failed",
+            level="error",
+            fingerprint="esp32-firmware-update-failed",
+            tags={"stage": stage},
+            context={
+                "detail": detail[:1000],
+                "expected_firmware": self.expected_firmware,
+                "previous_firmware": self.previous_firmware,
+            },
+        )
+        self._return_to_normal(now)
+        return event
+
+    def observe_raw_line(self, line: str, now: float) -> list[ESPDiagnostic]:
+        events: list[ESPDiagnostic] = []
+        normalized = line.strip("\r\n")
+        lowered = normalized.lower()
+        is_boot_banner = (
+            normalized.startswith("rst:0x")
+            and "boot:0x" in normalized
+            and " (SPI_FAST_FLASH_BOOT)" in normalized
+        )
+
+        if any(marker in lowered for marker in self.PANIC_MARKERS):
+            self._collecting_panic = True
+
+        if self._collecting_panic and not is_boot_banner:
+            self._append_panic_line(normalized)
+
+        if not is_boot_banner:
+            return events
+
+        self.boot_seen = True
+        self._collecting_panic = False
+        if self.phase in {
+            ESPCommunicationPhase.FLASHING,
+            ESPCommunicationPhase.WAITING_FOR_BOOT,
+        }:
+            self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+            return events
+
+        if self.phase == ESPCommunicationPhase.EXPECTED_RESET:
+            self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+            return events
+
+        self.pending_unexpected_reset = True
+        self.reset_reported = False
+        self._recent_unexpected_boots.append(now)
+        cutoff = now - self.BOOT_LOOP_WINDOW_SECONDS
+        while self._recent_unexpected_boots and self._recent_unexpected_boots[0] < cutoff:
+            self._recent_unexpected_boots.popleft()
+        if len(self._recent_unexpected_boots) == self.BOOT_LOOP_THRESHOLD:
+            events.append(
+                ESPDiagnostic(
+                    title="ESP32 firmware boot loop detected",
+                    level="critical",
+                    fingerprint="esp32-firmware-boot-loop",
+                    context={
+                        "resets": len(self._recent_unexpected_boots),
+                        "window_seconds": self.BOOT_LOOP_WINDOW_SECONDS,
+                        "previous_firmware": self.previous_firmware,
+                    },
+                )
+            )
+        return events
+
+    def observe_boot_reason(self, reason: str, code: str, now: float) -> list[ESPDiagnostic]:
+        reason = reason.strip().upper() or "UNKNOWN"
+        code = code.strip()
+        if not self.pending_unexpected_reset:
+            if reason == "PANIC" or self._panic_lines:
+                return [self._panic_diagnostic(reason, code)]
+            return []
+
+        if self.reset_reported:
+            return []
+
+        self.reset_reported = True
+        if reason == "PANIC" or self._panic_lines:
+            return [self._panic_diagnostic(reason, code)]
+        return [
+            ESPDiagnostic(
+                title="ESP32 unexpected reset detected",
+                level="error",
+                fingerprint=f"esp32-unexpected-reset-{reason.lower()}",
+                tags={"reset_reason": reason, "reset_reason_code": code},
+                context={"previous_firmware": self.previous_firmware},
+            )
+        ]
+
+    def observe_valid_message(
+        self,
+        message_type: str,
+        now: float,
+        firmware_version: str | None = None,
+    ) -> list[ESPDiagnostic]:
+        self.last_valid_message = now
+        self.timeout_reported = False
+
+        if self.pending_unexpected_reset and not self.reset_reported:
+            self.reset_reported = True
+            event = (
+                self._panic_diagnostic("UNKNOWN", "")
+                if self._panic_lines
+                else ESPDiagnostic(
+                    title="ESP32 unexpected reset detected",
+                    level="error",
+                    fingerprint="esp32-unexpected-reset-unknown",
+                    tags={"reset_reason": "UNKNOWN"},
+                    context={"previous_firmware": self.previous_firmware},
+                )
+            )
+            events = [event]
+        else:
+            events = []
+
+        if message_type != "ESPInfo":
+            return events
+
+        observed_firmware = self._clean_version(firmware_version)
+        if self.update_in_progress:
+            if not self.boot_seen:
+                return events
+            if self.expected_firmware and observed_firmware != self.expected_firmware:
+                return events
+            self._return_to_normal(now)
+        elif self.phase in {
+            ESPCommunicationPhase.EXPECTED_RESET,
+            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+        }:
+            self._return_to_normal(now)
+        elif self.pending_unexpected_reset:
+            self.pending_unexpected_reset = False
+            self._clear_panic()
+
+        if observed_firmware:
+            self.previous_firmware = observed_firmware
+        return events
+
+    def check_timeouts(self, now: float) -> list[ESPDiagnostic]:
+        if (
+            self.update_in_progress
+            and self.recovery_deadline is not None
+            and now > self.recovery_deadline
+        ):
+            phase = self.phase.value
+            event = ESPDiagnostic(
+                title="ESP32 did not recover after firmware update",
+                level="critical",
+                fingerprint="esp32-firmware-update-recovery-failed",
+                tags={"recovery_phase": phase},
+                context={
+                    "expected_firmware": self.expected_firmware,
+                    "previous_firmware": self.previous_firmware,
+                    "timeout_seconds": self.UPDATE_RECOVERY_TIMEOUT_SECONDS,
+                },
+            )
+            self._return_to_normal(now)
+            self.timeout_reported = True
+            return [event]
+
+        if (
+            not self._update_active
+            and self.phase
+            in {
+                ESPCommunicationPhase.EXPECTED_RESET,
+                ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+            }
+            and self.recovery_deadline is not None
+            and now > self.recovery_deadline
+        ):
+            phase = self.phase.value
+            self._return_to_normal(now)
+            self.timeout_reported = True
+            return [
+                ESPDiagnostic(
+                    title="ESP32 valid-message timeout",
+                    level="error",
+                    fingerprint="esp32-valid-message-timeout",
+                    tags={"operation": "expected_reset"},
+                    context={
+                        "recovery_phase": phase,
+                        "threshold_seconds": self.RESET_RECOVERY_TIMEOUT_SECONDS,
+                        "last_known_firmware": self.previous_firmware,
+                    },
+                )
+            ]
+
+        if self.phase != ESPCommunicationPhase.NORMAL or self.pending_unexpected_reset:
+            return []
+
+        elapsed = now - self.last_valid_message
+        if elapsed > self.VALID_MESSAGE_TIMEOUT_SECONDS and not self.timeout_reported:
+            self.timeout_reported = True
+            return [
+                ESPDiagnostic(
+                    title="ESP32 valid-message timeout",
+                    level="error",
+                    fingerprint="esp32-valid-message-timeout",
+                    context={
+                        "elapsed_seconds": round(elapsed, 3),
+                        "threshold_seconds": self.VALID_MESSAGE_TIMEOUT_SECONDS,
+                        "last_known_firmware": self.previous_firmware,
+                    },
+                )
+            ]
+        return []
+
+    def _panic_diagnostic(self, reason: str, code: str) -> ESPDiagnostic:
+        context: dict[str, object] = {
+            "reset_reason": reason,
+            "previous_firmware": self.previous_firmware,
+        }
+        if code:
+            context["reset_reason_code"] = code
+        if self._panic_lines:
+            context["panic_output"] = "\n".join(self._panic_lines)
+            context["panic_output_truncated"] = (
+                len(self._panic_lines) >= self.MAX_PANIC_LINES
+                or self._panic_bytes >= self.MAX_PANIC_BYTES
+            )
+        return ESPDiagnostic(
+            title="ESP32 firmware panic detected",
+            level="critical",
+            fingerprint="esp32-firmware-panic",
+            tags={"reset_reason": reason, "reset_reason_code": code},
+            context=context,
+        )
+
+    def _append_panic_line(self, line: str) -> None:
+        if len(self._panic_lines) >= self.MAX_PANIC_LINES:
+            return
+        encoded_size = len(line.encode("utf-8", errors="replace")) + 1
+        remaining = self.MAX_PANIC_BYTES - self._panic_bytes
+        if remaining <= 0:
+            return
+        if encoded_size > remaining:
+            line = line.encode("utf-8", errors="replace")[:remaining].decode(
+                "utf-8", errors="ignore"
+            )
+            encoded_size = len(line.encode("utf-8", errors="replace"))
+        self._panic_lines.append(line)
+        self._panic_bytes += encoded_size
+
+    def _return_to_normal(self, now: float) -> None:
+        self.phase = ESPCommunicationPhase.NORMAL
+        self.last_valid_message = now
+        self.recovery_deadline = None
+        self.expected_firmware = None
+        self._update_active = False
+        self.boot_seen = False
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self._clear_panic()
+
+    def _clear_panic(self) -> None:
+        self._collecting_panic = False
+        self._panic_lines = []
+        self._panic_bytes = 0
+
+    @staticmethod
+    def _clean_version(version: str | None) -> str | None:
+        if version is None:
+            return None
+        cleaned = version.strip()
+        return cleaned or None

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -1,6 +1,7 @@
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
+import re
 
 
 class ESPCommunicationPhase(Enum):
@@ -37,6 +38,10 @@ class ESPObservability:
         "stack smashing protect failure",
         "heap corruption",
     )
+    GURU_MEDITATION_PATTERN = re.compile(
+        r"Guru Meditation Error:\s*Core\s+(\d+)\s+panic'ed\s+\(([^)]+)\)",
+        re.IGNORECASE,
+    )
 
     def __init__(self, now: float = 0.0):
         self.phase = ESPCommunicationPhase.EXPECTED_RESET
@@ -48,10 +53,13 @@ class ESPObservability:
         self.boot_seen = False
         self.pending_unexpected_reset = False
         self.reset_reported = False
+        self.panic_reported = False
         self.timeout_reported = False
         self._collecting_panic = False
         self._panic_lines: list[str] = []
         self._panic_bytes = 0
+        self._panic_core = None
+        self._panic_reason = None
         self._recent_unexpected_boots: deque[float] = deque()
 
     @property
@@ -69,6 +77,7 @@ class ESPObservability:
         self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
         self.pending_unexpected_reset = False
         self.reset_reported = False
+        self.panic_reported = False
         self.timeout_reported = False
 
     def begin_update(
@@ -82,6 +91,7 @@ class ESPObservability:
         self.recovery_deadline = None
         self.pending_unexpected_reset = False
         self.reset_reported = False
+        self.panic_reported = False
         self.timeout_reported = False
         self._clear_panic()
 
@@ -116,6 +126,10 @@ class ESPObservability:
 
         if any(marker in lowered for marker in self.PANIC_MARKERS):
             self._collecting_panic = True
+            guru_match = self.GURU_MEDITATION_PATTERN.search(normalized)
+            if guru_match:
+                self._panic_core = guru_match.group(1)
+                self._panic_reason = guru_match.group(2)
 
         if self._collecting_panic and not is_boot_banner:
             self._append_panic_line(normalized)
@@ -125,6 +139,10 @@ class ESPObservability:
 
         self.boot_seen = True
         self._collecting_panic = False
+        if self._panic_lines and not self.panic_reported:
+            events.append(self._panic_diagnostic("UNKNOWN", ""))
+            self.panic_reported = True
+            self.reset_reported = True
         if self.phase in {
             ESPCommunicationPhase.FLASHING,
             ESPCommunicationPhase.WAITING_FOR_BOOT,
@@ -160,8 +178,11 @@ class ESPObservability:
     def observe_boot_reason(self, reason: str, code: str, now: float) -> list[ESPDiagnostic]:
         reason = reason.strip().upper() or "UNKNOWN"
         code = code.strip()
+        if self.panic_reported:
+            return []
         if not self.pending_unexpected_reset:
             if reason == "PANIC" or self._panic_lines:
+                self.panic_reported = True
                 return [self._panic_diagnostic(reason, code)]
             return []
 
@@ -170,6 +191,7 @@ class ESPObservability:
 
         self.reset_reported = True
         if reason == "PANIC" or self._panic_lines:
+            self.panic_reported = True
             return [self._panic_diagnostic(reason, code)]
         return [
             ESPDiagnostic(
@@ -300,10 +322,17 @@ class ESPObservability:
         return []
 
     def _panic_diagnostic(self, reason: str, code: str) -> ESPDiagnostic:
+        tags = {"reset_reason": reason, "reset_reason_code": code}
         context: dict[str, object] = {
             "reset_reason": reason,
             "previous_firmware": self.previous_firmware,
         }
+        if self._panic_reason:
+            tags["panic_reason"] = self._panic_reason
+            context["panic_reason"] = self._panic_reason
+        if self._panic_core:
+            tags["core"] = self._panic_core
+            context["core"] = self._panic_core
         if code:
             context["reset_reason_code"] = code
         if self._panic_lines:
@@ -316,7 +345,7 @@ class ESPObservability:
             title="ESP32 firmware panic detected",
             level="critical",
             fingerprint="esp32-firmware-panic",
-            tags={"reset_reason": reason, "reset_reason_code": code},
+            tags=tags,
             context=context,
         )
 
@@ -344,12 +373,15 @@ class ESPObservability:
         self.boot_seen = False
         self.pending_unexpected_reset = False
         self.reset_reported = False
+        self.panic_reported = False
         self._clear_panic()
 
     def _clear_panic(self) -> None:
         self._collecting_panic = False
         self._panic_lines = []
         self._panic_bytes = 0
+        self._panic_core = None
+        self._panic_reason = None
 
     @staticmethod
     def _clean_version(version: str | None) -> str | None:

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -32,6 +32,7 @@ class ESPObservability:
 
     PANIC_MARKERS = (
         "guru meditation error",
+        "abort() was called",
         "register dump",
         "backtrace",
         "assert failed",
@@ -40,6 +41,10 @@ class ESPObservability:
     )
     GURU_MEDITATION_PATTERN = re.compile(
         r"Guru Meditation Error:\s*Core\s+(\d+)\s+panic'ed\s+\(([^)]+)\)",
+        re.IGNORECASE,
+    )
+    ABORT_PATTERN = re.compile(
+        r"abort\(\) was called at PC\s+\S+\s+on core\s+(\d+)",
         re.IGNORECASE,
     )
 
@@ -130,6 +135,10 @@ class ESPObservability:
             if guru_match:
                 self._panic_core = guru_match.group(1)
                 self._panic_reason = guru_match.group(2)
+            abort_match = self.ABORT_PATTERN.search(normalized)
+            if abort_match:
+                self._panic_core = abort_match.group(1)
+                self._panic_reason = "abort"
 
         if self._collecting_panic and not is_boot_banner:
             self._append_panic_line(normalized)

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -143,14 +143,14 @@ class ESPObservability:
             events.append(self._panic_diagnostic("UNKNOWN", ""))
             self.panic_reported = True
             self.reset_reported = True
-        if self.phase in {
-            ESPCommunicationPhase.FLASHING,
-            ESPCommunicationPhase.WAITING_FOR_BOOT,
-        }:
+        if self.update_in_progress:
             self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
             return events
 
-        if self.phase == ESPCommunicationPhase.EXPECTED_RESET:
+        if self.phase in {
+            ESPCommunicationPhase.EXPECTED_RESET,
+            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+        }:
             self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
             return events
 

--- a/machine.py
+++ b/machine.py
@@ -43,6 +43,7 @@ from esp_serial.data import (
     HeaterTimeoutInfo,
 )
 from esp_serial.esp_tool_wrapper import ESPToolWrapper
+from esp_observability import ESPDiagnostic, ESPObservability
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
 from shot_debug_manager import ShotDebugManager
@@ -142,6 +143,7 @@ class Machine:
     shot_start_time = 0
     emulated = False
     firmware_available = None
+    firmware_available_string = None
     firmware_running = None
     startTime = None
 
@@ -158,6 +160,57 @@ class Machine:
     aborted_by_motor_consumtion = False
 
     esp_restart_request = False
+    esp_observability = ESPObservability(time.monotonic())
+
+    @staticmethod
+    def _capture_esp_diagnostic(diagnostic: ESPDiagnostic):
+        with sentry_sdk.new_scope() as scope:
+            scope.set_client(ESPSentryClient)
+            for key, value in diagnostic.tags.items():
+                if value:
+                    scope.set_tag(key, value)
+            if diagnostic.context:
+                scope.set_context("esp-diagnostic", diagnostic.context)
+
+            firmware_version = (
+                diagnostic.context.get("previous_firmware")
+                or Machine.esp_observability.previous_firmware
+            )
+            event = {
+                "message": diagnostic.title,
+                "level": diagnostic.level,
+                "fingerprint": [diagnostic.fingerprint],
+            }
+            if firmware_version:
+                event["release"] = f"espresso-firmware@{firmware_version}"
+                scope.set_tag("firmware-version", firmware_version)
+            scope.capture_event(event)
+
+    @staticmethod
+    def _report_esp_diagnostics(diagnostics: list[ESPDiagnostic]):
+        for diagnostic in diagnostics:
+            logger.warning(f"{diagnostic.title}: tags={diagnostic.tags}")
+            Machine._capture_esp_diagnostic(diagnostic)
+            if diagnostic.title in {
+                "ESP32 firmware panic detected",
+                "ESP32 unexpected reset detected",
+                "ESP32 firmware boot loop detected",
+            }:
+                if AlarmManager.is_alarm_set(AlarmType.ESP_RESTART) is None:
+                    AlarmManager.set_alarm(
+                        AlarmType.ESP_RESTART, end_time=None, force=False, quiet=True
+                    )
+            elif diagnostic.title in {
+                "ESP32 valid-message timeout",
+                "ESP32 did not recover after firmware update",
+            }:
+                if AlarmManager.is_alarm_set(AlarmType.ESP_DISCONNECTED) is None:
+                    AlarmManager.set_alarm(
+                        AlarmType.ESP_DISCONNECTED,
+                        end_time=None,
+                        force=True,
+                        quiet=True,
+                    )
 
     @staticmethod
     def get_somrev():
@@ -238,14 +291,16 @@ class Machine:
             logger.info("The ESP is alive")
 
     def refreshAvailableFirmware():
+        Machine.firmware_available_string = ESPToolWrapper.get_version_from_firmware()
         Machine.firmware_available = Machine._parseVersionString(
-            ESPToolWrapper.get_version_from_firmware()
+            Machine.firmware_available_string
         )
         logger.info(f"Backend available firmware version: {Machine.firmware_available}")
         return Machine.firmware_available
 
     def init(sio):
         Machine.esp_restart_request = True
+        Machine.esp_observability = ESPObservability(time.monotonic())
         Machine._sio = sio
         Machine.refreshAvailableFirmware()
 
@@ -340,10 +395,6 @@ class Machine:
         profile_time = 0
         emulated_firmware = False
         previous_preheat_remaining = None
-        ESP_tracing_info = []
-        collect_tracing_info = False
-        previous_valid_message_timestamp = time.monotonic()
-
         logger.info("Starting to listen for esp32 messages")
         Machine.startTime = time.time()
         while True:
@@ -365,6 +416,10 @@ class Machine:
                     logger.info(data_str.strip("\r\n"))
 
                 data_str_sensors = data_str.strip("\r\n").split(",")
+                now = time.monotonic()
+                Machine._report_esp_diagnostics(
+                    Machine.esp_observability.observe_raw_line(data_str, now)
+                )
 
                 # potential message types
                 button_event = None
@@ -372,6 +427,8 @@ class Machine:
                 data = None
                 info = None
                 notify = None
+                boot_reason = None
+                valid_message_type = None
                 is_valid_message = True
 
                 if data_str.startswith("rst:0x") and all(
@@ -385,25 +442,14 @@ class Machine:
                     Machine.infoReady = False
                     Machine.profileReady = False
                     is_valid_message = False
-                    collect_tracing_info = False
 
-                if Machine.reset_count >= 3:
+                if (
+                    Machine.reset_count >= 3
+                    and not Machine.esp_observability.update_in_progress
+                ):
                     logger.warning("The ESP seems to be resetting, sending update now")
                     Machine.startUpdate()
                     Machine.reset_count = 0
-
-                if any(
-                    crash_check in data_str.lower()
-                    for crash_check in [
-                        "backtrace",
-                        "guru meditation error",
-                        "register dump",
-                    ]
-                ):
-                    collect_tracing_info = True
-
-                if collect_tracing_info:
-                    ESP_tracing_info.append(data_str)
 
                 if Machine.infoReady and not info_requested and Machine.esp_info is None:
                     logger.info(
@@ -419,22 +465,33 @@ class Machine:
                         "CCW" | "CW" | "push" | "pu_d" | "elng" | "ta_d" | "ta_l" | "strt"
                     ] as ev:
                         button_event = ButtonEventData.from_args(ev)
+                        valid_message_type = "Event"
                     case ["Event", *eventData]:
                         button_event = ButtonEventData.from_args(eventData)
+                        valid_message_type = "Event"
                     case ["Data", *dataArgs]:
                         data = ShotData.from_args(dataArgs)
+                        valid_message_type = "Data"
                     case ["Sensors", colorCodedString]:
                         sensor = SensorData.from_color_coded_args(colorCodedString)
+                        valid_message_type = "Sensors"
                     case ["Sensors", *sensorArgs]:
                         sensor = SensorData.from_args(sensorArgs)
+                        valid_message_type = "Sensors"
                     case ["ESPInfo", *infoArgs]:
                         info = ESPInfo.from_args(infoArgs)
+                        valid_message_type = "ESPInfo"
+                    case ["ESPBoot", reason, code]:
+                        boot_reason = (reason, code)
+                        valid_message_type = "ESPBoot"
                     case ["Notify", *notifyArgs]:
                         notify = MachineNotify(
                             notifyArgs[0], ",".join(notifyArgs[1:]).replace(";", "\n")
                         )
+                        valid_message_type = "Notify"
 
                     case ["HeaterTimeoutInfo", *timeoutArgs]:
+                        valid_message_type = "HeaterTimeoutInfo"
                         try:
                             heater_timeout_info = HeaterTimeoutInfo.from_args(timeoutArgs)
                             Machine.heater_timeout_info = heater_timeout_info
@@ -454,6 +511,7 @@ class Machine:
                                 exc_info=True,
                             )
                     case ["Log", *log_data]:
+                        valid_message_type = "Log"
 
                         def get_log_items(log_data: list[str]):
                             for data_str in log_data[2:]:
@@ -525,6 +583,13 @@ class Machine:
                     case [*_]:
                         logger.info(data_str.strip("\r\n"))
                         is_valid_message = False
+
+                if boot_reason is not None:
+                    Machine._report_esp_diagnostics(
+                        Machine.esp_observability.observe_boot_reason(
+                            boot_reason[0], boot_reason[1], now
+                        )
+                    )
 
                 old_ready = Machine.infoReady
 
@@ -644,9 +709,7 @@ class Machine:
                         MeticulousConfig[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     )
                     Machine.setPartialRetraction(backend_partial_retraction)
-                    backend_auto_purge = bool(
-                        MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE]
-                    )
+                    backend_auto_purge = bool(MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE])
                     Machine.setAutoPurgeAfterShot(backend_auto_purge)
 
                     if (
@@ -693,6 +756,7 @@ class Machine:
 
                     if (
                         needs_update
+                        and not Machine.esp_observability.update_in_progress
                         and not MeticulousConfig[CONFIG_USER][DISALLOW_FIRMWARE_FLASHING]
                     ):
                         info_string = f"Firmware {Machine.firmware_running.get('Release')}-{Machine.firmware_running['ExtraCommits']} is outdated, upgrading"
@@ -756,38 +820,19 @@ class Machine:
 
             now = time.monotonic()
 
-            if data_bytes is not None and is_valid_message:
-                previous_valid_message_timestamp = now
-                if Machine.esp_restart_request:
-                    logger.debug("clearing Machine.esp_restart_request flag")
-                Machine.esp_restart_request = False
+            if data_bytes is not None and is_valid_message and valid_message_type is not None:
+                firmware_version = info.firmwareV if info is not None else None
+                Machine._report_esp_diagnostics(
+                    Machine.esp_observability.observe_valid_message(
+                        valid_message_type, now, firmware_version
+                    )
+                )
+                Machine.esp_restart_request = Machine.esp_observability.phase.value != "normal"
                 Machine.reset_count = 0
                 AlarmManager.clear_alarm(AlarmType.ESP_DISCONNECTED)
                 AlarmManager.clear_alarm(AlarmType.ESP_RESTART)
 
-            if Machine.reset_count > 0 and not Machine.esp_restart_request:
-                if AlarmManager.is_alarm_set(AlarmType.ESP_RESTART) is None:
-                    # notify sentry
-                    with sentry_sdk.new_scope() as scope:
-                        if len(ESP_tracing_info) > 0:
-                            tracing_info = "\n".join(ESP_tracing_info)
-                            scope.set_extra("Tracing Info", tracing_info)
-                        sentry_sdk.capture_message("ESP has restarted unexpectedly", "critical")
-                    AlarmManager.set_alarm(
-                        AlarmType.ESP_RESTART, end_time=None, force=False, quiet=True
-                    )
-                    ESP_tracing_info = []
-
-            if now - previous_valid_message_timestamp > 0.5 and not Machine.esp_restart_request:
-                if AlarmManager.is_alarm_set(AlarmType.ESP_DISCONNECTED) is None:
-                    # notify sentry
-                    sentry_sdk.capture_message("ESP has stopped communicating", "error")
-                    AlarmManager.set_alarm(
-                        AlarmType.ESP_DISCONNECTED,
-                        end_time=None,
-                        force=True,
-                        quiet=True,
-                    )
+            Machine._report_esp_diagnostics(Machine.esp_observability.check_timeouts(now))
 
     def stopMotorIfHot(_shotData: ShotData, _sensorData: SensorData):
         from monitoring.motor_power_monitoring import MAX_ENERGY_ALLOWED
@@ -811,11 +856,39 @@ class Machine:
         Machine.action("scale_master_calibration")
 
     def startUpdate():
-
+        previous_firmware = Machine.esp_info.firmwareV if Machine.esp_info is not None else None
+        Machine.esp_observability.begin_update(
+            Machine.firmware_available_string,
+            previous_firmware,
+            time.monotonic(),
+        )
         Machine._stopESPcomm = True
         Machine.esp_restart_request = True
-        error_msg = Machine._connection.sendUpdate()
-        Machine._stopESPcomm = False
+        error_msg = None
+        try:
+            error_msg = Machine._connection.sendUpdate()
+            if error_msg:
+                Machine._report_esp_diagnostics(
+                    [
+                        Machine.esp_observability.fail_flashing(
+                            str(error_msg), "flash", time.monotonic()
+                        )
+                    ]
+                )
+            else:
+                Machine.esp_observability.finish_flashing(time.monotonic())
+        except Exception as error:
+            error_msg = f"{type(error).__name__}: {error}"
+            Machine._report_esp_diagnostics(
+                [
+                    Machine.esp_observability.fail_flashing(
+                        error_msg, "exception", time.monotonic()
+                    )
+                ]
+            )
+        finally:
+            Machine._stopESPcomm = False
+            Machine.esp_restart_request = Machine.esp_observability.phase.value != "normal"
 
         if error_msg:
             updateNotification = Notification(
@@ -879,6 +952,7 @@ class Machine:
 
     def reset():
         Machine.esp_restart_request = True
+        Machine.esp_observability.begin_expected_reset(time.monotonic())
         Machine._connection.reset()
         Machine.infoReady = False
         Machine.profileReady = False

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -110,6 +110,24 @@ def test_expected_update_still_reports_a_real_panic():
     assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
 
 
+def test_second_boot_during_update_does_not_duplicate_panic():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "old")
+    monitor.begin_update("new", "old", 1)
+    monitor.finish_flashing(2)
+    monitor.observe_raw_line("Backtrace: 0x40381234:0x3fceabcd", 2.05)
+
+    first_boot_events = monitor.observe_raw_line(BOOT, 2.1)
+    second_boot_events = monitor.observe_raw_line(BOOT, 4)
+    reason_events = monitor.observe_boot_reason("PANIC", "4", 6)
+    protocol_events = monitor.observe_valid_message("ESPBoot", 6.1)
+
+    assert titles(first_boot_events) == ["ESP32 firmware panic detected"]
+    assert second_boot_events == []
+    assert reason_events == []
+    assert protocol_events == []
+
+
 def test_non_panic_reset_is_not_called_a_crash():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -85,6 +85,20 @@ def test_guru_meditation_is_reported_as_panic_with_bounded_evidence():
     assert events[0].context["previous_firmware"] == "1.2.3"
 
 
+def test_abort_panic_extracts_core_and_keeps_the_cause_line():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line("abort() was called at PC 0x420037e1 on core 1", 1)
+    monitor.observe_raw_line("Backtrace: 0x4037801a:0x3fcebce0", 1.1)
+
+    events = monitor.observe_raw_line(BOOT, 1.2)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert events[0].tags["panic_reason"] == "abort"
+    assert events[0].tags["core"] == "1"
+    assert events[0].context["panic_output"].startswith("abort() was called")
+
+
 def test_watchdog_reset_is_classified_as_unexpected_reset_without_raw_backtrace():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -73,12 +73,14 @@ def test_guru_meditation_is_reported_as_panic_with_bounded_evidence():
     monitor.observe_raw_line("Guru Meditation Error: Core  1 panic'ed (LoadProhibited).", 1)
     monitor.observe_raw_line("Core  1 register dump:", 1.1)
     monitor.observe_raw_line("Backtrace: 0x40381234:0x3fceabcd", 1.2)
-    monitor.observe_raw_line(BOOT, 1.3)
+    events = monitor.observe_raw_line(BOOT, 1.3)
 
-    events = monitor.observe_boot_reason("PANIC", "4", 3.5)
+    assert monitor.observe_boot_reason("PANIC", "4", 3.5) == []
 
     assert titles(events) == ["ESP32 firmware panic detected"]
-    assert events[0].tags["reset_reason"] == "PANIC"
+    assert events[0].tags["reset_reason"] == "UNKNOWN"
+    assert events[0].tags["panic_reason"] == "LoadProhibited"
+    assert events[0].tags["core"] == "1"
     assert "Guru Meditation Error" in events[0].context["panic_output"]
     assert events[0].context["previous_firmware"] == "1.2.3"
 
@@ -99,11 +101,12 @@ def test_expected_update_still_reports_a_real_panic():
     monitor.observe_valid_message("ESPInfo", 0.1, "old")
     monitor.begin_update("new", "old", 1)
     monitor.finish_flashing(2)
-    monitor.observe_raw_line(BOOT, 2.1)
+    monitor.observe_raw_line("Guru Meditation Error: Core 1 panic'ed.", 2.05)
 
-    events = monitor.observe_boot_reason("PANIC", "4", 4)
+    events = monitor.observe_raw_line(BOOT, 2.1)
 
     assert titles(events) == ["ESP32 firmware panic detected"]
+    assert monitor.observe_boot_reason("PANIC", "4", 4) == []
     assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
 
 

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -1,0 +1,151 @@
+from esp_observability import ESPCommunicationPhase, ESPObservability
+
+
+BOOT = "rst:0xc (RTC_SW_CPU_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)"
+
+
+def titles(events):
+    return [event.title for event in events]
+
+
+def test_stale_pre_update_info_does_not_finish_update():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", now=0.1, firmware_version="old")
+    monitor.begin_update("new", "old", now=1)
+    monitor.finish_flashing(now=10)
+
+    assert monitor.observe_valid_message("ESPInfo", 10.1, "old") == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_BOOT
+    assert monitor.check_timeouts(12.5) == []
+
+
+def test_update_requires_boot_and_expected_esp_info_without_false_timeout():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "old")
+    monitor.begin_update("new", "old", 1)
+    monitor.finish_flashing(10)
+
+    assert monitor.observe_raw_line(BOOT, 10.2) == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+    assert monitor.check_timeouts(15) == []
+    assert monitor.observe_boot_reason("SW", "3", 12) == []
+    assert monitor.observe_valid_message("Data", 12.1) == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+    assert monitor.observe_valid_message("ESPInfo", 12.2, "new") == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+def test_update_recovery_failure_is_specific():
+    monitor = ESPObservability(now=0)
+    monitor.begin_update("new", "old", 1)
+    monitor.finish_flashing(2)
+
+    events = monitor.check_timeouts(32.1)
+
+    assert titles(events) == ["ESP32 did not recover after firmware update"]
+    assert events[0].tags["recovery_phase"] == "waiting_for_boot"
+
+
+def test_flash_error_is_specific_and_restores_normal_state():
+    monitor = ESPObservability(now=0)
+    monitor.begin_update("new", "old", 1)
+
+    event = monitor.fail_flashing("esptool failed", "flash", 2)
+
+    assert event.title == "ESP32 firmware update failed"
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+def test_expected_api_reset_emits_no_error():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "current")
+    monitor.begin_expected_reset(1)
+
+    assert monitor.observe_raw_line(BOOT, 1.2) == []
+    assert monitor.observe_boot_reason("SW", "3", 3) == []
+    assert monitor.observe_valid_message("ESPInfo", 3.1, "current") == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+def test_guru_meditation_is_reported_as_panic_with_bounded_evidence():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line("Guru Meditation Error: Core  1 panic'ed (LoadProhibited).", 1)
+    monitor.observe_raw_line("Core  1 register dump:", 1.1)
+    monitor.observe_raw_line("Backtrace: 0x40381234:0x3fceabcd", 1.2)
+    monitor.observe_raw_line(BOOT, 1.3)
+
+    events = monitor.observe_boot_reason("PANIC", "4", 3.5)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert events[0].tags["reset_reason"] == "PANIC"
+    assert "Guru Meditation Error" in events[0].context["panic_output"]
+    assert events[0].context["previous_firmware"] == "1.2.3"
+
+
+def test_watchdog_reset_is_classified_as_unexpected_reset_without_raw_backtrace():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line(BOOT, 1)
+
+    events = monitor.observe_boot_reason("TASK_WDT", "6", 3)
+
+    assert titles(events) == ["ESP32 unexpected reset detected"]
+    assert events[0].tags["reset_reason"] == "TASK_WDT"
+
+
+def test_expected_update_still_reports_a_real_panic():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "old")
+    monitor.begin_update("new", "old", 1)
+    monitor.finish_flashing(2)
+    monitor.observe_raw_line(BOOT, 2.1)
+
+    events = monitor.observe_boot_reason("PANIC", "4", 4)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+
+
+def test_non_panic_reset_is_not_called_a_crash():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line(BOOT, 1)
+
+    events = monitor.observe_boot_reason("BROWNOUT", "9", 3)
+
+    assert titles(events) == ["ESP32 unexpected reset detected"]
+    assert events[0].tags["reset_reason"] == "BROWNOUT"
+
+
+def test_parser_valid_message_timeout_uses_normal_operation_threshold():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    assert monitor.check_timeouts(2) == []
+    events = monitor.check_timeouts(2.2)
+    assert titles(events) == ["ESP32 valid-message timeout"]
+    assert monitor.check_timeouts(5) == []
+
+
+def test_expected_reset_that_never_recovers_becomes_valid_message_timeout():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.begin_expected_reset(1)
+
+    events = monitor.check_timeouts(16.1)
+
+    assert titles(events) == ["ESP32 valid-message timeout"]
+    assert events[0].tags["operation"] == "expected_reset"
+
+
+def test_three_unexpected_boots_report_boot_loop_once():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    events = []
+    for timestamp in (1, 10, 20):
+        events += monitor.observe_raw_line(BOOT, timestamp)
+        monitor.observe_boot_reason("SW", "3", timestamp + 0.1)
+        monitor.observe_valid_message("ESPInfo", timestamp + 0.2, "1.2.3")
+
+    assert titles(events) == ["ESP32 firmware boot loop detected"]


### PR DESCRIPTION
## Summary
- Replace the ambiguous `ESP has stopped communicating` report with separate Sentry events for firmware panics, unexpected resets, valid-message timeouts, update failures, update-recovery failures, and boot loops.
- Suppress normal communication timeouts while a firmware flash and expected reboot are in progress.
- Require a post-boot `ESPInfo` message with the expected version before considering an update complete, so stale pre-update state cannot complete the flow.
- Capture bounded panic evidence, including Guru Meditation or `abort()` output and backtrace, with stable fingerprints and firmware context.
- Route these diagnostics through the existing ESP32 Sentry client.
- Companion firmware change: [EspressoFirmware #493](https://github.com/MeticulousHome/EspressoFirmware/pull/493).

## Root cause
The previous timeout path did not distinguish normal operation from an expected firmware-update reboot. A stale pre-update `ESPInfo` value could also bypass the restart guard, causing an expected loss of UART traffic to be reported as a device communication failure.

## Validation
- `pytest tests/test_esp_observability.py tests/test_machine_message_parsing.py` — 59 passed.
- Black, Flake8, `compileall`, and `git diff --check`.
- End-to-end healthy firmware update on a beta machine: flash, reboot, expected-version `ESPInfo`, and reconnection completed without the old false-positive Sentry events.
- End-to-end intentional ESP32 `abort()`: bounded panic and backtrace reported once in [ESPRESSO-FIRMWARE-2C](https://sentry.meticulousespresso.com/organizations/meticulous-home/issues/48093/).
- End-to-end intentional reboot loop: reported in [ESPRESSO-FIRMWARE-2A](https://sentry.meticulousespresso.com/organizations/meticulous-home/issues/48090/).
- Full-suite collection on Windows remains blocked by Linux/runtime dependencies not installed in that environment: `dbus_next.aio`, SQLAlchemy, and `zstandard`.