### PR TITLE
Backpropagate stable fixes to beta

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,7 @@ exclude =
     *.egg-info,
     .tox,
     .mypy_cache,
+    log_redactor, # Submodule. It owns its own lint and format config
     .pytest_cache
 
 # Set the maximum allowed line length

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        submodules: 'true'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -33,6 +35,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        submodules: 'true' # required for the log_refactor submodule
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -44,4 +48,28 @@ jobs:
       run: uv sync --group dev
 
     - name: Run tests
-      run: uv run pytest tests/ -v
+      run: uv run pytest -v
+
+  # Check the pinned log_redactor submodule commit is part of the main branch
+  # ideally main's HEAD but at list within main's branch commit history ( not an
+  # unmerged branch )
+  redactor-pin:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+
+    - name: Pinned redactor commit must be on the module's main branch
+      run: |
+        set -euo pipefail
+        SHA=$(git -C log_redactor rev-parse HEAD)
+        git -C log_redactor fetch --quiet origin main
+        if ! git -C log_redactor merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::log_redactor is pinned to $SHA, which is not on the module's main branch."
+            echo "Land the redactor change first, then bump this submodule to a merged commit."
+            exit 1
+        fi
+        echo "log_redactor pinned to $SHA (on main)"

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "default_profiles"]
 	path = default_profiles
 	url = https://github.com/MeticulousHome/ProfileDefaults
+[submodule "log_redactor"]
+	path = log_redactor
+	url = https://github.com/MeticulousHome/meticulous-log-redactor

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -46,6 +46,7 @@ RUN mkdir -p opt/meticulous-venv \
     opt/meticulous-backend/db-migrations \
     opt/meticulous-backend/profile_schema \
     opt/meticulous-backend/default_profiles/community \
+    opt/meticulous-backend/log_redactor \
     opt/meticulous-backend/sounds/default
 
 # Copy the venv from builder
@@ -67,6 +68,11 @@ COPY images/notificationImages/*.py /pkg/opt/meticulous-backend/images/notificat
 # Alembic migrations
 COPY alembic/env.py alembic/README alembic/script.py.mako /pkg/opt/meticulous-backend/alembic/
 COPY alembic/versions/*.py /pkg/opt/meticulous-backend/alembic/versions/
+
+# Code submodule. *.py rather than the directory, so the module's own test suite
+# stays out of the package. Not optional: log.py installs the redaction filter at
+# import time, so a .deb built without this fails at service start.
+COPY log_redactor/*.py /pkg/opt/meticulous-backend/log_redactor/
 
 # Data files (submodules - must be checked out before building)
 COPY profile_schema/ /pkg/opt/meticulous-backend/profile_schema/

--- a/api/base_handler.py
+++ b/api/base_handler.py
@@ -15,6 +15,19 @@ from log import MeticulousLogger
 logger = MeticulousLogger.getLogger(__name__)
 
 
+def redact_ip(ip: str) -> str:
+    """Keeps only the first two segments of an IPv4 or IPv6 address.
+
+    i.e 192.168.1.42 -> 192.168.x.xx, 2001:db8:1:2::7 -> 2001:db8:x:x:x:x
+    """
+    separator = ":" if ":" in ip else "."
+
+    return separator.join(
+        segment if index < 2 else "x" * max(len(segment), 1)
+        for index, segment in enumerate(ip.split(separator))
+    )
+
+
 class BaseHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
         # FIXME: I know this is not great, you know this isn't great. What shall we do about this?
@@ -87,7 +100,10 @@ class LocalAccessHandler(BaseHandler):
                 "127.0.0.1",
             )
         ):
-            logger.warning(f"Unauthorized access to {self.request.uri} from {remote_ip}")
+            logger.warning(
+                f"Unauthorized access to {self.request.uri} "
+                f"from remote IP: {redact_ip(remote_ip)}"
+            )
             self.set_status(403)
             self.write(
                 {

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -24,7 +24,6 @@ from config import (
     MACHINE_SERIAL_NUMBER,
     MeticulousConfig,
 )
-from reportable_config import get_reportable_config
 
 from database_models import bug_reports
 from log import MeticulousLogger
@@ -94,7 +93,7 @@ def _now_seconds() -> int:
 def _get_machine_info() -> dict[str, Any]:
     from .machine import get_machine_info
 
-    return get_reportable_config(get_machine_info())
+    return get_machine_info()
 
 
 def _new_local_id() -> str:

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -13,12 +13,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote_plus
-from hostname import HostnameManager
 
 import tornado.httpclient
 from sqlalchemy import and_, desc, func, insert, or_, select, update
 
-from config import DATABASE_URL, DEBUG_HISTORY_PATH
+from config import (
+    DATABASE_URL,
+    DEBUG_HISTORY_PATH,
+    CONFIG_SYSTEM,
+    MACHINE_SERIAL_NUMBER,
+    MeticulousConfig,
+)
 from reportable_config import get_reportable_config
 
 from database_models import bug_reports
@@ -831,7 +836,7 @@ class ReportsCreateHandler(BaseHandler):
                 "dateAndTime": now,
                 "attachments": attachments,
                 "multimedia": None,
-                "machineID": HostnameManager.generateHostname(),
+                "machineID": MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER],
                 "eventID": None,
                 "baseEventID": None,
                 "ticket": None,

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -19,6 +19,8 @@ import tornado.httpclient
 from sqlalchemy import and_, desc, func, insert, or_, select, update
 
 from config import DATABASE_URL, DEBUG_HISTORY_PATH
+from reportable_config import get_reportable_config
+
 from database_models import bug_reports
 from log import MeticulousLogger
 from shot_database import ShotDataBase
@@ -87,7 +89,7 @@ def _now_seconds() -> int:
 def _get_machine_info() -> dict[str, Any]:
     from .machine import get_machine_info
 
-    return get_machine_info()
+    return get_reportable_config(get_machine_info())
 
 
 def _new_local_id() -> str:

--- a/api/history.py
+++ b/api/history.py
@@ -42,7 +42,7 @@ class LastDebugFileHandler(BaseHandler):
         except FileNotFoundError as e:
             self._handle_error(404, str(e))
         except Exception as e:
-            logger.error(f"Unexpected error getting last debug file: {e}")
+            logger.error(f"Unexpected error getting last debug file: {type(e).__name__}")
             self._handle_error(500, "Internal server error")
 
     def _find_latest_debug_file(self):
@@ -80,7 +80,7 @@ class CompressedDebugHistoryHandler(BaseHandler):
             result = await compress_debug_file()
             self.redirect(f"{last_version_path}/history/debug/{result}")
         except Exception as e:
-            logger.error(f"Error compressing debug file: {e}")
+            logger.error(f"Error compressing debug file: {type(e).__name__}")
             self.set_status(500)
             self.write({"status": "error", "error": "Internal server error"})
 
@@ -266,7 +266,7 @@ class ShotRatingHandler(BaseHandler):
             rating = ShotDataBase.get_shot_rating(shot_id)
             self.write({"shot_id": shot_id, "rating": rating})
         except Exception as e:
-            logger.error(f"Error getting shot rating: {e}")
+            logger.error(f"Error getting shot rating: {type(e).__name__}")
             self.set_status(500)
             self.write({"status": "error", "error": "Internal server error"})
 
@@ -301,7 +301,7 @@ class ShotRatingHandler(BaseHandler):
             self.set_status(400)
             self.write({"status": "error", "error": "Invalid JSON"})
         except Exception as e:
-            logger.error(f"Error updating shot rating: {e}")
+            logger.error(f"Error updating shot rating: {type(e).__name__}")
             self.set_status(500)
             self.write({"status": "error", "error": "Internal server error"})
 

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -208,7 +208,7 @@ class DeleteProfileHandler(BaseHandler):
         logger.info("Deletion for profile " + profile_id)
         data = ProfileManager.delete_profile(profile_id, change_id=change_id)
         if data:
-            logger.info(f"Deleted profile: {data}")
+            logger.info(f"Deleted profile: {profile_id}")
             self.write(data)
         else:
             self.set_status(404)

--- a/api/wifi.py
+++ b/api/wifi.py
@@ -12,7 +12,7 @@ from config import (
     WIFI_MODE_AP,
     WIFI_MODE_CLIENT,
 )
-from wifi import WifiManager, WifiType
+from wifi import WifiManager, WifiType, redact_ssid
 from ble_gatt import PORT
 
 from .base_handler import BaseHandler
@@ -123,12 +123,12 @@ class WiFiConfigHandler(BaseHandler):
         except json.JSONDecodeError as e:
             self.set_status(400)
             self.write("Invalid JSON")
-            logger.warning(f"Failed to parse passed JSON: {e}", stack_info=False)
+            logger.warning(f"Failed to parse passed JSON: {type(e).__name__}", stack_info=False)
 
         except Exception as e:
             self.set_status(400)
             self.write("Failed to write config")
-            logger.warning("Failed to accept passed config: ", exc_info=e, stack_info=True)
+            logger.warning(f"Failed to accept passed config: {type(e).__name__}")
 
 
 class WiFiListHandler(BaseHandler):
@@ -154,7 +154,8 @@ class WiFiListHandler(BaseHandler):
                         networks[s.ssid] = formated.copy()
                     else:
                         # Dont overwrite the in_use network
-                        logger.info(f"{exists}, {exists.get('signal')}")
+                        redacted_ssid = redact_ssid(s.ssid)
+                        logger.info(f"{redacted_ssid}, {exists.get('signal')}")
                         if exists["in_use"]:
                             continue
                         if s.signal > exists["signal"]:
@@ -163,8 +164,10 @@ class WiFiListHandler(BaseHandler):
             return response
         except Exception as e:
             self.set_status(400)
-            self.write({"status": "error", "error": f"failed to fetch wifi list: {e}"})
-            logger.warning("Failed to fetch / format wifi list: ", exc_info=e, stack_info=True)
+            self.write(
+                {"status": "error", "error": f"failed to fetch wifi list: {type(e).__name__}"}
+            )
+            logger.warning(f"Failed to fetch / format wifi list: {type(e).__name__}")
 
     async def get(self):
         loop = asyncio.get_event_loop()
@@ -187,8 +190,10 @@ class WiFiConnectHandler(BaseHandler):
                 self.write({"status": "error", "error": "failed to conect to wifi"})
         except Exception as e:
             self.set_status(400)
-            self.write({"status": "error", "error": f"failed to conect to wifi: {e}"})
-            logger.warning("Failed to connect: ", exc_info=e, stack_info=True)
+            self.write(
+                {"status": "error", "error": f"failed to conect to wifi: {type(e).__name__}"}
+            )
+            logger.warning(f"Failed to connect: {type(e).__name__}")
 
 
 class WiFiDeleteHandler(BaseHandler):
@@ -204,8 +209,10 @@ class WiFiDeleteHandler(BaseHandler):
                 self.write({"status": "error", "error": "failed to delete unknown wifi"})
         except Exception as e:
             self.set_status(400)
-            self.write({"status": "error", "error": f"failed to delete wifi: {e}"})
-            logger.warning("Failed to connect: ", exc_info=e, stack_info=True)
+            self.write(
+                {"status": "error", "error": f"failed to delete wifi: {type(e).__name__}"}
+            )
+            logger.warning(f"Failed to delete wifi: {type(e).__name__}")
 
 
 API.register_handler(APIVersion.V1, r"/wifi/config", WiFiConfigHandler),

--- a/api/wifi.py
+++ b/api/wifi.py
@@ -61,9 +61,7 @@ class WiFiQRHandler(BaseHandler):
         config = WifiManager.getCurrentConfig()
         qr_contents: str = ""
         if config.is_hotspot():
-            ssid = self.escape_wifi_qr_value(
-                MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME]
-            )
+            ssid = self.escape_wifi_qr_value(MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME])
             password = self.escape_wifi_qr_value(
                 MeticulousConfig[CONFIG_WIFI][WIFI_AP_PASSWORD]
             )
@@ -149,9 +147,7 @@ class WiFiConfigHandler(BaseHandler):
                     )
                     return
 
-            config = await asyncio.get_event_loop().run_in_executor(
-                None, self.getWifiConfig
-            )
+            config = await asyncio.get_event_loop().run_in_executor(None, self.getWifiConfig)
             self.write(config)
         except json.JSONDecodeError as e:
             self.set_status(400)

--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -311,8 +311,7 @@ class GATTServer:
                     )
                 except Exception as cleanup_error:
                     logger.warning(
-                        "Could not clean up failed BLE advertisement: "
-                        f"{cleanup_error}"
+                        "Could not clean up failed BLE advertisement: " f"{cleanup_error}"
                     )
             raise
 

--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -24,7 +24,7 @@ from config import CONFIG_WIFI, WIFI_MODE, WIFI_MODE_AP, MeticulousConfig
 from hostname import HostnameManager
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
-from wifi import WifiManager, WifiWpaPskCredentials
+from wifi import WifiManager, WifiWpaPskCredentials, redact_ssid
 
 logger = MeticulousLogger.getLogger(__name__)
 
@@ -53,11 +53,11 @@ class NoInputNoOutputAgent(ServiceInterface):
         logger.info("[BLE Agent] Released")
 
     @method()
-    def RequestConfirmation(self, device: "o", passkey: "u"):
+    def RequestConfirmation(self, device: "o", passkey: "u"):  # noqa: F821
         logger.info(f"[BLE Agent] Auto-confirming pairing for {device}")
 
     @method()
-    def AuthorizeService(self, device: "o", uuid: "s"):
+    def AuthorizeService(self, device: "o", uuid: "s"):  # noqa: F821
         logger.info(f"[BLE Agent] Authorizing service {uuid} for {device}")
 
     @method()
@@ -81,7 +81,8 @@ async def register_pairing_agent():
         logger.info("[BLE Agent] Registered NoInputNoOutput pairing agent")
         return bus  # keep reference alive
     except Exception as e:
-        logger.warning(f"[BLE Agent] Failed to register pairing agent: {e}")
+        logger.warning(f"[BLE Agent] Failed to register pairing agent: {type(e).__name__}")
+
 
 # FIXME Remove once the tornado server logic is in its own class
 PORT = int(os.getenv("PORT", "8080"))
@@ -362,28 +363,19 @@ class GATTServer:
                 and msg.body[0] == "org.bluez.Device1"
             ):
                 changed_props = msg.body[1]
+                # Only the device name is reported; the DBus object path and the
+                # Address property both embed the peer's MAC address.
+                name = changed_props.get("Name", None)
+                name = name.value if name else "unknown"
                 if "Connected" in changed_props:
                     connected = changed_props["Connected"].value
-                    device_path = msg.path
-                    # Try to extract device address and name from changed properties
-                    address = changed_props.get("Address", None)
-                    if address:
-                        address = address.value
-                    name = changed_props.get("Name", None)
-                    if name:
-                        name = name.value
-                    device_info = f"path={device_path}"
-                    if address:
-                        device_info += f", address={address}"
-                    if name:
-                        device_info += f", name={name}"
                     if connected:
-                        logger.info(f"BLE client connected ({device_info})")
+                        logger.info(f"BLE client connected (name={name})")
                     else:
-                        logger.info(f"BLE client disconnected ({device_info})")
+                        logger.info(f"BLE client disconnected (name={name})")
                 if "DisconnectReason" in changed_props:
                     reason = changed_props["DisconnectReason"].value
-                    logger.info(f"BLE disconnect reason: {reason} (path={msg.path})")
+                    logger.info(f"BLE disconnect reason: {reason} (name={name})")
 
         bus.add_message_handler(_on_dbus_message)
         await bus.call(
@@ -481,7 +473,7 @@ class GATTServer:
             return None
 
         try:
-            logger.info(f"Connecting to '{ssid}' with password: '{passwd}'")
+            logger.info(f"Connecting to '{redact_ssid(ssid)}' with password: '{'*'*4}'")
             credentials = WifiWpaPskCredentials(ssid=ssid, password=passwd)
             if WifiManager.connectToWifi(credentials):
                 networkConfig = WifiManager.getCurrentConfig()

--- a/config.py
+++ b/config.py
@@ -350,6 +350,8 @@ class MeticulousConfigDict(dict):
 
     def save(self):
         sentry_sdk.set_context("config", get_reportable_config(self))
+        # invalidate log redactor known ssid data and refetch that, in case they have changed
+        MeticulousLogger.invalidate_redaction_values()
 
         Path(self.__path).parent.mkdir(parents=True, exist_ok=True)
         with open(self.__path, "w") as f:
@@ -382,3 +384,40 @@ class MeticulousConfigDict(dict):
 MeticulousConfig = MeticulousConfigDict(
     os.path.join(CONFIG_PATH, "config.yml"), DefaultConfiguration_V1
 )
+
+
+def _redaction_values():
+    """Values the log redaction filter should strip from any log message.
+
+    The shape-based rules cannot catch a bare network name in an arbitrary
+    message -- "Found known WIFI HomeNet. Connecting" has nothing to anchor on --
+    but the backend does not have to guess at them the way the watcher does.
+
+    APName is deliberately absent. wifi.py overwrites it on every init with
+    HostnameManager.generateDeviceName(), so it is machine-derived rather than
+    user-typed, and it embeds the same machine_name as the hostname. Redacting it
+    here would tokenise it in backend lines while kernel, avahi and
+    NetworkManager lines keep it in the clear, which helps nobody.
+    """
+    wifi = MeticulousConfig.get(CONFIG_WIFI) or {}
+    system = MeticulousConfig.get(CONFIG_SYSTEM) or {}
+    known_wifis = wifi.get(WIFI_KNOWN_WIFIS) or {}
+
+    ssids = list(known_wifis.keys())
+
+    credentials = [
+        wifi.get(WIFI_AP_PASSWORD),
+        system.get(ROOT_PASSWORD),
+        system.get(HTTP_AUTH_KEY),
+    ]
+    for entry in known_wifis.values():
+        # Legacy entries are the bare password; current ones are a dict.
+        if isinstance(entry, str):
+            credentials.append(entry)
+        elif isinstance(entry, dict):
+            credentials.append(entry.get("password"))
+
+    return ssids, credentials
+
+
+MeticulousLogger.set_redaction_value_provider(_redaction_values)

--- a/config.py
+++ b/config.py
@@ -298,7 +298,9 @@ class MeticulousConfigDict(dict):
 
         _config_logger.info("Config initialized")
 
-        cs = yaml.dump(self.copy(), default_flow_style=False, allow_unicode=True)
+        cs = yaml.dump(
+            get_reportable_config(self.copy()), default_flow_style=False, allow_unicode=True
+        )
         for line in cs.split("\n"):
             _config_logger.debug(f"CONF: {line}")
 
@@ -334,7 +336,7 @@ class MeticulousConfigDict(dict):
                     _config_logger.info("Successfully loaded config from disk")
                     self.__configError = False
                 except Exception as e:
-                    _config_logger.warning(f"Failed to load config: {e}")
+                    _config_logger.warning(f"Failed to load config: {type(e).__name__}")
                     basename, extension = os.path.splitext(self.__path)
                     backup_path = (
                         basename

--- a/esp_serial/esp_tool_wrapper.py
+++ b/esp_serial/esp_tool_wrapper.py
@@ -185,7 +185,7 @@ class ESPToolWrapper:
         try:
             esptool.write_flash(esp, args)
         except Exception as e:
-            logger.error(f"Failed to flash: {e}")
+            logger.error(f"Failed to flash: {type(e).__name__}")
             failure = e
         sys.stdout = _stdout
 

--- a/imager.py
+++ b/imager.py
@@ -306,7 +306,9 @@ class DiscImager:
             logger.warning(f'system date set to {new_date.strftime("%Y-%m-%d %H:%M:%S")}')
 
         except Exception as e:
-            logger.warning(f"could not set system dat to ${ROOTFS_ARCHIVE} birth date: {e}")
+            logger.warning(
+                f"could not set system dat to ${ROOTFS_ARCHIVE} birth date: {type(e).__name__}"
+            )
 
         tar_cmd = f"tar -x -C {mountpoint}"
         pv = subprocess.Popen(

--- a/log.py
+++ b/log.py
@@ -5,11 +5,30 @@ import os
 import shutil
 import coloredlogs
 
+from log_redaction_filter import LogRedactionFilter
+
 LOGLEVEL = os.getenv("LOGLEVEL", "DEBUG").upper()
 logformat = "%(asctime)s %(name)s %(levelname)s %(message)s"
 coloredlogs.install(fmt=logformat, level=LOGLEVEL, milliseconds=True)
 
 logging.basicConfig()
+
+# One instance, deliberately with no switch to turn it off: a privacy control
+# that can be disabled is a liability. Installed in two places, because neither
+# alone is enough:
+#
+#   * On every logger built here, which is every first-party logger. A logger
+#     filter runs inside Logger.handle() before callHandlers(), so it is the only
+#     placement that reaches Sentry's LoggingIntegration deterministically.
+#   * On the root logger's handlers, which catch third-party loggers
+#     (dbus_next, aiohttp, zeroconf, alembic) that never come through getLogger.
+#
+# A record that takes both routes is marked and only worked once.
+_REDACTION_FILTER = LogRedactionFilter()
+
+for _root_handler in logging.getLogger().handlers:
+    if _REDACTION_FILTER not in _root_handler.filters:
+        _root_handler.addFilter(_REDACTION_FILTER)
 
 
 class MeticulousLogger:
@@ -34,12 +53,16 @@ class MeticulousLogger:
 
     def _createHandler():
         MeticulousLogger._sh = logging.StreamHandler()
+        MeticulousLogger._sh.addFilter(_REDACTION_FILTER)
 
     def getLogger(name):
         if MeticulousLogger._sh is None:
             MeticulousLogger._createHandler()
 
         logger = logging.getLogger(name=name)
+
+        if _REDACTION_FILTER not in logger.filters:
+            logger.addFilter(_REDACTION_FILTER)
 
         # This will lead to double logging on some systems, so it is disabled by default
         if MeticulousLogger.FORCE_STDOUT_LOG and MeticulousLogger._sh not in logger.handlers:
@@ -48,9 +71,28 @@ class MeticulousLogger:
         return logger
 
     @staticmethod
+    def set_redaction_value_provider(provider):
+        """Give the redaction filter access to live config values.
+
+        Called by config.py once its singleton exists. See
+        LogRedactionFilter.set_value_provider.
+        """
+        _REDACTION_FILTER.set_value_provider(provider)
+
+    @staticmethod
+    def invalidate_redaction_values():
+        """Drop the filter's cached view of the config. Called from config.save()."""
+        _REDACTION_FILTER.invalidate()
+
+    @staticmethod
     def add_logging_handler(handler: logging.Handler, logger_name: str | None = None):
         if handler is None:
             return
+        # The shot-debug handler writes log text into files that ship inside the
+        # bug report, so it has to be filtered even if it is ever attached to a
+        # logger that did not come through getLogger.
+        if _REDACTION_FILTER not in handler.filters:
+            handler.addFilter(_REDACTION_FILTER)
         if logger_name is not None:
             target_logger = logging.Logger.manager.loggerDict.get(logger_name, None)
             if isinstance(target_logger, logging.Logger):

--- a/log_redaction_filter.py
+++ b/log_redaction_filter.py
@@ -1,0 +1,242 @@
+"""Redact personal data out of log records before any handler sees them.
+
+The watcher redacts at *read* time: it filters the journal when a bug report is
+built. That leaves the plaintext on the device -- in the journal on disk, in the
+shot-debug log files that ship inside the report, and in the Sentry events that
+LoggingIntegration builds from logger.error() calls. This filter closes that
+window by redacting at *emit* time, using the same rules and the same
+/root/.redaction_key, so a value gets the same token in both services.
+
+Installed at logger level by log.py. logging.Logger.handle() runs logger filters
+before callHandlers(), and sentry_sdk's LoggingIntegration patches callHandlers
+(sentry_sdk/integrations/logging.py), so mutating the record here reaches the
+journal, every handler, and Sentry's logentry.message -- in that order, always.
+
+This is a backstop, not the primary defence. Values are still kept out of log
+messages at the call site (reportable_config.get_reportable_config for the config
+dump, wifi.redact_ssid, base_handler.redact_ip, TimezoneManager.redact_timezone,
+`type(e).__name__` instead of `{e}`). Those cover classes no regex can reach --
+an allowlist over structured config, IPv4 addresses, MACs embedded in DBus object
+paths with underscores. Do not remove them because this filter exists.
+"""
+
+import logging
+import os
+import re
+import threading
+import time
+import traceback
+
+from log_redactor import (
+    DEFAULT_KEY_PATH,
+    MIN_SWEEP_LEN,
+    REDACTED,
+    RE_ALREADY_DONE,
+    RedactionState,
+    load_key,
+    pseudonym,
+    redact,
+)
+
+# Set on records this filter has already processed. The filter is installed both
+# on loggers and on the root handlers so third-party loggers are covered too, and
+# a record that took both routes must not be worked twice.
+_MARK = "_meticulous_redacted"
+
+# Upper bound on how stale the config-seeded sweep may be. Rebuilding walks the
+# config, and DEBUG logging is hot enough that doing so per record would show up.
+_REFRESH_INTERVAL_SECONDS = 2.0
+
+_SSID = "SSID"
+_CRED = "CRED"
+
+# The service runs as root on the machine and shares the watcher's key, which is
+# what makes the tokens match. Overridable for tests and dev hosts, which are not
+# root and would otherwise have every record replaced by the failure placeholder.
+# Not a secret: the key is per-device and reveals nothing about any other device.
+KEY_PATH = os.getenv("REDACTION_KEY_PATH", DEFAULT_KEY_PATH)
+
+_key_cache = {}
+_key_cache_lock = threading.Lock()
+
+
+def load_cached_key(path=None):
+    """Load the per-device key once per path, per process.
+
+    load_key() reads the file and chmods it on every call. Both this filter and
+    wifi.redact_ssid() are on hot paths -- a scan result per network, a log record
+    per line -- so the result is cached. Raises on failure; callers decide what
+    that means for them.
+    """
+    path = KEY_PATH if path is None else path
+    with _key_cache_lock:
+        key = _key_cache.get(path)
+        if key is None:
+            key = _key_cache[path] = load_key(path)
+        return key
+
+
+def reset_key_cache():
+    """Forget cached keys. For tests that swap the key file underneath."""
+    with _key_cache_lock:
+        _key_cache.clear()
+
+
+class LogRedactionFilter(logging.Filter):
+    """Rewrites record.msg through the shared redaction rules.
+
+    Two sources of coverage:
+
+    * The rules in log_redactor, which match on shape -- credentials in key:value
+      form, MACs, IPv6, anchored SSID phrasings, IANA timezones.
+    * A literal sweep of values read from the live config. This is the part the
+      watcher cannot do. Shape rules cannot catch a bare SSID in an arbitrary
+      message ("Found known WIFI HomeNet. Connecting"), and at emit time there is
+      no surrounding anchored line to learn one from. The backend does not have
+      to guess: it holds the real known-network names and credentials.
+    """
+
+    def __init__(self, key_path=None):
+        super().__init__()
+        key_path = KEY_PATH if key_path is None else key_path
+        self._key_path = key_path
+        # Reentrant on purpose. Handler.handle() runs filters before taking the
+        # handler's I/O lock, so nothing else serialises access to this state --
+        # and the value provider reads the config, so if anything on that path
+        # ever logs, a plain Lock would deadlock the caller instead of just
+        # producing a slightly odd nested redaction.
+        self._lock = threading.RLock()
+        self._state = RedactionState()
+        self._value_provider = None
+        self._sweep_pattern = None
+        self._sweep_kinds = {}
+        self._sweep_deadline = 0.0
+
+    # -- configuration -----------------------------------------------------
+
+    def set_value_provider(self, provider):
+        """Register a callable returning (ssids, credentials) from live config.
+
+        log.py cannot import config.py -- config.py imports log -- so the
+        dependency is inverted: config registers itself here once its singleton
+        exists. Until then the filter runs on shape rules alone.
+        """
+        with self._lock:
+            self._value_provider = provider
+            self._sweep_deadline = 0.0
+
+    def invalidate(self):
+        """Drop the cached sweep. Called when the config is saved."""
+        with self._lock:
+            self._sweep_deadline = 0.0
+
+    # -- sweep -------------------------------------------------------------
+
+    def _rebuild_sweep_locked(self):
+        self._sweep_pattern = None
+        self._sweep_kinds = {}
+
+        if self._value_provider is None:
+            self._sweep_deadline = time.monotonic() + _REFRESH_INTERVAL_SECONDS
+            return
+
+        # Deliberately before the deadline is extended: if the provider raises,
+        # the deadline stays in the past so the next record retries and fails
+        # again. Extending it first would mean one placeholder followed by two
+        # seconds of records redacted by the shape rules alone -- a bare network
+        # name would go to the journal in the clear with nothing to show for it.
+        ssids, credentials = self._value_provider()
+
+        kinds = {}
+        for value in credentials:
+            if self._is_sweepable(value):
+                kinds[str(value)] = _CRED
+        for value in ssids:
+            # A credential that happens to equal a network name stays a
+            # credential: destroyed outright rather than pseudonymised.
+            if self._is_sweepable(value) and str(value) not in kinds:
+                kinds[str(value)] = _SSID
+
+        if kinds:
+            # One alternation rather than a substitution per value: a wifi scan in
+            # a dense building can put dozens of names in the config, and this
+            # runs on every log record. Longest first so a name that contains a
+            # shorter one wins at the same position.
+            alternatives = "|".join(
+                re.escape(value) for value in sorted(kinds, key=len, reverse=True)
+            )
+            self._sweep_pattern = re.compile(rf"(?<![\w-]){alternatives}(?![\w-])")
+            self._sweep_kinds = kinds
+
+        self._sweep_deadline = time.monotonic() + _REFRESH_INTERVAL_SECONDS
+
+    @staticmethod
+    def _is_sweepable(value):
+        if not isinstance(value, str) or not value:
+            return False
+        # Same floor the rules use for learned SSIDs: anything shorter collides
+        # with ordinary log text. Short values are still caught by the shape
+        # rules when they appear in a key:value or anchored form.
+        if len(value) < MIN_SWEEP_LEN:
+            return False
+        return not RE_ALREADY_DONE.match(value)
+
+    def _sweep_locked(self, text, key):
+        if time.monotonic() >= self._sweep_deadline:
+            self._rebuild_sweep_locked()
+        if self._sweep_pattern is None:
+            return text
+
+        def _replace(match):
+            value = match.group(0)
+            if self._sweep_kinds.get(value) == _SSID:
+                return pseudonym(_SSID, value, key)
+            return REDACTED
+
+        return self._sweep_pattern.sub(_replace, text)
+
+    # -- filtering ---------------------------------------------------------
+
+    def _redact(self, text, key):
+        with self._lock:
+            redacted, _ = redact(text, key, state=self._state)
+            return self._sweep_locked(redacted, key)
+
+    def filter(self, record):
+        if record.__dict__.get(_MARK):
+            return True
+
+        try:
+            key = load_cached_key(self._key_path)
+
+            record.msg = self._redact(record.getMessage(), key)
+            record.args = None
+
+            if record.exc_info and not record.exc_text:
+                # Render it here so the traceback text can be redacted. A
+                # Formatter reuses exc_text and skips formatting exc_info, so
+                # every handler gets the redacted rendering. exc_info itself is
+                # left in place: Sentry builds its exception from it, and
+                # scrubbing the structured event is sentry_privacy's job.
+                rendered = "".join(traceback.format_exception(*record.exc_info))
+                if rendered.endswith("\n"):
+                    rendered = rendered[:-1]
+                record.exc_text = self._redact(rendered, key)
+
+            if record.stack_info:
+                record.stack_info = self._redact(record.stack_info, key)
+        except Exception as exception:
+            # A filter that raises propagates into whatever called logger.info(),
+            # so failure can never be loud. Keep the fact that something was
+            # logged and where, drop the content. Never log from in here.
+            record.msg = (
+                f"<redaction failed for a {record.name!r} record: "
+                f"{type(exception).__name__}>"
+            )
+            record.args = None
+            record.exc_info = None
+            record.exc_text = None
+            record.stack_info = None
+
+        record.__dict__[_MARK] = True
+        return True

--- a/machine.py
+++ b/machine.py
@@ -644,9 +644,7 @@ class Machine:
                         MeticulousConfig[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     )
                     Machine.setPartialRetraction(backend_partial_retraction)
-                    backend_auto_purge = bool(
-                        MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE]
-                    )
+                    backend_auto_purge = bool(MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE])
                     Machine.setAutoPurgeAfterShot(backend_auto_purge)
 
                     if (
@@ -888,8 +886,7 @@ class Machine:
         json_string = json.dumps(json_obj)
         json_data = "json\n" + json_string + "\x03"
 
-        logger.debug("JSON to stream to the machine:")
-        logger.debug(json_data)
+        logger.debug("streaming JSON to the machine")
 
         json_hash = hashlib.md5(json_data[5:-1].encode("utf-8")).hexdigest()
 

--- a/ota.py
+++ b/ota.py
@@ -241,7 +241,7 @@ class UpdateManager:
         except FileNotFoundError:
             logger.warning(f"{REPO_INFO_FILE} file not found")
         except Exception as e:
-            logger.error(f"Error reading repository info: {e}")
+            logger.error(f"Error reading repository info: {type(e).__name__}")
 
         return UpdateManager.REPO_INFO
 

--- a/profiles.py
+++ b/profiles.py
@@ -345,9 +345,10 @@ class ProfileManager:
         return {"profile": profile, "change_id": change_id}
 
     def get_profile(id):
-        logger.info(f"Serving profile: {id}")
-        logger.info(ProfileManager._known_profiles.get(id))
-        return ProfileManager._known_profiles.get(id)
+        profile = ProfileManager._known_profiles.get(id)
+        profile_md5 = ProfileManager._get_payload_md5(profile)
+        logger.info(f"Serving profile: {id} - MD5: {profile_md5}")
+        return profile
 
     def load_profile_and_send(id):
         profile = ProfileManager._known_profiles.get(id)
@@ -367,8 +368,8 @@ class ProfileManager:
             data["id"] = str(uuid.uuid4())
 
         ProfileManager.handle_image(data)
-
-        logger.info(f"Recieved data: {data} {type(data)}")
+        data_md5 = ProfileManager._get_payload_md5(data)
+        logger.info(f"Recieved {type(data)} data with MD5: {data_md5}")
 
         logger.info("processing simplified profile")
         errors = ProfileManager.validate_profile(data)
@@ -397,7 +398,7 @@ class ProfileManager:
             )
 
         logger.info(
-            f"simplified profile streamed to ESP32: data={json.dumps(preprocessed_profile)}"
+            f"simplified profile streamed to ESP32: data MD5={ProfileManager._get_payload_md5(preprocessed_profile)}"
         )
 
         Machine.send_json_with_hash(preprocessed_profile)
@@ -674,6 +675,13 @@ class ProfileManager:
             for chunk in iter(lambda: f.read(4096), b""):
                 hash_md5.update(chunk)
         return hash_md5.hexdigest()
+
+    def _get_payload_md5(payload):
+        # Used to reference a profile in the logs without dumping its contents,
+        # which carry the author / author_id fields.
+        if payload is None:
+            return None
+        return hashlib.md5(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
     def validate_profile(data):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,5 @@ dev = [
 [tool.black]
 line-length = 96
 target-version = ["py311"]
+# log_redactor submodule formats itself
+extend-exclude = "/log_redactor/"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
-testpaths = tests
+# log_redactor is a submodule (github.com/MeticulousHome/meticulous-log-redactor).
+# Running its suite here, rather than keeping a copy of it, is what verifies the
+# commit this repo has pinned: test_redaction_contract.py asserts the exact token
+# strings, so a bad bump fails the backend's own test run instead of surfacing as
+# a bug report whose SSID tokens disagree with the watcher's.
+testpaths = tests log_redactor/tests
 pythonpath = .

--- a/reportable_config.py
+++ b/reportable_config.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, Callable
 
-
 Validator = Callable[[Any], bool]
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUN_COMMAND="pytest tests/ -v"
+RUN_COMMAND="pytest -v"
 
 if [ "$(uname)" = "Darwin" ]; then
     echo "macOS detected, running tests inside Docker..."

--- a/sentry_privacy.py
+++ b/sentry_privacy.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from reportable_config import get_reportable_config
 
-
 _SENSITIVE_KEY_PARTS = {
     "password",
     "passwd",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ os.environ.setdefault("CONFIG_PATH", "/tmp/meticulous-test/config")
 os.environ.setdefault("LOG_PATH", "/tmp/meticulous-test/logs")
 os.environ.setdefault("HISTORY_PATH", "/tmp/meticulous-test/history")
 os.environ.setdefault("DEBUG_HISTORY_PATH", "/tmp/meticulous-test/history/debug")
+# The real redaction key lives in /root, which the test runner cannot read.
+# Without this every record would come out as the failure placeholder.
+os.makedirs("/tmp/meticulous-test", exist_ok=True)
+os.environ.setdefault("REDACTION_KEY_PATH", "/tmp/meticulous-test/.redaction_key")
 
 # Add the backend root to sys.path so imports like "from config import ..."
 # work without installing the package.

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -412,9 +412,7 @@ class TestCredentialLogRedaction:
         assert "ssid_bytes=" in logged
         assert "password_bytes=" in logged
 
-    def test_wifi_connect_exception_does_not_log_exception_credentials(
-        self, mock_wifi_manager
-    ):
+    def test_wifi_connect_exception_does_not_log_exception_credentials(self, mock_wifi_manager):
         password = "SENTINEL-EXCEPTION-SECRET"
         mock_wifi_manager.connectToWifi.side_effect = RuntimeError(
             f"NetworkManager rejected {password}"

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -389,6 +389,8 @@ class TestAdvertisementUpdateRecovery:
             bus.unexport.assert_any_call(failed_advertisement.path, failed_advertisement)
         finally:
             server.loop.close()
+
+
 class TestCredentialLogRedaction:
     @staticmethod
     def logged_output():

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -426,8 +426,11 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
     monkeypatch.setattr(report_module, "_new_local_id", lambda: "local-test-id")
     monkeypatch.setattr(report_module, "_now_seconds", lambda: 1)
     monkeypatch.setattr(report_module, "_fetch_report_files", fake_fetch_report_files)
-    monkeypatch.setattr(
-        report_module.HostnameManager, "generateHostname", lambda: "machine-test-id"
+    monkeypatch.setattr(ShotDataBase, "statistics", lambda: {})
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
     )
 
     handler = FakeHandler()

--- a/tests/test_log_redaction_filter.py
+++ b/tests/test_log_redaction_filter.py
@@ -1,0 +1,360 @@
+"""Tests for the emit-time redaction filter.
+
+Everything here drives a real logging.Logger, because the properties worth
+testing are properties of the logging machinery: what a handler downstream
+actually receives, that the caller never sees an exception, and that the record
+is already clean by the time callHandlers() runs.
+"""
+
+import logging
+import os
+import tempfile
+import time
+import unittest
+
+from log_redaction_filter import LogRedactionFilter, reset_key_cache
+from log_redactor import pseudonym
+
+TEST_KEY = bytes(range(32))
+
+
+class CapturingHandler(logging.Handler):
+    """Records what reached a handler, and what the record looked like there."""
+
+    def __init__(self):
+        super().__init__()
+        self.messages = []
+        self.records = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+        self.records.append(record)
+
+
+class FilterTestCase(unittest.TestCase):
+    counter = 0
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.key_path = os.path.join(self.tempdir.name, ".redaction_key")
+        with open(self.key_path, "wb") as handle:
+            handle.write(TEST_KEY)
+        reset_key_cache()
+        self.addCleanup(reset_key_cache)
+
+        self.filter = LogRedactionFilter(key_path=self.key_path)
+
+        # A uniquely named logger per test: logging.Logger objects are process
+        # global, so a shared name would leak filters between tests.
+        FilterTestCase.counter += 1
+        self.logger = logging.getLogger(f"redaction_test_{FilterTestCase.counter}")
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.propagate = False
+        self.logger.addFilter(self.filter)
+        self.handler = CapturingHandler()
+        self.logger.addHandler(self.handler)
+
+    def seed(self, ssids=(), credentials=()):
+        self.filter.set_value_provider(lambda: (list(ssids), list(credentials)))
+
+    @property
+    def last(self):
+        return self.handler.messages[-1]
+
+
+class ShapeRuleTests(FilterTestCase):
+    def test_credential_key_value_is_redacted(self):
+        self.logger.info("CONF:   root_password: s3cr3tvalue")
+        self.assertEqual(self.last, "CONF:   root_password: [REDACTED]")
+
+    def test_mac_and_ipv6_become_tokens(self):
+        self.logger.info("authenticate with aa:bb:cc:dd:ee:ff via fe80::1122:3344:5566:7788")
+        self.assertNotIn("aa:bb:cc:dd:ee:ff", self.last)
+        self.assertNotIn("fe80::1122:3344:5566:7788", self.last)
+        self.assertRegex(self.last, r"with \[MAC_[0-9a-f]{8}\] via \[IPV6_[0-9a-f]{8}\]")
+
+    def test_anchored_ssid_is_redacted_without_seeding(self):
+        self.logger.info("Trying to associate with SSID 'HomeNet'")
+        self.assertNotIn("HomeNet", self.last)
+
+    def test_timezone_is_coarsened(self):
+        self.logger.info("Changed time zone to 'America/Mexico_City' (CST).")
+        self.assertEqual(self.last, "Changed time zone to 'America/*****' (*****).")
+
+
+class ConfigSeededSweepTests(FilterTestCase):
+    def test_bare_known_ssid_is_redacted(self):
+        """The case no shape rule can reach -- wifi.py's tryAutoConnect message.
+
+        There is no anchored phrasing here and nothing for the watcher's literal
+        sweep to have learned from, so this only works because the backend seeds
+        the sweep from its own config.
+        """
+        self.seed(ssids=["HomeNet"])
+        self.logger.info("Found known WIFI HomeNet. Connecting")
+        self.assertEqual(
+            self.last,
+            f"Found known WIFI {pseudonym('SSID', 'HomeNet', TEST_KEY)}. Connecting",
+        )
+
+    def test_bare_credential_is_destroyed_not_pseudonymised(self):
+        self.seed(credentials=["sup3rs3cret"])
+        self.logger.info("nmcli failed: connection needs sup3rs3cret to activate")
+        self.assertNotIn("sup3rs3cret", self.last)
+        self.assertIn("[REDACTED]", self.last)
+
+    def test_credential_wins_when_a_value_is_both(self):
+        """A password that happens to equal a network name is still a password."""
+        self.seed(ssids=["sharedvalue"], credentials=["sharedvalue"])
+        self.logger.info("saw sharedvalue in the wild")
+        self.assertEqual(self.last, "saw [REDACTED] in the wild")
+
+    def test_longest_value_wins_at_the_same_position(self):
+        self.seed(ssids=["Coffee", "Coffee Bar"])
+        self.logger.info("joined Coffee Bar now")
+        self.assertEqual(self.last, f"joined {pseudonym('SSID', 'Coffee Bar', TEST_KEY)} now")
+
+    def test_short_values_are_not_swept(self):
+        """Below the sweep floor, a name collides with ordinary log text."""
+        self.seed(ssids=["up"])
+        self.logger.info("link is up and running")
+        self.assertEqual(self.last, "link is up and running")
+
+    def test_word_boundaries_are_respected(self):
+        self.seed(ssids=["Home"])
+        self.logger.info("Homeless value and Home itself")
+        self.assertIn("Homeless", self.last)
+        self.assertNotIn(" Home itself", self.last)
+
+    def test_invalidate_picks_up_a_new_network(self):
+        networks = ["FirstNet"]
+        self.filter.set_value_provider(lambda: (list(networks), []))
+        self.logger.info("saw FirstNet and SecondNet")
+        self.assertNotIn("FirstNet", self.last)
+        self.assertIn("SecondNet", self.last)
+
+        networks.append("SecondNet")
+        self.filter.invalidate()
+        self.logger.info("saw FirstNet and SecondNet")
+        self.assertNotIn("SecondNet", self.last)
+
+    def test_sweep_refreshes_without_an_explicit_invalidate(self):
+        """The cache has a ceiling, so a missed invalidate cannot persist."""
+        networks = []
+        self.filter.set_value_provider(lambda: (list(networks), []))
+        self.logger.info("nothing yet")
+
+        networks.append("LateNet")
+        # Reach past the refresh interval rather than sleeping through it.
+        self.filter._sweep_deadline = time.monotonic() - 1
+        self.logger.info("saw LateNet")
+        self.assertNotIn("LateNet", self.last)
+
+    def test_provider_failure_does_not_leak_or_raise(self):
+        def broken():
+            raise RuntimeError("config unavailable")
+
+        self.filter.set_value_provider(broken)
+        self.logger.info("Found known WIFI HomeNet. Connecting")
+        self.assertNotIn("HomeNet", self.last)
+        self.assertIn("redaction failed", self.last)
+
+    def test_provider_failure_keeps_failing_instead_of_degrading(self):
+        """A broken provider must not fall back to shape rules alone.
+
+        The refresh deadline used to be extended before the provider was called,
+        so one record failed loudly and every record for the next two seconds was
+        redacted by the shape rules only -- which put a bare network name in the
+        journal in the clear, with nothing in the log to say so.
+        """
+
+        def broken():
+            raise RuntimeError("config unavailable")
+
+        self.filter.set_value_provider(broken)
+        for _ in range(3):
+            self.logger.info("Found known WIFI HomeNet. Connecting")
+
+        for message in self.handler.messages:
+            self.assertNotIn("HomeNet", message)
+            self.assertIn("redaction failed", message)
+
+    def test_recovery_after_a_provider_failure(self):
+        state = {"broken": True}
+
+        def provider():
+            if state["broken"]:
+                raise RuntimeError("config unavailable")
+            return ["HomeNet"], []
+
+        self.filter.set_value_provider(provider)
+        self.logger.info("Found known WIFI HomeNet. Connecting")
+        self.assertIn("redaction failed", self.last)
+
+        state["broken"] = False
+        self.logger.info("Found known WIFI HomeNet. Connecting")
+        self.assertNotIn("HomeNet", self.last)
+        self.assertNotIn("redaction failed", self.last)
+
+
+class RecordShapeTests(FilterTestCase):
+    def test_percent_args_are_formatted_then_redacted(self):
+        self.seed(ssids=["HomeNet"])
+        self.logger.info("connecting to %s on %s", "HomeNet", "wlan0")
+        self.assertNotIn("HomeNet", self.last)
+        self.assertIn("on wlan0", self.last)
+        # Left un-consumed, a handler would try to re-apply them and raise.
+        self.assertIsNone(self.handler.records[-1].args)
+
+    def test_non_string_msg_survives(self):
+        self.logger.info({"root_password": "s3cr3tvalue"})
+        self.assertNotIn("s3cr3tvalue", self.last)
+
+    def test_multiline_record_is_redacted_line_by_line(self):
+        self.logger.info("first: aa:bb:cc:dd:ee:ff\nsecond: root_password: s3cr3tvalue")
+        self.assertNotIn("aa:bb:cc:dd:ee:ff", self.last)
+        self.assertNotIn("s3cr3tvalue", self.last)
+        self.assertEqual(len(self.last.splitlines()), 2)
+
+    def test_traceback_text_is_redacted(self):
+        self.seed(ssids=["HomeNet"])
+        try:
+            raise ValueError("could not reach HomeNet at aa:bb:cc:dd:ee:ff")
+        except ValueError:
+            self.logger.error("wifi failed", exc_info=True)
+
+        record = self.handler.records[-1]
+        rendered = logging.Formatter().format(record)
+        self.assertNotIn("HomeNet", rendered)
+        self.assertNotIn("aa:bb:cc:dd:ee:ff", rendered)
+        self.assertIn("ValueError", rendered)
+        # exc_info is left in place so sentry_privacy still gets an exception to
+        # work with; exc_text is what every Formatter renders.
+        self.assertIsNotNone(record.exc_info)
+
+    def test_stack_info_is_redacted(self):
+        self.seed(credentials=["s3cr3tvalue"])
+        self.logger.info("saving s3cr3tvalue", stack_info=True)
+        record = self.handler.records[-1]
+        self.assertNotIn("s3cr3tvalue", record.stack_info)
+        self.assertNotIn("s3cr3tvalue", logging.Formatter().format(record))
+
+    def test_output_is_idempotent(self):
+        self.seed(ssids=["HomeNet"])
+        self.logger.info("Found known WIFI HomeNet. Connecting")
+        once = self.last
+        self.logger.info(once)
+        self.assertEqual(self.last, once)
+
+    def test_an_already_redacted_record_is_not_reprocessed(self):
+        """redact_ssid() output must survive the filter unchanged."""
+        token = pseudonym("SSID", "HomeNet", TEST_KEY)
+        self.logger.info(f"Connecting to wifi: {token}")
+        self.assertEqual(self.last, f"Connecting to wifi: {token}")
+
+
+class KnownWifisContinuationTests(FilterTestCase):
+    def test_yaml_block_spanning_records_is_tracked(self):
+        """The config dump is one log record per line.
+
+        Nothing else carries block state across calls, so this is what the
+        RedactionState in log_redactor exists for. Records from another logger are
+        interleaved to prove the tracking is not confused by them.
+        """
+        other = logging.getLogger("redaction_test_interleaved")
+        other.setLevel(logging.DEBUG)
+        other.propagate = False
+        other.addFilter(self.filter)
+        other.addHandler(self.handler)
+
+        self.logger.debug("CONF: wifi:")
+        other.info("an unrelated record arrives mid-dump")
+        self.logger.debug("CONF:   KnownWifis:")
+        other.info("and another one")
+        self.logger.debug("CONF:     HomeNet:")
+        self.logger.debug("CONF:       password: s3cr3tvalue")
+        self.logger.debug("CONF:     OfficeNet:")
+
+        joined = "\n".join(self.handler.messages)
+        self.assertNotIn("HomeNet", joined)
+        self.assertNotIn("OfficeNet", joined)
+        self.assertNotIn("s3cr3tvalue", joined)
+        # The attribute level is not an SSID -- the key itself must survive.
+        self.assertIn("password: [REDACTED]", joined)
+
+
+class FailureModeTests(FilterTestCase):
+    def test_unreadable_key_yields_a_placeholder_and_never_raises(self):
+        broken = LogRedactionFilter(key_path=os.path.join(self.tempdir.name, "nope/key"))
+        self.logger.removeFilter(self.filter)
+        self.logger.addFilter(broken)
+
+        self.logger.info("Connecting to wifi: HomeNet with aa:bb:cc:dd:ee:ff")
+
+        self.assertNotIn("HomeNet", self.last)
+        self.assertNotIn("aa:bb:cc:dd:ee:ff", self.last)
+        self.assertIn("redaction failed", self.last)
+        # The logger name survives, which is the point of the placeholder.
+        self.assertIn(self.logger.name, self.last)
+
+    def test_failure_drops_traceback_text(self):
+        broken = LogRedactionFilter(key_path=os.path.join(self.tempdir.name, "nope/key"))
+        self.logger.removeFilter(self.filter)
+        self.logger.addFilter(broken)
+
+        try:
+            raise ValueError("could not reach HomeNet")
+        except ValueError:
+            self.logger.error("wifi failed", exc_info=True)
+
+        record = self.handler.records[-1]
+        self.assertIsNone(record.exc_info)
+        self.assertNotIn("HomeNet", logging.Formatter().format(record))
+
+
+class OrderingTests(FilterTestCase):
+    def test_record_is_clean_before_handlers_run(self):
+        """Sentry's LoggingIntegration patches Logger.callHandlers and reads the
+        record after the handlers have run. A logger-level filter runs inside
+        Logger.handle() before callHandlers(), so if the record is already clean
+        when a handler sees it, it is clean for Sentry too."""
+        self.seed(ssids=["HomeNet"])
+        self.logger.info("Found known WIFI HomeNet. Connecting")
+
+        record = self.handler.records[-1]
+        self.assertNotIn("HomeNet", record.msg)
+        self.assertNotIn("HomeNet", record.getMessage())
+
+
+class ThroughputTests(FilterTestCase):
+    def test_throughput_budget(self):
+        """DEBUG logging is hot on this device -- log_all_sensor_messages makes it
+        hotter. A future rule must not quietly make this the bottleneck."""
+        self.seed(
+            ssids=[f"Network{index}" for index in range(40)],
+            credentials=[f"secret{index}" for index in range(10)],
+        )
+        message = (
+            "tornado.access INFO 304 GET /api/v1/settings/ (10.10.0.79) 4.10ms "
+            "state=idle sensor=1234 profile=default"
+        )
+        # Warm the sweep so compilation is not counted.
+        self.logger.info(message)
+
+        iterations = 4000
+        started = time.perf_counter()
+        for _ in range(iterations):
+            self.logger.info(message)
+        elapsed = time.perf_counter() - started
+
+        rate = iterations / elapsed
+        self.assertGreater(
+            rate,
+            20000,
+            f"redaction throughput fell to {rate:.0f} records/s",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reportable_config.py
+++ b/tests/test_reportable_config.py
@@ -4,11 +4,7 @@ from reportable_config import get_reportable_config
 def _leaf_paths(value, prefix=()):
     if not isinstance(value, dict):
         return {prefix}
-    return {
-        path
-        for key, item in value.items()
-        for path in _leaf_paths(item, (*prefix, key))
-    }
+    return {path for key, item in value.items() for path in _leaf_paths(item, (*prefix, key))}
 
 
 def test_reportable_config_is_allowlist_only_and_does_not_mutate_input():

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -31,6 +31,29 @@ class TimezoneManager:
     _MAX_TIMEZONE_FETCH_ATTEMPTS: int = 5
 
     @staticmethod
+    def redact_timezone(timezone: str | None):
+        """Shows only the broader timezone zone
+
+        i.e America/Mexico_City -> America/******
+        """
+        if not timezone:
+            return ""
+
+        tz_split = str(timezone).split("/")
+
+        return tz_split[0] + ("/*****" if len(tz_split) > 1 else "")
+
+    @staticmethod
+    def _redact_timezone_in(text, timezone: str | None) -> str:
+        """Strips a raw timezone out of free-form text (command lines, stdout,
+        stderr, exception messages) so it cannot leak through error paths.
+        """
+        if not text or not timezone:
+            return str(text)
+
+        return str(text).replace(str(timezone), TimezoneManager.redact_timezone(timezone))
+
+    @staticmethod
     def init():
         TimezoneManager.validate_timezones_json()
         TimezoneManager.__system_timezone = TimezoneManager.get_system_timezone()
@@ -44,7 +67,7 @@ class TimezoneManager:
                 MeticulousConfig[CONFIG_USER][TIME_ZONE] = target_timezone
             else:
                 logger.warning(
-                    f"user config and system timezones confilct, updating system config to {MeticulousConfig[CONFIG_USER][TIME_ZONE]}"
+                    f"user config and system timezones confilct, updating system config to {TimezoneManager.redact_timezone(MeticulousConfig[CONFIG_USER][TIME_ZONE])}"
                 )
 
             # Try to set the system_timezone to the user specified tz
@@ -53,7 +76,7 @@ class TimezoneManager:
             except TimezoneManagerError as e:
                 # If fails, set the system_timezone as the user timezone and report the error
                 logger.error(
-                    f"failed to set system TZ, syncing user TZ with system to {TimezoneManager.__system_timezone}. Error: {e}"
+                    f"failed to set system TZ, syncing user TZ with system to {TimezoneManager.redact_timezone(TimezoneManager.__system_timezone)}. Error: {e}"
                 )
                 MeticulousConfig[CONFIG_USER][TIME_ZONE] = TimezoneManager.__system_timezone
             finally:
@@ -88,14 +111,19 @@ class TimezoneManager:
                 error = f"[ Out:{cmd_result.stdout} | Err: {cmd_result.stderr} ]"
                 raise Exception(error)
 
-            logger.info(f"new system time zone: {TimezoneManager.get_system_timezone()}")
+            logger.info(
+                f"new system time zone: {TimezoneManager.redact_timezone(TimezoneManager.get_system_timezone())}"
+            )
         except subprocess.CalledProcessError as e:
-            message = (
-                f"Error setting system time zone: {e} [ Out: {e.stdout} | Err: {e.stderr} ]"
+            message = TimezoneManager._redact_timezone_in(
+                f"Error setting system time zone: {e} [ Out: {e.stdout} | Err: {e.stderr} ]",
+                new_timezone,
             )
             raise TimezoneManagerError(message)
         except Exception as e:
-            message = f"Error setting system time zone: {e}"
+            message = TimezoneManager._redact_timezone_in(
+                f"Error setting system time zone: {e}", new_timezone
+            )
             logger.error(message)
             raise TimezoneManagerError(message)
 
@@ -251,7 +279,10 @@ class TimezoneManager:
     def tz_background_update():
         tz_config = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
         if tz_config == "automatic" and not TimezoneManager.__system_synced:
-            if TimezoneManager.__timezone_fetch_attempts >= TimezoneManager._MAX_TIMEZONE_FETCH_ATTEMPTS:
+            if (
+                TimezoneManager.__timezone_fetch_attempts
+                >= TimezoneManager._MAX_TIMEZONE_FETCH_ATTEMPTS
+            ):
                 return
             TimezoneManager.__timezone_fetch_attempts += 1
             try:

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -75,8 +75,15 @@ class TimezoneManager:
                 TimezoneManager.set_system_timezone(target_timezone)
             except TimezoneManagerError as e:
                 # If fails, set the system_timezone as the user timezone and report the error
+                # Redact the timezones on the exception message
+                error_text = TimezoneManager._redact_timezone_in(e, target_timezone)
+                error_text = TimezoneManager._redact_timezone_in(
+                    error_text, TimezoneManager.__system_timezone
+                )
                 logger.error(
-                    f"failed to set system TZ, syncing user TZ with system to {TimezoneManager.redact_timezone(TimezoneManager.__system_timezone)}. Error: {e}"
+                    "failed to set system TZ, syncing user TZ with system to "
+                    f"{TimezoneManager.redact_timezone(TimezoneManager.__system_timezone)}"
+                    f". Error: {error_text}"
                 )
                 MeticulousConfig[CONFIG_USER][TIME_ZONE] = TimezoneManager.__system_timezone
             finally:

--- a/wifi.py
+++ b/wifi.py
@@ -29,6 +29,8 @@ from timezone_manager import TimezoneManager
 from machine import Machine
 
 from log import MeticulousLogger
+from log_redaction_filter import load_cached_key
+from log_redactor import pseudonym
 from named_thread import NamedThread
 
 logger = MeticulousLogger.getLogger(__name__)
@@ -41,14 +43,29 @@ ZEROCONF_OVERWRITE = os.getenv("ZEROCONF_OVERWRITE", "")
 
 
 def redact_ssid(ssid: str):
+    """Pseudonymise a network name for logging.
+
+    Returns the same token the emit-time redaction filter and the watcher produce
+    for that network -- all three derive it from the same per-device key. That is
+    what lets an occurrence in a backend log line be matched up with the same
+    network in the NetworkManager line beside it.
+
+    This used to keep the first two characters. A prefix is still a fragment of a
+    unique identifier, and it broke that correlation for no benefit.
+
+    Kept as a call-site helper rather than left to the filter because a scan
+    result is a *neighbour's* network name: it is not in our config, so the filter
+    has nothing to seed a sweep with and no anchored phrasing to learn it from.
+    """
     ssid = str(ssid)
-    ssid_len = len(ssid)
-    chars_to_show = min(2, ssid_len)
+    if not ssid:
+        return ssid
 
-    if ssid_len == 2:
-        chars_to_show = 1
-
-    return f"{ssid[0:chars_to_show]}{'*'*(ssid_len - chars_to_show)}"
+    try:
+        return pseudonym("SSID", ssid, load_cached_key())
+    except Exception:
+        # Never leak just because the key is unavailable.
+        return "*" * len(ssid)
 
 
 class WifiType(str, Enum):
@@ -276,7 +293,7 @@ class WifiManager:
                         break
 
                 if network.ssid in previousNetworks:
-                    logger.info(f"Found known WIFI {network.ssid}. Connecting")
+                    logger.info(f"Found known WIFI {redact_ssid(network.ssid)}. Connecting")
                     credentials = previousNetworks[network.ssid]
                     # Mark WiFi connection if the security type has changed or is missing
                     if type(credentials) is dict:
@@ -288,7 +305,8 @@ class WifiManager:
                                 != WifiType.from_nmcli_security(network.security).value
                             ):
                                 logger.warning(
-                                    f"known WI-FI ({network.ssid}) has changed its security, forgetting connection"
+                                    f"known WI-FI ({redact_ssid(network.ssid)}) has changed"
+                                    " its security, forgetting connection"
                                 )
                                 WifiManager.deleteWifi(network.ssid)
                                 continue

--- a/wifi.py
+++ b/wifi.py
@@ -214,8 +214,7 @@ class WifiHealthStatus:
             "ap_active": self.ap_active,
             "degraded": self.degraded,
             "last_error": self.last_error,
-            "message": self.message
-            or WifiManager.getHealthErrorMessage(self.last_error),
+            "message": self.message or WifiManager.getHealthErrorMessage(self.last_error),
             "last_recovery_action": self.last_recovery_action,
             "last_recovery_result": self.last_recovery_result,
         }
@@ -340,9 +339,7 @@ class WifiManager:
                 "invalid_credentials",
                 "Incorrect Wi-Fi password. Please check it and try again.",
             )
-        if auth_expected and any(
-            marker in lower_error for marker in auth_activation_markers
-        ):
+        if auth_expected and any(marker in lower_error for marker in auth_activation_markers):
             return (
                 "wifi_join_failed",
                 "Could not join this Wi-Fi network. Check the password and try again, or move closer to the router.",
@@ -374,8 +371,7 @@ class WifiManager:
     def healthCacheIsValid(config: WifiSystemConfig = None):
         if (
             WifiManager._cached_health is None
-            or time.time() - WifiManager._health_cache_time
-            >= WifiManager._health_cache_ttl
+            or time.time() - WifiManager._health_cache_time >= WifiManager._health_cache_ttl
         ):
             return False
 
@@ -499,9 +495,7 @@ class WifiManager:
                         break
 
                 if network.ssid in known_networks:
-                    logger.info(
-                        f"Found known WIFI {redact_ssid(network.ssid)}. Connecting"
-                    )
+                    logger.info(f"Found known WIFI {redact_ssid(network.ssid)}. Connecting")
                     credentials = {
                         "ssid": network.ssid,
                         "type": WifiType.from_nmcli_security(network.security),
@@ -555,9 +549,7 @@ class WifiManager:
             )
             if add_result is None or add_result.returncode != 0:
                 stderr = (
-                    add_result.stderr.strip()
-                    if add_result is not None
-                    else "command failed"
+                    add_result.stderr.strip() if add_result is not None else "command failed"
                 )
                 stdout = add_result.stdout.strip() if add_result is not None else ""
                 last_error = f"channel={channel}: {stderr or stdout or 'connection add failed'}"
@@ -614,7 +606,9 @@ class WifiManager:
                     else "command failed"
                 )
                 stdout = modify_result.stdout.strip() if modify_result is not None else ""
-                last_error = f"channel={channel}: {stderr or stdout or 'connection modify failed'}"
+                last_error = (
+                    f"channel={channel}: {stderr or stdout or 'connection modify failed'}"
+                )
                 logger.error(f"Starting hotspot failed: {last_error}")
                 WifiManager.deleteConnectionProfile(WifiManager._conname)
                 time.sleep(1)
@@ -639,9 +633,7 @@ class WifiManager:
                 last_error = f"channel={channel}: hotspot did not become active"
                 logger.error(f"Starting hotspot failed: {last_error}")
             else:
-                stderr = (
-                    result.stderr.strip() if result is not None else "command failed"
-                )
+                stderr = result.stderr.strip() if result is not None else "command failed"
                 stdout = result.stdout.strip() if result is not None else ""
                 last_error = f"channel={channel}: {stderr or stdout or 'unknown error'}"
                 logger.error(f"Starting hotspot failed: {last_error}")
@@ -908,9 +900,11 @@ class WifiManager:
                 last_error,
                 WifiManager._last_recovery_action,
                 WifiManager._last_recovery_result,
-                "Hotspot active. Connect your phone or computer to the machine's Wi-Fi network."
-                if ap_active
-                else "",
+                (
+                    "Hotspot active. Connect your phone or computer to the machine's Wi-Fi network."
+                    if ap_active
+                    else ""
+                ),
             )
             WifiManager._cached_health = health
             WifiManager._health_cache_time = time.time()
@@ -1108,7 +1102,10 @@ class WifiManager:
                 ]
             else:
                 steps = [
-                    ("restart_connection", lambda: WifiManager.restartActiveConnection(current)),
+                    (
+                        "restart_connection",
+                        lambda: WifiManager.restartActiveConnection(current),
+                    ),
                     ("restart_wifi_radio", WifiManager.restartWifiRadio),
                     ("driver_in_band_reset", WifiManager.driverInBandReset),
                     ("restart_wifi_service", WifiManager.restartWifiService),
@@ -1158,9 +1155,7 @@ class WifiManager:
                     return False
 
             WifiManager._last_recovery_result = "failed"
-            WifiManager._last_health_error = WifiManager.getHealthStatus(
-                force=True
-            ).last_error
+            WifiManager._last_health_error = WifiManager.getHealthStatus(force=True).last_error
             WifiManager.update_gatt_advertisement()
             record("completed", result="failed")
             return False
@@ -1173,7 +1168,9 @@ class WifiManager:
             logger.warning("No active WiFi connection to restart")
             return
 
-        logger.warning(f"Restarting active WiFi connection: {config.connection_name}")
+        logger.warning(
+            f"Restarting active WiFi connection: {redact_ssid(config.connection_name)}"
+        )
         try:
             nmcli.connection.down(config.connection_name)
         except Exception as e:
@@ -1316,10 +1313,7 @@ class WifiManager:
         known_wifis = {}
         try:
             for connection in nmcli.connection():
-                if (
-                    connection.conn_type == "wifi"
-                    and connection.name != WifiManager._conname
-                ):
+                if connection.conn_type == "wifi" and connection.name != WifiManager._conname:
                     known_wifis[connection.name] = {
                         "ssid": connection.name,
                         "type": WifiManager.getSavedWifiType(connection.name),
@@ -1354,7 +1348,10 @@ class WifiManager:
             if "802-1x" in key_mgmt:
                 return WifiType.Enterprise.value
         except Exception as e:
-            logger.warning(f"Failed to read saved Wi-Fi type for {ssid}: {e}")
+            logger.warning(
+                "Failed to read saved Wi-Fi type for "
+                f"{redact_ssid(ssid)} ({exception_metadata(e)})"
+            )
         return WifiType.PreSharedKey.value
 
     @staticmethod
@@ -1404,7 +1401,8 @@ class WifiManager:
     def createNetworkManagerWifiProfile(ssid: str, wifi_type: WifiType, password=None):
         if wifi_type in {WifiType.PreSharedKey, WifiType.PSK_SAE} and not password:
             logger.warning(
-                f"Cannot migrate Wi-Fi profile {ssid}: password is not available"
+                "Cannot migrate Wi-Fi profile "
+                f"{redact_ssid(ssid)}: password is not available"
             )
             return False
 
@@ -1467,7 +1465,7 @@ class WifiManager:
             WifiManager.deleteConnectionProfile(ssid)
             return False
 
-        logger.info(f"Migrated Wi-Fi profile {ssid} into NetworkManager")
+        logger.info(f"Migrated Wi-Fi profile {redact_ssid(ssid)} into NetworkManager")
         return True
 
     @staticmethod
@@ -1585,7 +1583,9 @@ class WifiManager:
             time.sleep(0.5)
         return False
 
-    def connectToWifi(credentials: WiFiCredentials, source: str = "manual") -> bool:  # noqa: C901
+    def connectToWifi(  # noqa: C901
+        credentials: WiFiCredentials, source: str = "manual"
+    ) -> bool:
 
         WifiManager.clearLastConnectionError()
 
@@ -1624,9 +1624,7 @@ class WifiManager:
             )
             return False
         if not is_auto_connect:
-            WifiManager.suppressAutoConnect(
-                90, f"manual connect to {redact_ssid(ssid)}"
-            )
+            WifiManager.suppressAutoConnect(90, f"manual connect to {redact_ssid(ssid)}")
 
         logger.info(f"Connecting to wifi: {redact_ssid(ssid)}")
 
@@ -1663,13 +1661,10 @@ class WifiManager:
             networks = cached_networks or WifiManager.scanForNetworks(
                 timeout=8, target_network_ssid=ssid
             )
-        logger.info(networks)
+        logger.info(f"Found {len(networks)} candidate Wi-Fi networks")
 
         for network in networks:
-            if (
-                wifi_type == WifiType.PreSharedKey
-                and "WPA3" in network.security.upper()
-            ):
+            if wifi_type == WifiType.PreSharedKey and "WPA3" in network.security.upper():
                 wifi_type = WifiType.PSK_SAE
                 credentials["type"] = WifiType.PSK_SAE
                 logger.info("Network supports WPA3, switching to SAE")
@@ -1682,7 +1677,7 @@ class WifiManager:
                 nmcli.device.wifi_connect(ssid, None)
             elif wifi_type == WifiType.PreSharedKey or wifi_type == WifiType.PSK_SAE:
                 if password is None and has_known_profile:
-                    logger.info(f"Connecting to known Wi-Fi profile: {ssid}")
+                    logger.info(f"Connecting to known Wi-Fi profile: {redact_ssid(ssid)}")
                     nmcli.connection.up(ssid, wait=12)
                 elif password is None:
                     WifiManager.setLastConnectionError(
@@ -1714,9 +1709,7 @@ class WifiManager:
                     e, auth_expected=auth_expected
                 )
                 WifiManager.setLastConnectionError(code, message)
-                logger.error(
-                    f"Failed to connect to wifi ({exception_metadata(e)})"
-                )
+                logger.error(f"Failed to connect to wifi ({exception_metadata(e)})")
                 WifiManager.update_gatt_advertisement()
                 return False
         if needs_fix:
@@ -1731,9 +1724,7 @@ class WifiManager:
                     e, auth_expected=auth_expected
                 )
                 WifiManager.setLastConnectionError(code, message)
-                logger.error(
-                    f"Failed to connect to wifi ({exception_metadata(e)})"
-                )
+                logger.error(f"Failed to connect to wifi ({exception_metadata(e)})")
                 WifiManager.update_gatt_advertisement()
                 return False
 
@@ -1742,7 +1733,7 @@ class WifiManager:
             logger.info("Successfully connected")
             if not is_auto_connect:
                 WifiManager.suppressAutoConnect(
-                    45, f"manual connect to {ssid} completed"
+                    45, f"manual connect to {redact_ssid(ssid)} completed"
                 )
                 WifiManager.persistClientModeAfterManualConnect(ssid)
             WifiManager._zeroconf.restart()
@@ -1760,7 +1751,7 @@ class WifiManager:
             )
             if not is_auto_connect:
                 WifiManager.suppressAutoConnect(
-                    30, f"manual connect to {ssid} was preempted"
+                    30, f"manual connect to {redact_ssid(ssid)} was preempted"
                 )
         elif wifi_type == WifiType.PreSharedKey or wifi_type == WifiType.PSK_SAE:
             WifiManager.setLastConnectionError(

--- a/wifi.py
+++ b/wifi.py
@@ -40,6 +40,17 @@ nmcli.set_lang("C.UTF-8")
 ZEROCONF_OVERWRITE = os.getenv("ZEROCONF_OVERWRITE", "")
 
 
+def redact_ssid(ssid: str):
+    ssid = str(ssid)
+    ssid_len = len(ssid)
+    chars_to_show = min(2, ssid_len)
+
+    if ssid_len == 2:
+        chars_to_show = 1
+
+    return f"{ssid[0:chars_to_show]}{'*'*(ssid_len - chars_to_show)}"
+
+
 class WifiType(str, Enum):
     Open = "OPEN"
     PreSharedKey = "PSK"
@@ -163,9 +174,7 @@ class WifiManager:
     def init():
         logger.info("Wifi initializing")
         if ZEROCONF_OVERWRITE != "":
-            logger.info(
-                f"Overwriting network configuration due to ZEROCONF_OVERWRITE={ZEROCONF_OVERWRITE}"
-            )
+            logger.info("Overwriting network configuration due to ZEROCONF_OVERWRITE")
 
         try:
             nmcli.device.show_all()
@@ -321,7 +330,7 @@ class WifiManager:
                 password=MeticulousConfig[CONFIG_WIFI][WIFI_AP_PASSWORD],
             )
         except Exception as e:
-            logger.error(f"Starting hotspot failed: {e}")
+            logger.error(f"Starting hotspot failed: {type(e).__name__}")
         WifiManager._zeroconf.restart()
 
     def stopHotspot():
@@ -390,7 +399,7 @@ class WifiManager:
 
     @staticmethod
     def fixWifiConnection(ssid, wifi_type: WifiType):
-        logger.info(f"Fixing wifi connection for {ssid} with type {wifi_type}")
+        logger.info(f"Fixing wifi connection for {redact_ssid(ssid)}")
 
         keymgmt = None
         match wifi_type:
@@ -435,10 +444,12 @@ class WifiManager:
         if ssid is None:
             return False
 
-        logger.info(f"Connecting to wifi: {ssid}")
+        logger.info(f"Connecting to wifi: {redact_ssid(ssid)}")
 
         networks = WifiManager.scanForNetworks(timeout=30, target_network_ssid=ssid)
-        logger.info(networks)
+        for network in networks:
+            logger.info(f"Found network: {redact_ssid(network.ssid)}")
+
         if len(networks) > 0:
             if len([x for x in networks if x.in_use]) > 0:
                 logger.info("Already connected")


### PR DESCRIPTION
## Summary
- Forward stable bug-report sanitization and application-wide log redaction into beta.
- Preserve beta's newer Wi-Fi recovery and connection behavior while pseudonymizing SSIDs and sanitizing exceptions across the resolved paths.
- Carry the shared log-redactor submodule and its focused tests into beta.
- Update the inherited bug-report test to assert the stable serial-based `machineID` contract.

## Validation
- `python -m pytest tests/test_ble_gatt_wifi.py tests/test_wifi_repair.py tests/test_bug_report_api.py::test_create_report_returns_machine_id_matching_report_info -v`: 29 passed.
- `black --check` on the four resolved/formatted files.
- `flake8` passes for the repository code and excludes local validation environments and submodules.
- `git diff --check`
- Latest complete Linux CI run before the formatting follow-up: 200 passed, 1 failed on the existing redactor RSS budget (136668 KiB vs 131072 KiB); the new run is pending.
- Verified `origin/stable` is an ancestor of the PR head.