### PR TITLE
Add issue time report collection

### DIFF
--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -48,7 +48,6 @@ DEBUG_ARCHIVE_DIR = "debug"
 MAX_DEBUG_SHOTS = 10
 ALLOWED_DRAFT_UPDATE_KEYS = {
     "description",
-    "dateAndTime",
     "baseEventID",
     "ticket",
     "multimedia",
@@ -160,7 +159,8 @@ def _row_to_report_info(row) -> dict[str, Any]:
     log_files = [name for name in (row.logFiles or "").split(",") if name]
     return {
         "description": row.description,
-        "dateAndTime": row.issueTime,
+        "dateAndTime": row.creationTime,
+        "issueTime": row.issueTime,
         "attachments": {
             "debugFiles": {"automatic": log_files},
             "machineInfo": bool(row.machineInfo),
@@ -294,8 +294,19 @@ def _find_debug_file(file_name: str) -> Path | None:
     return matches[0] if matches else None
 
 
+def _debug_file_timestamp(path: Path) -> int | None:
+    try:
+        day = path.parent.name
+        clock = path.name.split(".", 1)[0]
+        return int(datetime.strptime(f"{day} {clock}", "%Y-%m-%d %H:%M:%S").timestamp())
+    except ValueError:
+        return None
+
+
 def _select_debug_files(
-    limit: int = MAX_DEBUG_SHOTS, reference_time: int | None = None
+    limit: int = MAX_DEBUG_SHOTS,
+    start_time: int | None = None,
+    end_time: int | None = None,
 ) -> tuple[list[Path], list[str]]:
     debug_root = DEBUG_HISTORY_ROOT
     if not debug_root.exists():
@@ -303,7 +314,7 @@ def _select_debug_files(
 
     selected = []
     errors = []
-    if reference_time is None:
+    if start_time is None or end_time is None:
         directories = sorted(
             [path for path in debug_root.iterdir() if path.is_dir()],
             key=lambda path: path.name,
@@ -316,37 +327,20 @@ def _select_debug_files(
                     if len(selected) >= limit:
                         return selected, errors
     else:
-        ref_dt = datetime.fromtimestamp(reference_time)
-        if (
-            ref_dt.hour == 0
-            and ref_dt.minute == 0
-            and ref_dt.second == 0
-            and ref_dt.microsecond == 0
-        ):
-            date_dir = debug_root.joinpath(ref_dt.strftime("%Y-%m-%d"))
-            candidates = (
-                sorted(date_dir.iterdir(), key=lambda item: item.name, reverse=True)
-                if date_dir.exists()
-                else []
+        timestamped_files = [
+            (timestamp, path)
+            for path in debug_root.rglob("*")
+            if path.is_file() and (timestamp := _debug_file_timestamp(path)) is not None
+        ]
+        timestamped_files.sort(key=lambda item: (item[0], str(item[1])), reverse=True)
+        selected.extend(
+            path for timestamp, path in timestamped_files if start_time <= timestamp <= end_time
+        )
+        if len(selected) < limit:
+            selected.extend(
+                path for timestamp, path in timestamped_files if timestamp < start_time
             )
-            selected.extend([path for path in candidates if path.is_file()][:limit])
-        else:
-            end_ts = min(_now_seconds(), reference_time + (3 * 60 * 60))
-            start_ts = end_ts - (24 * 60 * 60)
-            for path in debug_root.rglob("*"):
-                if not path.is_file():
-                    continue
-                try:
-                    day = path.parent.name
-                    clock = path.name.split(".", 1)[0]
-                    file_dt = datetime.strptime(f"{day} {clock}", "%Y-%m-%d %H:%M:%S")
-                    file_ts = int(file_dt.timestamp())
-                except ValueError:
-                    continue
-                if start_ts <= file_ts <= end_ts:
-                    selected.append(path)
-            selected.sort(key=lambda item: (item.parent.name, item.name), reverse=True)
-            selected = selected[:limit]
+        selected = selected[:limit]
 
     if len(selected) < limit:
         errors.append(
@@ -376,10 +370,12 @@ def _machine_is_emulated() -> bool:
     return bool(Machine.emulated)
 
 
-def _emulated_machine_logs(reference_time: int | None = None) -> str:
+def _emulated_machine_logs(start_time: int | None = None, end_time: int | None = None) -> str:
     timestamp = datetime.now(timezone.utc).isoformat()
     reference_text = (
-        f"reference_time={reference_time}" if reference_time is not None else "latest"
+        f"start_time={start_time}, end_time={end_time}"
+        if start_time is not None and end_time is not None
+        else "latest"
     )
     return (
         f"{timestamp} INFO meticulous-backend Emulated machine logs generated "
@@ -399,15 +395,17 @@ def _emulated_machine_status() -> str:
     )
 
 
-async def _fetch_machine_logs(reference_time: int | None = None) -> str:
+async def _fetch_machine_logs(
+    start_time: int | None = None, end_time: int | None = None
+) -> str:
     if _machine_is_emulated():
-        return _emulated_machine_logs(reference_time)
+        return _emulated_machine_logs(start_time, end_time)
 
     url = WATCHER_LOGS_URL
-    if reference_time is not None:
-        ceiling = min(_now_seconds(), reference_time + (3 * 60 * 60))
-        start_hours = max(0, int((time.time() - (ceiling - 24 * 60 * 60) + 3599) // 3600))
-        end_hours = max(0, int((time.time() - ceiling) // 3600))
+    if start_time is not None and end_time is not None:
+        collection_time = _now_seconds()
+        start_hours = max(0, (collection_time - start_time + 3599) // 3600)
+        end_hours = max(0, (collection_time - end_time) // 3600)
         separator = "&" if "?" in url else "?"
         url = f"{url}{separator}since={start_hours}&until={end_hours}"
     client = tornado.httpclient.AsyncHTTPClient()
@@ -424,7 +422,12 @@ async def _fetch_machine_status() -> str:
     return response.body.decode("utf-8", errors="replace")
 
 
-async def _fetch_report_files(draft_dir: Path) -> FetchResult:
+async def _fetch_report_files(
+    draft_dir: Path,
+    start_time: int | None = None,
+    end_time: int | None = None,
+    capture_active_debug_shot: bool = True,
+) -> FetchResult:
     result = FetchResult()
     draft_dir.mkdir(parents=True, exist_ok=True)
 
@@ -440,7 +443,9 @@ async def _fetch_report_files(draft_dir: Path) -> FetchResult:
 
     try:
         machine_logs_path = draft_dir.joinpath(MACHINE_LOGS_NAME)
-        machine_logs_path.write_text(await _fetch_machine_logs(), encoding="utf-8")
+        machine_logs_path.write_text(
+            await _fetch_machine_logs(start_time, end_time), encoding="utf-8"
+        )
         result.files[MACHINE_LOGS_NAME] = machine_logs_path
         result.machine_logs = True
     except Exception as exc:
@@ -455,17 +460,20 @@ async def _fetch_report_files(draft_dir: Path) -> FetchResult:
         result.errors.append(f"Failed to fetch machine status: {exc}")
 
     debug_limit = MAX_DEBUG_SHOTS
-    try:
-        incomplete_debug_file = await _capture_incomplete_debug_shot(draft_dir)
-        if incomplete_debug_file is not None:
-            archive_name = _debug_archive_name(incomplete_debug_file)
-            result.files[archive_name] = draft_dir.joinpath(archive_name)
-            result.automatic_debug_files.append(incomplete_debug_file)
-            debug_limit -= 1
-    except Exception as exc:
-        result.errors.append(f"Failed to capture active debug shot: {exc}")
+    if capture_active_debug_shot:
+        try:
+            incomplete_debug_file = await _capture_incomplete_debug_shot(draft_dir)
+            if incomplete_debug_file is not None:
+                archive_name = _debug_archive_name(incomplete_debug_file)
+                result.files[archive_name] = draft_dir.joinpath(archive_name)
+                result.automatic_debug_files.append(incomplete_debug_file)
+                debug_limit -= 1
+        except Exception as exc:
+            result.errors.append(f"Failed to capture active debug shot: {exc}")
 
-    debug_files, debug_errors = _select_debug_files(limit=debug_limit)
+    debug_files, debug_errors = _select_debug_files(
+        limit=debug_limit, start_time=start_time, end_time=end_time
+    )
     result.errors.extend(debug_errors)
     for path in debug_files:
         archive_name = _debug_archive_name(_safe_archive_name(path))
@@ -491,7 +499,7 @@ def _insert_report(report_info: dict[str, Any]):
                     localID=report_info["localID"],
                     eventID=None,
                     baseEventID=None,
-                    issueTime=report_info["dateAndTime"],
+                    issueTime=report_info["issueTime"],
                     creationTime=report_info["dateAndTime"],
                     submissionTime=None,
                     description=None,
@@ -584,62 +592,6 @@ def _apply_scalar_draft_patch(
         db_values["multimedia"] = patch["multimedia"]
 
 
-async def _apply_draft_time_patch(
-    report_info: dict[str, Any],
-    files: dict[str, Path],
-    draft_dir: Path,
-    attachments: dict[str, Any],
-    debug_files: dict[str, Any],
-    user_files: list[str],
-    db_values: dict[str, Any],
-    patch: dict[str, Any],
-) -> list[str]:
-    if "dateAndTime" not in patch:
-        return []
-    if patch["dateAndTime"] is None:
-        raise ValueError("dateAndTime cannot be null")
-
-    issue_time = int(patch["dateAndTime"])
-    report_info["dateAndTime"] = issue_time
-    db_values["issueTime"] = issue_time
-
-    preserve_user_names = set(user_files)
-    for name in list(debug_files.setdefault("automatic", [])):
-        if name not in preserve_user_names:
-            archive_name = _debug_archive_name(name)
-            files.pop(archive_name, None)
-            _remove_draft_file(draft_dir, archive_name)
-
-    errors = []
-    try:
-        machine_logs_path = draft_dir.joinpath(MACHINE_LOGS_NAME)
-        machine_logs_path.write_text(
-            await _fetch_machine_logs(reference_time=issue_time), encoding="utf-8"
-        )
-        files[MACHINE_LOGS_NAME] = machine_logs_path
-        attachments["machineLogs"] = True
-    except Exception as exc:
-        _remove_draft_file(draft_dir, MACHINE_LOGS_NAME)
-        files.pop(MACHINE_LOGS_NAME, None)
-        attachments["machineLogs"] = False
-        errors.append(f"Failed to fetch machine logs: {exc}")
-
-    selected_debug_files, debug_errors = _select_debug_files(reference_time=issue_time)
-    errors.extend(debug_errors)
-    copied_debug_files = []
-    for path in selected_debug_files:
-        name = _safe_archive_name(path)
-        archive_name = _debug_archive_name(name)
-        try:
-            files[archive_name] = _copy_draft_file(draft_dir, archive_name, path)
-            copied_debug_files.append(name)
-        except Exception as exc:
-            errors.append(f"Failed to copy debug file {path}: {exc}")
-
-    debug_files["automatic"] = copied_debug_files
-    return errors
-
-
 def _apply_user_debug_file_patch(
     files: dict[str, Path],
     draft_dir: Path,
@@ -698,18 +650,6 @@ async def _apply_draft_patch(local_id: str, patch: dict[str, Any]) -> dict[str, 
     log_errors = []
 
     _apply_scalar_draft_patch(report_info, db_values, patch)
-    log_errors.extend(
-        await _apply_draft_time_patch(
-            report_info,
-            files,
-            draft_dir,
-            attachments,
-            debug_files,
-            user_files,
-            db_values,
-            patch,
-        )
-    )
     log_errors.extend(
         _apply_user_debug_file_patch(files, draft_dir, debug_files, user_files, patch)
     )
@@ -814,16 +754,47 @@ def _parse_fiql(filter_text: str):
     return or_(*valid_parts), False
 
 
+def _create_report_issue_time(body: bytes) -> int | None:
+    if not body:
+        return None
+    data = _json_loads_body(body)
+    if set(data) != {"issueTime"}:
+        raise ValueError("Create report body must contain only issueTime")
+    issue_time = data["issueTime"]
+    if isinstance(issue_time, bool) or not isinstance(issue_time, int):
+        raise ValueError("issueTime must be an integer epoch timestamp")
+    return issue_time
+
+
+def _collection_range(issue_time: int, now: int) -> tuple[int, int]:
+    if now >= issue_time + (12 * 60 * 60):
+        return issue_time - (12 * 60 * 60), issue_time + (12 * 60 * 60)
+    return now - (24 * 60 * 60), now
+
+
 class ReportsCreateHandler(BaseHandler):
     async def post(self):
-        if self.request.body:
-            _api_error(self, 400, "Request body must be empty")
-            return
-        local_id = _new_local_id()
         now = _now_seconds()
+        try:
+            requested_issue_time = _create_report_issue_time(self.request.body)
+        except ValueError as exc:
+            _api_error(self, 400, str(exc))
+            return
+
+        local_id = _new_local_id()
+        issue_time = requested_issue_time if requested_issue_time is not None else now
+        collection_range = (
+            _collection_range(issue_time, now) if requested_issue_time is not None else None
+        )
         draft_dir = _draft_path(local_id)
         try:
-            fetched = await _fetch_report_files(draft_dir)
+            fetched = await _fetch_report_files(
+                draft_dir,
+                *(collection_range or (None, None)),
+                capture_active_debug_shot=(
+                    collection_range is None or collection_range[1] == now
+                ),
+            )
             attachments = {
                 "debugFiles": {"automatic": fetched.automatic_debug_files},
                 "machineInfo": fetched.machine_info,
@@ -833,6 +804,7 @@ class ReportsCreateHandler(BaseHandler):
             report_info = {
                 "description": None,
                 "dateAndTime": now,
+                "issueTime": issue_time,
                 "attachments": attachments,
                 "multimedia": None,
                 "machineID": MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER],

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -815,6 +815,11 @@ class ReportsCreateHandler(BaseHandler):
         collection_range = (
             _collection_range(issue_time, now) if requested_issue_time is not None else None
         )
+        if collection_range is not None:
+            start, end = collection_range
+            logger.debug(f"information requested from {start} to {end}")
+        else:
+            logger.debug("information requested from the last day")
         draft_dir = _draft_path(local_id)
         try:
             fetched = await _fetch_report_files(

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -15,7 +15,7 @@ from typing import Any
 from urllib.parse import unquote_plus
 
 import tornado.httpclient
-from sqlalchemy import and_, desc, func, insert, or_, select, update
+from sqlalchemy import and_, delete, desc, func, insert, or_, select, update
 
 from config import (
     DATABASE_URL,
@@ -533,6 +533,35 @@ def _get_report_row(local_id: str):
         ).first()
 
 
+def _remove_report_representation(path: Path):
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists() or path.is_symlink():
+        path.unlink()
+
+
+def _delete_report(local_id: str) -> bool:
+    """Remove all stored report files, then delete the matching database row."""
+    if local_id in {"", ".", ".."} or Path(local_id).name != local_id:
+        return False
+    if _get_report_row(local_id) is None:
+        return False
+
+    _remove_report_representation(_draft_path(local_id))
+    _remove_report_representation(_finalized_draft_path(local_id))
+
+    _ensure_database_initialized()
+    with ShotDataBase.engine.connect() as connection:
+        with connection.begin():
+            result = connection.execute(
+                delete(bug_reports).where(bug_reports.c.localID == local_id)
+            )
+            logger.info(
+                f"Deleted bug report draft with localID: {local_id}, affected rows: {result.rowcount}"
+            )
+            return result.rowcount > 0
+
+
 def _list_report_page(page: int, size: int, condition=None) -> dict[str, Any]:
     _ensure_database_initialized()
     query = select(bug_reports).order_by(
@@ -875,6 +904,25 @@ class ReportDraftHandler(BaseHandler):
         except Exception as exc:
             logger.exception("Failed to update bug report draft")
             _api_error(self, 500, "Failed to update report draft", {"message": str(exc)})
+
+    async def delete(self, local_id: str):
+        if self.request.body:
+            _api_error(self, 400, "Delete report draft request must not contain a body")
+            return
+
+        try:
+            deleted = _delete_report(local_id)
+            logger.info(f"Deleted bug report draft with localID: {local_id}")
+        except Exception as exc:
+            logger.exception("Failed to delete bug report draft")
+            _api_error(self, 500, "Failed to delete report draft", {"message": str(exc)})
+            return
+
+        if not deleted:
+            _api_error(self, 404, "Unknown localID")
+            return
+        self.set_status(204)
+        self.finish()
 
 
 class ReportsListHandler(BaseHandler):

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -880,3 +880,98 @@ def test_submit_without_ticket_preserves_existing_ticket(report_module):
     assert row.ticketNumber == 42
     assert archived_info["eventID"] == "event-1"
     assert archived_info["ticket"] == 42
+
+
+class _DeleteDraftHandler:
+    def __init__(self, body=b""):
+        self.request = SimpleNamespace(body=body)
+        self.status = None
+        self.response = None
+        self.finished = False
+
+    def set_status(self, status):
+        self.status = status
+
+    def write(self, body):
+        self.response = body
+
+    def finish(self):
+        self.finished = True
+
+
+def _insert_deletable_report(report_module, local_id: str, status: str = "draft"):
+    with ShotDataBase.engine.begin() as connection:
+        connection.execute(
+            insert(bug_reports).values(
+                localID=local_id,
+                issueTime=1,
+                creationTime=1,
+                machineInfo=False,
+                machineLogs=False,
+                machineStatus=False,
+                status=status,
+            )
+        )
+
+
+@pytest.mark.parametrize("representation", ["directory", "archive", "both"])
+def test_delete_draft_removes_all_report_representations_and_db_row(
+    report_module, representation
+):
+    local_id = f"delete-{representation}"
+    draft_dir = report_module._draft_path(local_id)
+    archive_path = report_module._finalized_draft_path(local_id)
+    if representation in {"directory", "both"}:
+        draft_dir.mkdir()
+        draft_dir.joinpath("report.txt").write_text("draft", encoding="utf-8")
+    if representation in {"archive", "both"}:
+        archive_path.write_bytes(b"archive")
+    _insert_deletable_report(report_module, local_id)
+
+    handler = _DeleteDraftHandler()
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, local_id))
+
+    assert handler.status == 204
+    assert handler.finished is True
+    assert not draft_dir.exists()
+    assert not archive_path.exists()
+    with ShotDataBase.engine.connect() as connection:
+        row = connection.execute(
+            select(bug_reports).where(bug_reports.c.localID == local_id)
+        ).first()
+    assert row is None
+
+
+def test_delete_draft_allows_submitted_report(report_module):
+    local_id = "submitted-report"
+    archive_path = report_module._finalized_draft_path(local_id)
+    archive_path.write_bytes(b"archive")
+    _insert_deletable_report(report_module, local_id, status="submitted")
+
+    handler = _DeleteDraftHandler()
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, local_id))
+
+    assert handler.status == 204
+    assert not archive_path.exists()
+    assert report_module._get_report_row(local_id) is None
+
+
+def test_delete_draft_returns_not_found_for_unknown_local_id(report_module):
+    handler = _DeleteDraftHandler()
+
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, "unknown-id"))
+
+    assert handler.status == 404
+    assert handler.response == {"error": "Unknown localID", "description": ""}
+
+
+def test_delete_draft_rejects_request_body(report_module):
+    handler = _DeleteDraftHandler(body=b"{}")
+
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, "unknown-id"))
+
+    assert handler.status == 400
+    assert handler.response == {
+        "error": "Delete report draft request must not contain a body",
+        "description": "",
+    }

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -107,10 +107,35 @@ def test_fetch_machine_logs_uses_emulated_response_without_watcher(report_module
 
     monkeypatch.setattr(report_module.tornado.httpclient.AsyncHTTPClient, "fetch", fail_fetch)
 
-    logs = asyncio.run(report_module._fetch_machine_logs(reference_time=123))
+    logs = asyncio.run(report_module._fetch_machine_logs(123, 456))
 
     assert "Emulated machine logs generated for bug report" in logs
-    assert "reference_time=123" in logs
+    assert "start_time=123, end_time=456" in logs
+
+
+def test_fetch_machine_logs_converts_range_to_watcher_hours(report_module, monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        async def fetch(self, url, request_timeout):
+            captured["url"] = url
+            captured["request_timeout"] = request_timeout
+            return SimpleNamespace(body=b"logs")
+
+    monkeypatch.setattr(report_module, "_machine_is_emulated", lambda: False)
+    monkeypatch.setattr(report_module, "_now_seconds", lambda: 100000)
+    monkeypatch.setattr(report_module.tornado.httpclient, "AsyncHTTPClient", FakeClient)
+
+    logs = asyncio.run(
+        report_module._fetch_machine_logs(
+            100000 - (24 * 60 * 60) - 1,
+            100000 - (60 * 60) - 1,
+        )
+    )
+
+    assert logs == "logs"
+    assert captured["url"].endswith("&since=25&until=1")
+    assert captured["request_timeout"] == 600
 
 
 def test_fetch_machine_status_uses_emulated_response_without_watcher(
@@ -175,6 +200,60 @@ def test_fetch_report_files_includes_active_incomplete_debug_shot_first(
     )
 
 
+def test_select_debug_files_prioritizes_range_then_older_history(report_module):
+    for name in (
+        "09:00:00.shot.json.zst",
+        "10:00:00.shot.json.zst",
+        "11:00:00.shot.json.zst",
+        "12:00:00.shot.json.zst",
+        "13:00:00.shot.json.zst",
+    ):
+        _debug_file(report_module.DEBUG_HISTORY_ROOT, "2026-05-18", name)
+
+    start = int(datetime(2026, 5, 18, 10, 0, 0).timestamp())
+    end = int(datetime(2026, 5, 18, 12, 0, 0).timestamp())
+    selected, errors = report_module._select_debug_files(
+        limit=4, start_time=start, end_time=end
+    )
+
+    assert [path.name for path in selected] == [
+        "12:00:00.shot.json.zst",
+        "11:00:00.shot.json.zst",
+        "10:00:00.shot.json.zst",
+        "09:00:00.shot.json.zst",
+    ]
+    assert errors == []
+
+
+def test_fetch_report_files_skips_active_debug_shot_for_historical_range(
+    report_module, monkeypatch
+):
+    async def fail_capture(_draft_dir):
+        raise AssertionError("Historical reports must not capture the active debug shot")
+
+    async def fake_machine_logs(*_args):
+        return "logs"
+
+    async def fake_machine_status():
+        return "status"
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", fake_machine_logs)
+    monkeypatch.setattr(report_module, "_fetch_machine_status", fake_machine_status)
+    monkeypatch.setattr(report_module, "_capture_incomplete_debug_shot", fail_capture)
+
+    fetched = asyncio.run(
+        report_module._fetch_report_files(
+            report_module._draft_path("historic"),
+            start_time=1,
+            end_time=2,
+            capture_active_debug_shot=False,
+        )
+    )
+
+    assert fetched.automatic_debug_files == []
+
+
 def test_incomplete_debug_shot_snapshot_keeps_active_state(tmp_path):
     from shot_debug_manager import ShotDebugManager
 
@@ -227,88 +306,11 @@ def test_fiql_filter_ignores_invalid_fields_and_rejects_empty(report_module):
     assert empty_invalid is True
 
 
-def test_draft_patch_preserves_user_file_when_date_changes(report_module, monkeypatch):
-    old_auto = _debug_file(
-        report_module.DEBUG_HISTORY_ROOT, "2026-05-17", "11:00:00.old.json.zst"
-    )
-    old_user = _debug_file(
-        report_module.DEBUG_HISTORY_ROOT, "2026-05-17", "12:00:00.user.json.zst"
-    )
-    new_auto = _debug_file(
-        report_module.DEBUG_HISTORY_ROOT, "2026-05-18", "13:00:00.new.json.zst"
-    )
-    old_auto_name = report_module._safe_archive_name(old_auto)
-    old_user_name = report_module._safe_archive_name(old_user)
-    new_auto_name = report_module._safe_archive_name(new_auto)
-
-    async def fake_machine_logs(reference_time=None):
-        return "new logs"
-
-    monkeypatch.setattr(report_module, "_fetch_machine_logs", fake_machine_logs)
-    monkeypatch.setattr(
-        report_module,
-        "_select_debug_files",
-        lambda limit=10, reference_time=None: ([new_auto], []),
-    )
-
-    local_id = "local-test-id"
-    draft_dir = report_module._draft_path(local_id)
-    draft_dir.mkdir(parents=True)
-    report_info = {
-        "description": None,
-        "dateAndTime": 1,
-        "attachments": {
-            "debugFiles": {
-                "automatic": [old_auto_name, old_user_name],
-                "user": [old_user_name],
-            },
-            "machineInfo": True,
-            "machineLogs": True,
-            "machineStatus": True,
-        },
-        "multimedia": None,
-        "machineID": "machine",
-        "eventID": None,
-        "baseEventID": None,
-        "ticket": None,
-        "localID": local_id,
-    }
-    report_module._copy_draft_file(
-        draft_dir, report_module._debug_archive_name(old_auto_name), old_auto
-    )
-    report_module._copy_draft_file(
-        draft_dir, report_module._debug_archive_name(old_user_name), old_user
-    )
-    report_module._write_draft_report_info(draft_dir, report_info)
-    with ShotDataBase.engine.begin() as connection:
-        connection.execute(
-            insert(bug_reports).values(
-                localID=local_id,
-                issueTime=1,
-                creationTime=1,
-                logFiles=f"{old_auto_name},{old_user_name}",
-                machineInfo=True,
-                machineLogs=True,
-                machineStatus=True,
-                status="draft",
-            )
-        )
-
-    updated = asyncio.run(report_module._apply_draft_patch(local_id, {"dateAndTime": 2}))
-    archived_info = report_module._read_draft_report_info(draft_dir)
-    archived_names = set(report_module._draft_files(draft_dir).keys())
-
-    assert updated["attachments"]["debugFiles"]["automatic"] == [new_auto_name]
-    assert report_module._debug_archive_name(old_auto_name) not in archived_names
-    assert report_module._debug_archive_name(old_user_name) in archived_names
-    assert report_module._debug_archive_name(new_auto_name) in archived_names
-    assert archived_info["dateAndTime"] == 2
-
-    with ShotDataBase.engine.connect() as connection:
-        row = connection.execute(select(bug_reports)).first()
-    assert row.issueTime == 2
-    assert old_user_name in row.logFiles
-    assert new_auto_name in row.logFiles
+def test_draft_patch_rejects_date_and_issue_times(report_module):
+    with pytest.raises(PermissionError):
+        report_module._validate_draft_patch({"dateAndTime": 2})
+    with pytest.raises(PermissionError):
+        report_module._validate_draft_patch({"issueTime": 2})
 
 
 def test_draft_patch_adds_user_debug_file_to_draft_directory(report_module):
@@ -408,7 +410,10 @@ def test_draft_directory_can_be_compressed(report_module):
 
 
 def test_create_report_returns_machine_id_matching_report_info(report_module, monkeypatch):
-    async def fake_fetch_report_files(draft_dir):
+    calls = []
+
+    async def fake_fetch_report_files(draft_dir, *args, **kwargs):
+        calls.append((args, kwargs))
         draft_dir.mkdir(parents=True, exist_ok=True)
         machine_status = draft_dir.joinpath(report_module.MACHINE_STATUS_NAME)
         machine_status.write_text('{"ok": true}', encoding="utf-8")
@@ -435,6 +440,11 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
             },
         },
     )
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
 
     handler = FakeHandler()
     asyncio.run(report_module.ReportsCreateHandler.post(handler))
@@ -444,11 +454,129 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
 
     assert handler.body == {"localID": "local-test-id", "machineID": "machine-test-id"}
     assert report_info["machineID"] == handler.body["machineID"]
+    assert report_info["dateAndTime"] == 1
+    assert report_info["issueTime"] == 1
+    assert calls == [((None, None), {"capture_active_debug_shot": True})]
     with ShotDataBase.engine.connect() as connection:
         row = connection.execute(select(bug_reports)).first()
     assert row.localID == "local-test-id"
     assert row.machineID == "machine-test-id"
     assert row.machineStatus is True
+    assert row.creationTime == 1
+    assert row.issueTime == 1
+
+
+def test_create_report_with_historical_issue_time_persists_metadata_and_range(
+    report_module, monkeypatch
+):
+    now = 200000
+    issue_time = now - (25 * 60 * 60)
+    calls = []
+
+    async def fake_fetch_report_files(draft_dir, *args, **kwargs):
+        calls.append((args, kwargs))
+        draft_dir.mkdir(parents=True, exist_ok=True)
+        return report_module.FetchResult()
+
+    class FakeHandler:
+        request = SimpleNamespace(body=json.dumps({"issueTime": issue_time}).encode())
+
+        def write(self, body):
+            self.body = body
+
+    monkeypatch.setattr(report_module, "_new_local_id", lambda: "historical-id")
+    monkeypatch.setattr(report_module, "_now_seconds", lambda: now)
+    monkeypatch.setattr(report_module, "_fetch_report_files", fake_fetch_report_files)
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
+
+    handler = FakeHandler()
+    asyncio.run(report_module.ReportsCreateHandler.post(handler))
+
+    report_info = report_module._read_draft_report_info(
+        report_module._draft_path("historical-id")
+    )
+    listed = report_module._list_report_page(page=0, size=1)["content"][0]
+    with ShotDataBase.engine.connect() as connection:
+        row = connection.execute(select(bug_reports)).first()
+
+    assert calls == [
+        (
+            (issue_time - (12 * 60 * 60), issue_time + (12 * 60 * 60)),
+            {"capture_active_debug_shot": False},
+        )
+    ]
+    assert report_info["dateAndTime"] == now
+    assert report_info["issueTime"] == issue_time
+    assert row.creationTime == now
+    assert row.issueTime == issue_time
+    assert listed["dateAndTime"] == now
+    assert listed["issueTime"] == issue_time
+
+
+def test_create_report_uses_trailing_range_for_recent_and_future_issue_times(report_module):
+    now = 200000
+
+    assert report_module._collection_range(now - 1, now) == (
+        now - (24 * 60 * 60),
+        now,
+    )
+    assert report_module._collection_range(now + 1, now) == (
+        now - (24 * 60 * 60),
+        now,
+    )
+    assert report_module._collection_range(now - (12 * 60 * 60), now) == (
+        now - (24 * 60 * 60),
+        now,
+    )
+
+
+def test_create_report_with_recent_issue_time_keeps_active_shot_eligible(
+    report_module, monkeypatch
+):
+    now = 200000
+    issue_time = now - 1
+    calls = []
+
+    async def fake_fetch_report_files(draft_dir, *args, **kwargs):
+        calls.append((args, kwargs))
+        draft_dir.mkdir(parents=True, exist_ok=True)
+        return report_module.FetchResult()
+
+    class FakeHandler:
+        request = SimpleNamespace(body=json.dumps({"issueTime": issue_time}).encode())
+
+        def write(self, body):
+            self.body = body
+
+    monkeypatch.setattr(report_module, "_new_local_id", lambda: "recent-id")
+    monkeypatch.setattr(report_module, "_now_seconds", lambda: now)
+    monkeypatch.setattr(report_module, "_fetch_report_files", fake_fetch_report_files)
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
+
+    asyncio.run(report_module.ReportsCreateHandler.post(FakeHandler()))
+
+    assert calls == [
+        (
+            (now - (24 * 60 * 60), now),
+            {"capture_active_debug_shot": True},
+        )
+    ]
+
+
+def test_create_report_request_requires_only_integer_issue_time(report_module):
+    assert report_module._create_report_issue_time(b"") is None
+    assert report_module._create_report_issue_time(b'{"issueTime": 123}') == 123
+    for body in (b"{}", b'{"issueTime": true}', b'{"issueTime": 1.5}', b"[]"):
+        with pytest.raises(ValueError):
+            report_module._create_report_issue_time(body)
 
 
 def test_draft_patch_persists_ticket_and_multimedia_in_db_and_report_info(
@@ -537,6 +665,8 @@ def test_list_report_page_returns_newest_first_with_machine_id(report_module):
 
     assert response["content"][0]["localID"] == "newer-id"
     assert response["content"][0]["machineID"] == "newer-machine"
+    assert response["content"][0]["dateAndTime"] == 2
+    assert response["content"][0]["issueTime"] == 2
     assert response["hasMore"] is True
 
 


### PR DESCRIPTION
The post fnc callback on the `CreateReportHandler` class will now accept an optional
```json
{
    issueTime: number;
}
```
object to allow the backend set a window time on which it will fetch the logs and debug files required:
* The system logs will be fetched from [-12hrs,+12hrs] from the provided timestamp, in case the timestamp is less that 12 hrs ago from the present, it will be capped to the present time and 24 hrs ago
* It will fetch at most 10 shot debug files within the previously defined time window, in case there is less than 10 debug shot files in the time window it can continue fetching in the past

 in case there is no object present it will behave as currently does by fetching the logs from the last day as well as the 10 latest debug shot files

Every other report information is fetched the same