### PR TITLE
chore: make lint pass on nightly (flake8 + black)

### DIFF
--- a/api/wifi.py
+++ b/api/wifi.py
@@ -61,9 +61,7 @@ class WiFiQRHandler(BaseHandler):
         config = WifiManager.getCurrentConfig()
         qr_contents: str = ""
         if config.is_hotspot():
-            ssid = self.escape_wifi_qr_value(
-                MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME]
-            )
+            ssid = self.escape_wifi_qr_value(MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME])
             password = self.escape_wifi_qr_value(
                 MeticulousConfig[CONFIG_WIFI][WIFI_AP_PASSWORD]
             )
@@ -149,9 +147,7 @@ class WiFiConfigHandler(BaseHandler):
                     )
                     return
 
-            config = await asyncio.get_event_loop().run_in_executor(
-                None, self.getWifiConfig
-            )
+            config = await asyncio.get_event_loop().run_in_executor(None, self.getWifiConfig)
             self.write(config)
         except json.JSONDecodeError as e:
             self.set_status(400)

--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -58,11 +58,11 @@ class NoInputNoOutputAgent(ServiceInterface):
         logger.info("[BLE Agent] Released")
 
     @method()
-    def RequestConfirmation(self, device: "o", passkey: "u"):
+    def RequestConfirmation(self, device: "o", passkey: "u"):  # noqa: F821
         logger.info(f"[BLE Agent] Auto-confirming pairing for {device}")
 
     @method()
-    def AuthorizeService(self, device: "o", uuid: "s"):
+    def AuthorizeService(self, device: "o", uuid: "s"):  # noqa: F821
         logger.info(f"[BLE Agent] Authorizing service {uuid} for {device}")
 
     @method()
@@ -87,6 +87,7 @@ async def register_pairing_agent():
         return bus  # keep reference alive
     except Exception as e:
         logger.warning(f"[BLE Agent] Failed to register pairing agent: {e}")
+
 
 # FIXME Remove once the tornado server logic is in its own class
 PORT = int(os.getenv("PORT", "8080"))
@@ -310,8 +311,7 @@ class GATTServer:
                     )
                 except Exception as cleanup_error:
                     logger.warning(
-                        "Could not clean up failed BLE advertisement: "
-                        f"{cleanup_error}"
+                        "Could not clean up failed BLE advertisement: " f"{cleanup_error}"
                     )
             raise
 

--- a/machine.py
+++ b/machine.py
@@ -647,9 +647,7 @@ class Machine:
                         MeticulousConfig[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     )
                     Machine.setPartialRetraction(backend_partial_retraction)
-                    backend_auto_purge = bool(
-                        MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE]
-                    )
+                    backend_auto_purge = bool(MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE])
                     Machine.setAutoPurgeAfterShot(backend_auto_purge)
 
                     if (

--- a/reportable_config.py
+++ b/reportable_config.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, Callable
 
-
 Validator = Callable[[Any], bool]
 
 

--- a/sentry_privacy.py
+++ b/sentry_privacy.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from reportable_config import get_reportable_config
 
-
 _SENSITIVE_KEY_PARTS = {
     "password",
     "passwd",

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -389,6 +389,8 @@ class TestAdvertisementUpdateRecovery:
             bus.unexport.assert_any_call(failed_advertisement.path, failed_advertisement)
         finally:
             server.loop.close()
+
+
 class TestCredentialLogRedaction:
     @staticmethod
     def logged_output():
@@ -410,9 +412,7 @@ class TestCredentialLogRedaction:
         assert "ssid_bytes=" in logged
         assert "password_bytes=" in logged
 
-    def test_wifi_connect_exception_does_not_log_exception_credentials(
-        self, mock_wifi_manager
-    ):
+    def test_wifi_connect_exception_does_not_log_exception_credentials(self, mock_wifi_manager):
         password = "SENTINEL-EXCEPTION-SECRET"
         mock_wifi_manager.connectToWifi.side_effect = RuntimeError(
             f"NetworkManager rejected {password}"

--- a/tests/test_reportable_config.py
+++ b/tests/test_reportable_config.py
@@ -4,11 +4,7 @@ from reportable_config import get_reportable_config
 def _leaf_paths(value, prefix=()):
     if not isinstance(value, dict):
         return {prefix}
-    return {
-        path
-        for key, item in value.items()
-        for path in _leaf_paths(item, (*prefix, key))
-    }
+    return {path for key, item in value.items() for path in _leaf_paths(item, (*prefix, key))}
 
 
 def test_reportable_config_is_allowlist_only_and_does_not_mutate_input():

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -251,7 +251,10 @@ class TimezoneManager:
     def tz_background_update():
         tz_config = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
         if tz_config == "automatic" and not TimezoneManager.__system_synced:
-            if TimezoneManager.__timezone_fetch_attempts >= TimezoneManager._MAX_TIMEZONE_FETCH_ATTEMPTS:
+            if (
+                TimezoneManager.__timezone_fetch_attempts
+                >= TimezoneManager._MAX_TIMEZONE_FETCH_ATTEMPTS
+            ):
                 return
             TimezoneManager.__timezone_fetch_attempts += 1
             try:

--- a/wifi.py
+++ b/wifi.py
@@ -186,8 +186,7 @@ class WifiHealthStatus:
             "ap_active": self.ap_active,
             "degraded": self.degraded,
             "last_error": self.last_error,
-            "message": self.message
-            or WifiManager.getHealthErrorMessage(self.last_error),
+            "message": self.message or WifiManager.getHealthErrorMessage(self.last_error),
             "last_recovery_action": self.last_recovery_action,
             "last_recovery_result": self.last_recovery_result,
         }
@@ -312,9 +311,7 @@ class WifiManager:
                 "invalid_credentials",
                 "Incorrect Wi-Fi password. Please check it and try again.",
             )
-        if auth_expected and any(
-            marker in lower_error for marker in auth_activation_markers
-        ):
+        if auth_expected and any(marker in lower_error for marker in auth_activation_markers):
             return (
                 "wifi_join_failed",
                 "Could not join this Wi-Fi network. Check the password and try again, or move closer to the router.",
@@ -346,8 +343,7 @@ class WifiManager:
     def healthCacheIsValid(config: WifiSystemConfig = None):
         if (
             WifiManager._cached_health is None
-            or time.time() - WifiManager._health_cache_time
-            >= WifiManager._health_cache_ttl
+            or time.time() - WifiManager._health_cache_time >= WifiManager._health_cache_ttl
         ):
             return False
 
@@ -527,9 +523,7 @@ class WifiManager:
             )
             if add_result is None or add_result.returncode != 0:
                 stderr = (
-                    add_result.stderr.strip()
-                    if add_result is not None
-                    else "command failed"
+                    add_result.stderr.strip() if add_result is not None else "command failed"
                 )
                 stdout = add_result.stdout.strip() if add_result is not None else ""
                 last_error = f"channel={channel}: {stderr or stdout or 'connection add failed'}"
@@ -586,7 +580,9 @@ class WifiManager:
                     else "command failed"
                 )
                 stdout = modify_result.stdout.strip() if modify_result is not None else ""
-                last_error = f"channel={channel}: {stderr or stdout or 'connection modify failed'}"
+                last_error = (
+                    f"channel={channel}: {stderr or stdout or 'connection modify failed'}"
+                )
                 logger.error(f"Starting hotspot failed: {last_error}")
                 WifiManager.deleteConnectionProfile(WifiManager._conname)
                 time.sleep(1)
@@ -611,9 +607,7 @@ class WifiManager:
                 last_error = f"channel={channel}: hotspot did not become active"
                 logger.error(f"Starting hotspot failed: {last_error}")
             else:
-                stderr = (
-                    result.stderr.strip() if result is not None else "command failed"
-                )
+                stderr = result.stderr.strip() if result is not None else "command failed"
                 stdout = result.stdout.strip() if result is not None else ""
                 last_error = f"channel={channel}: {stderr or stdout or 'unknown error'}"
                 logger.error(f"Starting hotspot failed: {last_error}")
@@ -880,9 +874,11 @@ class WifiManager:
                 last_error,
                 WifiManager._last_recovery_action,
                 WifiManager._last_recovery_result,
-                "Hotspot active. Connect your phone or computer to the machine's Wi-Fi network."
-                if ap_active
-                else "",
+                (
+                    "Hotspot active. Connect your phone or computer to the machine's Wi-Fi network."
+                    if ap_active
+                    else ""
+                ),
             )
             WifiManager._cached_health = health
             WifiManager._health_cache_time = time.time()
@@ -1080,7 +1076,10 @@ class WifiManager:
                 ]
             else:
                 steps = [
-                    ("restart_connection", lambda: WifiManager.restartActiveConnection(current)),
+                    (
+                        "restart_connection",
+                        lambda: WifiManager.restartActiveConnection(current),
+                    ),
                     ("restart_wifi_radio", WifiManager.restartWifiRadio),
                     ("driver_in_band_reset", WifiManager.driverInBandReset),
                     ("restart_wifi_service", WifiManager.restartWifiService),
@@ -1130,9 +1129,7 @@ class WifiManager:
                     return False
 
             WifiManager._last_recovery_result = "failed"
-            WifiManager._last_health_error = WifiManager.getHealthStatus(
-                force=True
-            ).last_error
+            WifiManager._last_health_error = WifiManager.getHealthStatus(force=True).last_error
             WifiManager.update_gatt_advertisement()
             record("completed", result="failed")
             return False
@@ -1288,10 +1285,7 @@ class WifiManager:
         known_wifis = {}
         try:
             for connection in nmcli.connection():
-                if (
-                    connection.conn_type == "wifi"
-                    and connection.name != WifiManager._conname
-                ):
+                if connection.conn_type == "wifi" and connection.name != WifiManager._conname:
                     known_wifis[connection.name] = {
                         "ssid": connection.name,
                         "type": WifiManager.getSavedWifiType(connection.name),
@@ -1375,9 +1369,7 @@ class WifiManager:
     @staticmethod
     def createNetworkManagerWifiProfile(ssid: str, wifi_type: WifiType, password=None):
         if wifi_type in {WifiType.PreSharedKey, WifiType.PSK_SAE} and not password:
-            logger.warning(
-                f"Cannot migrate Wi-Fi profile {ssid}: password is not available"
-            )
+            logger.warning(f"Cannot migrate Wi-Fi profile {ssid}: password is not available")
             return False
 
         keymgmt = None
@@ -1557,7 +1549,9 @@ class WifiManager:
             time.sleep(0.5)
         return False
 
-    def connectToWifi(credentials: WiFiCredentials, source: str = "manual") -> bool:  # noqa: C901
+    def connectToWifi(  # noqa: C901
+        credentials: WiFiCredentials, source: str = "manual"
+    ) -> bool:
 
         WifiManager.clearLastConnectionError()
 
@@ -1590,9 +1584,7 @@ class WifiManager:
 
         is_auto_connect = source == "auto"
         if is_auto_connect and WifiManager.isAutoConnectSuppressed():
-            logger.info(
-                f"Skipping auto-connect to {ssid}; manual WiFi connect is in progress"
-            )
+            logger.info(f"Skipping auto-connect to {ssid}; manual WiFi connect is in progress")
             return False
         if not is_auto_connect:
             WifiManager.suppressAutoConnect(90, f"manual connect to {ssid}")
@@ -1604,9 +1596,7 @@ class WifiManager:
             logger.info("Already connected")
             if not is_auto_connect:
                 WifiManager.persistClientModeAfterManualConnect(ssid)
-                WifiManager.suppressAutoConnect(
-                    45, f"manual connect to {ssid} completed"
-                )
+                WifiManager.suppressAutoConnect(45, f"manual connect to {ssid} completed")
             WifiManager._zeroconf.restart()
             WifiManager.update_gatt_advertisement()
             return True
@@ -1635,10 +1625,7 @@ class WifiManager:
         logger.info(networks)
 
         for network in networks:
-            if (
-                wifi_type == WifiType.PreSharedKey
-                and "WPA3" in network.security.upper()
-            ):
+            if wifi_type == WifiType.PreSharedKey and "WPA3" in network.security.upper():
                 wifi_type = WifiType.PSK_SAE
                 credentials["type"] = WifiType.PSK_SAE
                 logger.info("Network supports WPA3, switching to SAE")
@@ -1683,9 +1670,7 @@ class WifiManager:
                     e, auth_expected=auth_expected
                 )
                 WifiManager.setLastConnectionError(code, message)
-                logger.error(
-                    f"Failed to connect to wifi ({exception_metadata(e)})"
-                )
+                logger.error(f"Failed to connect to wifi ({exception_metadata(e)})")
                 WifiManager.update_gatt_advertisement()
                 return False
         if needs_fix:
@@ -1700,9 +1685,7 @@ class WifiManager:
                     e, auth_expected=auth_expected
                 )
                 WifiManager.setLastConnectionError(code, message)
-                logger.error(
-                    f"Failed to connect to wifi ({exception_metadata(e)})"
-                )
+                logger.error(f"Failed to connect to wifi ({exception_metadata(e)})")
                 WifiManager.update_gatt_advertisement()
                 return False
 
@@ -1710,9 +1693,7 @@ class WifiManager:
         if WifiManager.waitForConnection(ssid, timeout=8):
             logger.info("Successfully connected")
             if not is_auto_connect:
-                WifiManager.suppressAutoConnect(
-                    45, f"manual connect to {ssid} completed"
-                )
+                WifiManager.suppressAutoConnect(45, f"manual connect to {ssid} completed")
                 WifiManager.persistClientModeAfterManualConnect(ssid)
             WifiManager._zeroconf.restart()
             WifiManager.invalidateHealthCache()
@@ -1728,9 +1709,7 @@ class WifiManager:
                 f"Connected to {current.connection_name or 'another network'} instead of {ssid}.",
             )
             if not is_auto_connect:
-                WifiManager.suppressAutoConnect(
-                    30, f"manual connect to {ssid} was preempted"
-                )
+                WifiManager.suppressAutoConnect(30, f"manual connect to {ssid} was preempted")
         elif wifi_type == WifiType.PreSharedKey or wifi_type == WifiType.PSK_SAE:
             WifiManager.setLastConnectionError(
                 "wifi_join_failed",


### PR DESCRIPTION
## Why

Nightly's CI `lint` job has been failing since PR #365 (2026-07-10). It's two unrelated lint problems, neither tied to any feature work — this PR clears both so the branch goes green and future PRs aren't reviewed against a red baseline.

Split out of #376 (WiFi reliability) so that PR stays reviewable as pure logic.

## flake8

| File | Error | Fix |
|---|---|---|
| `ble_gatt.py` | `F821 undefined name 'o' / 'u' / 's'` | dbus-next encodes D-Bus signatures as **string annotations** (`device: "o"` object path, `passkey: "u"` uint32, `uuid: "s"` string). pyflakes reads them as forward references to undefined names. The strings can't change without breaking the D-Bus signature, so the check is suppressed on those two lines. |
| `tests/test_ble_gatt_wifi.py` | `E302 expected 2 blank lines` | Added the blank lines before `TestCredentialLogRedaction`. |
| `wifi.py` | `C901 too complex` | Black wraps `connectToWifi`'s signature across lines, which pushed the existing `# noqa: C901` off the `def` line. Moved it back onto the `def`. |

## black

Applies the repo-pinned black 26.3.1 to the 9 files that had drifted out of format: `api/wifi.py`, `ble_gatt.py`, `machine.py`, `reportable_config.py`, `sentry_privacy.py`, `timezone_manager.py`, `wifi.py`, `tests/test_ble_gatt_wifi.py`, `tests/test_reportable_config.py`.

## Safety

**Formatting only — zero behaviour change.** Every changed file was verified to parse to an identical AST before and after:

```
9 files | AST differences: NONE
```

(Black also self-verifies AST equivalence in its default safe mode; this is an independent second check.)

## Verification

- `flake8 .` → passes
- `black --check .` → 100 files unchanged
- `pytest tests/` → 155 passed

## Known unrelated failure

The `test` job fails independently on two pre-existing cases in `tests/test_bug_report_api.py` (`test_create_report_returns_machine_id_matching_report_info`, `test_incomplete_debug_shot_snapshot_keeps_active_state`). They fail identically on nightly today and are **not** touched by this PR — they need a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)