### PR TITLE
SW-8: Optimize Hawkbit Polling Frequency

### DIFF
--- a/api/base_handler.py
+++ b/api/base_handler.py
@@ -90,12 +90,7 @@ class LocalAccessHandler(BaseHandler):
     def prepare(self):
         super().prepare()
         remote_ip = self.request.headers.get("X-Real-IP")
-        request_host = self.request.host.split(":")[0]
-        if (
-            remote_ip
-            and remote_ip not in ("127.0.0.1", "::1", "localhost")
-            and request_host not in ("localhost", "127.0.0.1")
-        ):
+        if remote_ip and remote_ip not in ("127.0.0.1", "::1", "localhost"):
             logger.warning(
                 f"Unauthorized access to {self.request.uri} "
                 f"from remote IP: {redact_ip(remote_ip)}"

--- a/api/base_handler.py
+++ b/api/base_handler.py
@@ -90,16 +90,7 @@ class LocalAccessHandler(BaseHandler):
     def prepare(self):
         super().prepare()
         remote_ip = self.request.headers.get("X-Real-IP")
-        request_host = self.request.host.split(":")[0]
-        if (
-            remote_ip
-            and remote_ip not in ("127.0.0.1", "::1", "localhost")
-            and request_host
-            not in (
-                "localhost",
-                "127.0.0.1",
-            )
-        ):
+        if remote_ip and remote_ip not in ("127.0.0.1", "::1", "localhost"):
             logger.warning(
                 f"Unauthorized access to {self.request.uri} "
                 f"from remote IP: {redact_ip(remote_ip)}"

--- a/api/base_handler.py
+++ b/api/base_handler.py
@@ -90,7 +90,12 @@ class LocalAccessHandler(BaseHandler):
     def prepare(self):
         super().prepare()
         remote_ip = self.request.headers.get("X-Real-IP")
-        if remote_ip and remote_ip not in ("127.0.0.1", "::1", "localhost"):
+        request_host = self.request.host.split(":")[0]
+        if (
+            remote_ip
+            and remote_ip not in ("127.0.0.1", "::1", "localhost")
+            and request_host not in ("localhost", "127.0.0.1")
+        ):
             logger.warning(
                 f"Unauthorized access to {self.request.uri} "
                 f"from remote IP: {redact_ip(remote_ip)}"

--- a/api/base_handler.py
+++ b/api/base_handler.py
@@ -1,3 +1,5 @@
+from ipaddress import ip_address
+
 import tornado.web
 from netaddr import IPNetwork
 
@@ -87,13 +89,29 @@ class BaseHandler(tornado.web.RequestHandler):
 class LocalAccessHandler(BaseHandler):
     """Base handler that restricts access to local requests only."""
 
+    @staticmethod
+    def _is_loopback(address):
+        try:
+            return ip_address(address).is_loopback
+        except (TypeError, ValueError):
+            return False
+
+    @classmethod
+    def _request_is_local(cls, request):
+        forwarded_ip = request.headers.get("X-Real-IP")
+        return cls._is_loopback(request.remote_ip) and (
+            forwarded_ip is None or cls._is_loopback(forwarded_ip)
+        )
+
     def prepare(self):
         super().prepare()
-        remote_ip = self.request.headers.get("X-Real-IP")
-        if remote_ip and remote_ip not in ("127.0.0.1", "::1", "localhost"):
+        peer_ip = self.request.remote_ip
+        forwarded_ip = self.request.headers.get("X-Real-IP")
+        if not self._request_is_local(self.request):
+            rejected_ip = forwarded_ip or peer_ip
             logger.warning(
                 f"Unauthorized access to {self.request.uri} "
-                f"from remote IP: {redact_ip(remote_ip)}"
+                f"from remote IP: {redact_ip(rejected_ip)}"
             )
             self.set_status(403)
             self.write(

--- a/api/update.py
+++ b/api/update.py
@@ -1,20 +1,25 @@
 from esp_serial.esp_tool_wrapper import ESPToolWrapper, FikaSupportedESP32
-from machine import Machine
 import os
 import subprocess
 import tempfile
 import zipfile
 from named_thread import NamedThread
 
-from tornado.web import MissingArgumentError
+from tornado.web import HTTPError, MissingArgumentError
 
-from .base_handler import BaseHandler, LocalAccessHandler
+from .base_handler import BaseHandler, LocalAccessHandler, redact_ip
 from .api import API, APIVersion
-from .machine import OSStatus, UpdateOSStatus
 
 from log import MeticulousLogger
 
 logger = MeticulousLogger.getLogger(__name__)
+
+
+def os_update_is_active():
+    """Read update state lazily without initializing machine hardware on import."""
+    from .machine import OSStatus, UpdateOSStatus
+
+    return UpdateOSStatus.last_status in (OSStatus.DOWNLOADING, OSStatus.INSTALLING)
 
 
 class UpdateFirmwareWithZipHandler(BaseHandler):
@@ -70,6 +75,8 @@ class UpdateFirmwareWithZipHandler(BaseHandler):
         if error_occured:
             self.write("failure during upload")
             return
+
+        from machine import Machine
 
         Machine.refreshAvailableFirmware()
 
@@ -128,8 +135,17 @@ class UpdateFirmwareWithZipHandler(BaseHandler):
 
 
 class UpdateCheckHandler(LocalAccessHandler):
+    def prepare(self):
+        super().prepare()
+        if self._finished:
+            return
+        remote_ip = self.request.headers.get("X-Real-IP")
+        if remote_ip and remote_ip not in ("127.0.0.1", "::1", "localhost"):
+            logger.warning("Unauthorized update check from remote IP: %s", redact_ip(remote_ip))
+            raise HTTPError(403)
+
     def post(self):
-        if UpdateOSStatus.last_status in (OSStatus.DOWNLOADING, OSStatus.INSTALLING):
+        if os_update_is_active():
             self.set_status(409)
             self.write({"status": "error", "error": "An update is already active"})
             return
@@ -139,8 +155,18 @@ class UpdateCheckHandler(LocalAccessHandler):
                 ["systemctl", "restart", "rauc-hawkbit-updater"],
                 check=True,
             )
-        except (OSError, subprocess.CalledProcessError):
-            logger.error("Failed to request a Hawkbit update check")
+        except subprocess.CalledProcessError as error:
+            logger.error(
+                "Hawkbit update check service restart failed with exit code %s",
+                error.returncode,
+            )
+            self.set_status(500)
+            self.write({"status": "error", "error": "Failed to request update check"})
+            return
+        except OSError as error:
+            logger.error(
+                "Hawkbit update check service restart failed: %s", type(error).__name__
+            )
             self.set_status(500)
             self.write({"status": "error", "error": "Failed to request update check"})
             return

--- a/api/update.py
+++ b/api/update.py
@@ -5,9 +5,9 @@ import tempfile
 import zipfile
 from named_thread import NamedThread
 
-from tornado.web import HTTPError, MissingArgumentError
+from tornado.web import MissingArgumentError
 
-from .base_handler import BaseHandler, LocalAccessHandler, redact_ip
+from .base_handler import BaseHandler, LocalAccessHandler
 from .api import API, APIVersion
 
 from log import MeticulousLogger
@@ -135,15 +135,6 @@ class UpdateFirmwareWithZipHandler(BaseHandler):
 
 
 class UpdateCheckHandler(LocalAccessHandler):
-    def prepare(self):
-        super().prepare()
-        if self._finished:
-            return
-        remote_ip = self.request.headers.get("X-Real-IP")
-        if remote_ip and remote_ip not in ("127.0.0.1", "::1", "localhost"):
-            logger.warning("Unauthorized update check from remote IP: %s", redact_ip(remote_ip))
-            raise HTTPError(403)
-
     def post(self):
         if os_update_is_active():
             self.set_status(409)
@@ -165,7 +156,9 @@ class UpdateCheckHandler(LocalAccessHandler):
             return
         except OSError as error:
             logger.error(
-                "Hawkbit update check service restart failed: %s", type(error).__name__
+                "Hawkbit update check service restart failed: %s (errno=%s)",
+                type(error).__name__,
+                error.errno,
             )
             self.set_status(500)
             self.write({"status": "error", "error": "Failed to request update check"})

--- a/api/update.py
+++ b/api/update.py
@@ -1,14 +1,16 @@
 from esp_serial.esp_tool_wrapper import ESPToolWrapper, FikaSupportedESP32
 from machine import Machine
 import os
+import subprocess
 import tempfile
 import zipfile
 from named_thread import NamedThread
 
 from tornado.web import MissingArgumentError
 
-from .base_handler import BaseHandler
+from .base_handler import BaseHandler, LocalAccessHandler
 from .api import API, APIVersion
+from .machine import OSStatus, UpdateOSStatus
 
 from log import MeticulousLogger
 
@@ -125,4 +127,26 @@ class UpdateFirmwareWithZipHandler(BaseHandler):
         return False
 
 
+class UpdateCheckHandler(LocalAccessHandler):
+    def post(self):
+        if UpdateOSStatus.last_status in (OSStatus.DOWNLOADING, OSStatus.INSTALLING):
+            self.set_status(409)
+            self.write({"status": "error", "error": "An update is already active"})
+            return
+
+        try:
+            subprocess.run(
+                ["systemctl", "restart", "rauc-hawkbit-updater"],
+                check=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            logger.error("Failed to request a Hawkbit update check")
+            self.set_status(500)
+            self.write({"status": "error", "error": "Failed to request update check"})
+            return
+
+        self.write({"status": "success"})
+
+
 API.register_handler(APIVersion.V1, r"/update/firmware", UpdateFirmwareWithZipHandler)
+API.register_handler(APIVersion.V1, r"/update/check", UpdateCheckHandler)

--- a/api/update.py
+++ b/api/update.py
@@ -1,10 +1,13 @@
-from esp_serial.esp_tool_wrapper import ESPToolWrapper, FikaSupportedESP32
+import asyncio
+import math
 import os
 import subprocess
 import tempfile
+import time
 import zipfile
-from named_thread import NamedThread
 
+from esp_serial.esp_tool_wrapper import ESPToolWrapper, FikaSupportedESP32
+from named_thread import NamedThread
 from tornado.web import MissingArgumentError
 
 from .base_handler import BaseHandler, LocalAccessHandler
@@ -14,12 +17,70 @@ from log import MeticulousLogger
 
 logger = MeticulousLogger.getLogger(__name__)
 
+HAWKBIT_UPDATER_SERVICE = "rauc-hawkbit-updater"
+HAWKBIT_RESTART_TIMEOUT_SECONDS = 60
+# The updater unit allows five starts in 20,000 seconds. Keep manual checks
+# farther apart than the average start-limit budget so they cannot exhaust it.
+HAWKBIT_CHECK_COOLDOWN_SECONDS = 4_001
+HAWKBIT_CHECK_STATE_PATH = "/run/meticulous-backend-hawkbit-update-check"
+_update_check_lock = asyncio.Lock()
+
 
 def os_update_is_active():
     """Read update state lazily without initializing machine hardware on import."""
     from .machine import OSStatus, UpdateOSStatus
 
     return UpdateOSStatus.last_status in (OSStatus.DOWNLOADING, OSStatus.INSTALLING)
+
+
+def machine_is_emulated():
+    """Read emulation state lazily to avoid initializing machine hardware on import."""
+    from machine import Machine
+
+    return Machine.emulated
+
+
+def _boot_time():
+    return time.monotonic()
+
+
+def _read_last_restart_attempt():
+    try:
+        with open(HAWKBIT_CHECK_STATE_PATH, encoding="ascii") as state_file:
+            return float(state_file.read())
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as error:
+        logger.error(
+            "Unable to read Hawkbit update check cooldown state: %s",
+            type(error).__name__,
+        )
+        raise
+
+
+def _record_restart_attempt(attempted_at):
+    state_directory = os.path.dirname(HAWKBIT_CHECK_STATE_PATH)
+    if state_directory:
+        os.makedirs(state_directory, exist_ok=True)
+    temporary_path = f"{HAWKBIT_CHECK_STATE_PATH}.{os.getpid()}.tmp"
+    try:
+        with open(temporary_path, "w", encoding="ascii") as state_file:
+            state_file.write(f"{attempted_at:.9f}")
+        os.replace(temporary_path, HAWKBIT_CHECK_STATE_PATH)
+    except OSError:
+        try:
+            os.unlink(temporary_path)
+        except OSError:
+            pass
+        raise
+
+
+def _restart_hawkbit_updater():
+    subprocess.run(
+        ["systemctl", "restart", HAWKBIT_UPDATER_SERVICE],
+        check=True,
+        timeout=HAWKBIT_RESTART_TIMEOUT_SECONDS,
+    )
 
 
 class UpdateFirmwareWithZipHandler(BaseHandler):
@@ -135,36 +196,68 @@ class UpdateFirmwareWithZipHandler(BaseHandler):
 
 
 class UpdateCheckHandler(LocalAccessHandler):
-    def post(self):
-        if os_update_is_active():
-            self.set_status(409)
-            self.write({"status": "error", "error": "An update is already active"})
+    async def post(self):
+        if machine_is_emulated():
+            self.write({"status": "emulated", "message": "Update check skipped"})
             return
 
-        try:
-            subprocess.run(
-                ["systemctl", "restart", "rauc-hawkbit-updater"],
-                check=True,
-            )
-        except subprocess.CalledProcessError as error:
-            logger.error(
-                "Hawkbit update check service restart failed with exit code %s",
-                error.returncode,
-            )
-            self.set_status(500)
-            self.write({"status": "error", "error": "Failed to request update check"})
-            return
-        except OSError as error:
-            logger.error(
-                "Hawkbit update check service restart failed: %s (errno=%s)",
-                type(error).__name__,
-                error.errno,
-            )
-            self.set_status(500)
-            self.write({"status": "error", "error": "Failed to request update check"})
-            return
+        async with _update_check_lock:
+            if os_update_is_active():
+                self.set_status(409)
+                self.write({"status": "error", "error": "An update is already active"})
+                return
 
-        self.write({"status": "success"})
+            now = _boot_time()
+            try:
+                last_attempt = _read_last_restart_attempt()
+                if last_attempt is not None:
+                    elapsed = now - last_attempt
+                    if 0 <= elapsed < HAWKBIT_CHECK_COOLDOWN_SECONDS:
+                        retry_after = math.ceil(HAWKBIT_CHECK_COOLDOWN_SECONDS - elapsed)
+                        self.set_status(429)
+                        self.set_header("Retry-After", str(retry_after))
+                        self.write(
+                            {
+                                "status": "cooldown",
+                                "error": "An update check was recently requested",
+                                "retry_after_seconds": retry_after,
+                            }
+                        )
+                        return
+                # Record before invoking systemctl: even failed starts consume the
+                # unit's start-limit budget.
+                _record_restart_attempt(now)
+            except (OSError, ValueError):
+                self.set_status(500)
+                self.write({"status": "error", "error": "Failed to request update check"})
+                return
+
+            try:
+                await asyncio.to_thread(_restart_hawkbit_updater)
+            except subprocess.CalledProcessError as error:
+                logger.error(
+                    "Hawkbit update check service restart failed with exit code %s",
+                    error.returncode,
+                )
+                self.set_status(500)
+                self.write({"status": "error", "error": "Failed to request update check"})
+                return
+            except subprocess.TimeoutExpired:
+                logger.error("Hawkbit update check service restart timed out")
+                self.set_status(500)
+                self.write({"status": "error", "error": "Failed to request update check"})
+                return
+            except OSError as error:
+                logger.error(
+                    "Hawkbit update check service restart failed: %s (errno=%s)",
+                    type(error).__name__,
+                    error.errno,
+                )
+                self.set_status(500)
+                self.write({"status": "error", "error": "Failed to request update check"})
+                return
+
+            self.write({"status": "success"})
 
 
 API.register_handler(APIVersion.V1, r"/update/firmware", UpdateFirmwareWithZipHandler)

--- a/api/update.py
+++ b/api/update.py
@@ -19,9 +19,9 @@ logger = MeticulousLogger.getLogger(__name__)
 
 HAWKBIT_UPDATER_SERVICE = "rauc-hawkbit-updater"
 HAWKBIT_RESTART_TIMEOUT_SECONDS = 60
-# The updater unit allows five starts in 20,000 seconds. Keep manual checks
-# farther apart than the average start-limit budget so they cannot exhaust it.
-HAWKBIT_CHECK_COOLDOWN_SECONDS = 4_001
+# The updater unit allows five starts in 20,000 seconds. Limit manual checks to
+# two in that window, preserving three starts for boot and configuration changes.
+HAWKBIT_CHECK_COOLDOWN_SECONDS = 10_001
 HAWKBIT_CHECK_STATE_PATH = "/run/meticulous-backend-hawkbit-update-check"
 _update_check_lock = asyncio.Lock()
 

--- a/tests/test_local_access_handler.py
+++ b/tests/test_local_access_handler.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+import pytest
+import tornado.web
+from tornado.httputil import HTTPHeaders
+from tornado.testing import AsyncHTTPTestCase
+
+from api.base_handler import LocalAccessHandler
+
+
+class LocalOnlyTestHandler(LocalAccessHandler):
+    def get(self):
+        self.write({"status": "success"})
+
+
+class TestLocalAccessHandlerHTTP(AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application([(r"/local", LocalOnlyTestHandler)])
+
+    def test_prepare_allows_loopback_request(self):
+        assert self.fetch("/local").code == 200
+
+    def test_prepare_rejects_remote_forwarded_address(self):
+        response = self.fetch(
+            "/local", headers={"X-Real-IP": "203.0.113.42"}, raise_error=False
+        )
+
+        assert response.code == 403
+
+
+def request(peer_address, forwarded_address=None):
+    headers = HTTPHeaders()
+    if forwarded_address is not None:
+        headers["X-Real-IP"] = forwarded_address
+    return SimpleNamespace(remote_ip=peer_address, headers=headers)
+
+
+@pytest.mark.parametrize("peer_address", ["127.0.0.1", "127.42.0.9", "::1"])
+def test_local_access_allows_genuine_loopback_peers(peer_address):
+    assert LocalAccessHandler._request_is_local(request(peer_address))
+
+
+def test_local_access_rejects_direct_remote_peer():
+    assert not LocalAccessHandler._request_is_local(request("203.0.113.42"))
+
+
+def test_local_access_rejects_proxied_remote_peer():
+    assert not LocalAccessHandler._request_is_local(
+        request("127.0.0.1", forwarded_address="203.0.113.42")
+    )
+
+
+def test_local_access_rejects_spoofed_loopback_header_from_remote_peer():
+    assert not LocalAccessHandler._request_is_local(
+        request("203.0.113.42", forwarded_address="127.0.0.1")
+    )
+
+
+def test_local_access_allows_loopback_proxy_for_loopback_caller():
+    assert LocalAccessHandler._request_is_local(
+        request("127.0.0.1", forwarded_address="::1")
+    )
+
+
+@pytest.mark.parametrize("forwarded_address", ["localhost", "unknown", ""])
+def test_local_access_rejects_non_address_forwarded_values(forwarded_address):
+    assert not LocalAccessHandler._request_is_local(
+        request("127.0.0.1", forwarded_address=forwarded_address)
+    )

--- a/tests/test_local_access_handler.py
+++ b/tests/test_local_access_handler.py
@@ -57,9 +57,7 @@ def test_local_access_rejects_spoofed_loopback_header_from_remote_peer():
 
 
 def test_local_access_allows_loopback_proxy_for_loopback_caller():
-    assert LocalAccessHandler._request_is_local(
-        request("127.0.0.1", forwarded_address="::1")
-    )
+    assert LocalAccessHandler._request_is_local(request("127.0.0.1", forwarded_address="::1"))
 
 
 @pytest.mark.parametrize("forwarded_address", ["localhost", "unknown", ""])

--- a/tests/test_update_check_api.py
+++ b/tests/test_update_check_api.py
@@ -7,7 +7,6 @@ from tornado.testing import AsyncHTTPTestCase
 
 from api.api import API, APIVersion
 from api.base_handler import LocalAccessHandler
-from api.machine import OSStatus, UpdateOSStatus
 from api.update import UpdateCheckHandler
 
 
@@ -17,15 +16,10 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
 
     def setUp(self):
         super().setUp()
-        self.previous_status = UpdateOSStatus.last_status
-        UpdateOSStatus.last_status = OSStatus.IDLE
 
-    def tearDown(self):
-        UpdateOSStatus.last_status = self.previous_status
-        super().tearDown()
-
+    @patch("api.update.os_update_is_active", return_value=False)
     @patch("api.update.subprocess.run")
-    def test_restarts_existing_updater(self, run):
+    def test_restarts_existing_updater(self, run, _active):
         response = self.fetch("/api/v1/update/check", method="POST", body="")
 
         assert response.code == 200
@@ -34,19 +28,18 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
             ["systemctl", "restart", "rauc-hawkbit-updater"], check=True
         )
 
+    @patch("api.update.os_update_is_active", return_value=True)
     @patch("api.update.subprocess.run")
-    def test_rejects_active_update_without_restart(self, run):
-        for status in (OSStatus.DOWNLOADING, OSStatus.INSTALLING):
-            UpdateOSStatus.last_status = status
+    def test_rejects_active_update_without_restart(self, run, _active):
+        response = self.fetch("/api/v1/update/check", method="POST", body="")
 
-            response = self.fetch("/api/v1/update/check", method="POST", body="")
-
-            assert response.code == 409
+        assert response.code == 409
 
         run.assert_not_called()
 
+    @patch("api.update.os_update_is_active", return_value=False)
     @patch("api.update.subprocess.run")
-    def test_rejects_non_loopback_proxy_address(self, run):
+    def test_rejects_non_loopback_proxy_address(self, run, _active):
         response = self.fetch(
             "/api/v1/update/check",
             method="POST",
@@ -57,8 +50,9 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
         assert response.code == 403
         run.assert_not_called()
 
+    @patch("api.update.os_update_is_active", return_value=False)
     @patch("api.update.subprocess.run")
-    def test_restart_failure_is_sanitized(self, run):
+    def test_restart_failure_is_sanitized(self, run, _active):
         sensitive_detail = "token=secret /private/updater stderr detail"
         run.side_effect = subprocess.CalledProcessError(
             1,

--- a/tests/test_update_check_api.py
+++ b/tests/test_update_check_api.py
@@ -1,13 +1,21 @@
+import asyncio
 import json
+import os
 import subprocess
+import tempfile
+import threading
 from unittest.mock import patch
 
 import tornado.web
-from tornado.testing import AsyncHTTPTestCase
+from tornado.testing import AsyncHTTPTestCase, gen_test
 
 from api.api import API, APIVersion
 from api.base_handler import LocalAccessHandler
-from api.update import UpdateCheckHandler
+from api.update import (
+    HAWKBIT_CHECK_COOLDOWN_SECONDS,
+    HAWKBIT_RESTART_TIMEOUT_SECONDS,
+    UpdateCheckHandler,
+)
 
 
 class TestUpdateCheckHandler(AsyncHTTPTestCase):
@@ -15,7 +23,19 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
         return tornado.web.Application([(r"/api/v1/update/check", UpdateCheckHandler)])
 
     def setUp(self):
+        self.state_directory = tempfile.TemporaryDirectory()
+        self.state_path = f"{self.state_directory.name}/last-attempt"
+        self.state_patch = patch("api.update.HAWKBIT_CHECK_STATE_PATH", self.state_path)
+        self.emulation_patch = patch("api.update.machine_is_emulated", return_value=False)
+        self.state_patch.start()
+        self.emulation_patch.start()
         super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        self.emulation_patch.stop()
+        self.state_patch.stop()
+        self.state_directory.cleanup()
 
     @patch("api.update.os_update_is_active", return_value=False)
     @patch("api.update.subprocess.run")
@@ -25,7 +45,9 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
         assert response.code == 200
         assert json.loads(response.body) == {"status": "success"}
         run.assert_called_once_with(
-            ["systemctl", "restart", "rauc-hawkbit-updater"], check=True
+            ["systemctl", "restart", "rauc-hawkbit-updater"],
+            check=True,
+            timeout=HAWKBIT_RESTART_TIMEOUT_SECONDS,
         )
 
     @patch("api.update.os_update_is_active", return_value=True)
@@ -34,61 +56,182 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
         response = self.fetch("/api/v1/update/check", method="POST", body="")
 
         assert response.code == 409
-
-        run.assert_not_called()
-
-    @patch("api.update.os_update_is_active", return_value=False)
-    @patch("api.update.subprocess.run")
-    def test_rejects_non_loopback_proxy_address(self, run, _active):
-        response = self.fetch(
-            "/api/v1/update/check",
-            method="POST",
-            body="",
-            headers={"X-Real-IP": "203.0.113.42"},
-        )
-
-        assert response.code == 403
         assert json.loads(response.body) == {
             "status": "error",
-            "error": "This endpoint can only be accessed locally",
+            "error": "An update is already active",
         }
         run.assert_not_called()
 
+    @patch("api.update.subprocess.run")
+    def test_emulation_is_safe_no_op_without_production_state(self, run):
+        with patch("api.update.machine_is_emulated", return_value=True):
+            response = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert response.code == 200
+        assert json.loads(response.body) == {
+            "status": "emulated",
+            "message": "Update check skipped",
+        }
+        assert not os.path.exists(self.state_path)
+        run.assert_not_called()
+
     @patch("api.update.os_update_is_active", return_value=False)
     @patch("api.update.subprocess.run")
-    def test_restart_failure_is_sanitized(self, run, _active):
-        sensitive_detail = "token=secret /private/updater stderr detail"
+    def test_records_attempt_before_invoking_systemctl(self, run, _active):
+        def assert_state_exists(*_args, **_kwargs):
+            assert os.path.exists(self.state_path)
+
+        run.side_effect = assert_state_exists
+
+        response = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert response.code == 200
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update._boot_time", side_effect=[100.0, 100.0])
+    @patch("api.update.subprocess.run")
+    def test_cooldown_is_persisted_across_handler_recreation(self, run, _time, _active):
+        first = self.fetch("/api/v1/update/check", method="POST", body="")
+        second = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert first.code == 200
+        assert second.code == 429
+        assert second.headers["Retry-After"] == str(HAWKBIT_CHECK_COOLDOWN_SECONDS)
+        assert json.loads(second.body) == {
+            "status": "cooldown",
+            "error": "An update check was recently requested",
+            "retry_after_seconds": HAWKBIT_CHECK_COOLDOWN_SECONDS,
+        }
+        run.assert_called_once()
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update._boot_time", return_value=101.0)
+    @patch("api.update.subprocess.run")
+    def test_persisted_cooldown_is_loaded_without_process_memory(self, run, _time, _active):
+        with open(self.state_path, "w", encoding="ascii") as state_file:
+            state_file.write("100.0")
+
+        response = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert response.code == 429
+        assert json.loads(response.body)["retry_after_seconds"] == 4_000
+        run.assert_not_called()
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update._boot_time")
+    @patch("api.update.subprocess.run")
+    def test_cooldown_boundary_allows_restart(self, run, monotonic, _active):
+        monotonic.side_effect = [100.0, 100.0 + HAWKBIT_CHECK_COOLDOWN_SECONDS]
+
+        first = self.fetch("/api/v1/update/check", method="POST", body="")
+        second = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert first.code == 200
+        assert second.code == 200
+        assert run.call_count == 2
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update.subprocess.run")
+    @gen_test
+    async def test_concurrent_requests_are_serialized(self, run, _active):
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_restart(*_args, **_kwargs):
+            started.set()
+            assert release.wait(timeout=2)
+
+        run.side_effect = blocking_restart
+        first = self.http_client.fetch(
+            self.get_url("/api/v1/update/check"), method="POST", body=""
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        second = self.http_client.fetch(
+            self.get_url("/api/v1/update/check"), method="POST", body="", raise_error=False
+        )
+        release.set()
+        first_response, second_response = await asyncio.gather(first, second)
+
+        assert first_response.code == 200
+        assert second_response.code == 429
+        run.assert_called_once()
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update.subprocess.run")
+    @gen_test
+    async def test_restart_does_not_block_io_loop(self, run, _active):
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_restart(*_args, **_kwargs):
+            started.set()
+            assert release.wait(timeout=2)
+
+        run.side_effect = blocking_restart
+        response_future = self.http_client.fetch(
+            self.get_url("/api/v1/update/check"), method="POST", body=""
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        loop_remained_responsive = False
+        await asyncio.sleep(0)
+        loop_remained_responsive = True
+        release.set()
+        response = await response_future
+
+        assert loop_remained_responsive
+        assert response.code == 200
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update.subprocess.run")
+    def test_timeout_is_sanitized_and_attempt_remains_on_cooldown(self, run, _active):
+        sensitive_command = ["systemctl", "secret-value"]
+        run.side_effect = subprocess.TimeoutExpired(sensitive_command, 60, stderr="secret")
+
+        response = self.fetch("/api/v1/update/check", method="POST", body="")
+        retry = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert response.code == 500
+        assert json.loads(response.body) == {
+            "status": "error",
+            "error": "Failed to request update check",
+        }
+        assert b"secret" not in response.body
+        assert retry.code == 429
+        run.assert_called_once()
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update.subprocess.run")
+    def test_called_process_failure_is_sanitized(self, run, _active):
         run.side_effect = subprocess.CalledProcessError(
-            1,
-            ["systemctl", "restart", "rauc-hawkbit-updater"],
-            output=sensitive_detail,
-            stderr=sensitive_detail,
+            1, ["systemctl", "secret-value"], output="secret", stderr="secret"
         )
 
         response = self.fetch("/api/v1/update/check", method="POST", body="")
 
         assert response.code == 500
-        response_body = response.body.decode()
-        assert json.loads(response_body) == {
+        assert json.loads(response.body) == {
             "status": "error",
             "error": "Failed to request update check",
         }
-        assert sensitive_detail not in response_body
+        assert b"secret" not in response.body
 
     @patch("api.update.os_update_is_active", return_value=False)
     @patch("api.update.subprocess.run")
     def test_os_error_is_sanitized(self, run, _active):
-        run.side_effect = FileNotFoundError(2, "systemctl missing", "/private/systemctl")
+        run.side_effect = FileNotFoundError(2, "secret", "/private/systemctl")
 
         response = self.fetch("/api/v1/update/check", method="POST", body="")
 
         assert response.code == 500
-        response_body = response.body.decode()
-        assert json.loads(response_body) == {
+        assert json.loads(response.body) == {
             "status": "error",
             "error": "Failed to request update check",
         }
-        assert "/private/systemctl" not in response_body
+        assert b"/private/systemctl" not in response.body
+
+
+def test_cooldown_exceeds_updater_start_limit_average():
+    assert HAWKBIT_CHECK_COOLDOWN_SECONDS > 20_000 / 5
 
 
 def test_route_is_registered_as_local_access_handler():

--- a/tests/test_update_check_api.py
+++ b/tests/test_update_check_api.py
@@ -48,6 +48,10 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
         )
 
         assert response.code == 403
+        assert json.loads(response.body) == {
+            "status": "error",
+            "error": "This endpoint can only be accessed locally",
+        }
         run.assert_not_called()
 
     @patch("api.update.os_update_is_active", return_value=False)
@@ -70,6 +74,21 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
             "error": "Failed to request update check",
         }
         assert sensitive_detail not in response_body
+
+    @patch("api.update.os_update_is_active", return_value=False)
+    @patch("api.update.subprocess.run")
+    def test_os_error_is_sanitized(self, run, _active):
+        run.side_effect = FileNotFoundError(2, "systemctl missing", "/private/systemctl")
+
+        response = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert response.code == 500
+        response_body = response.body.decode()
+        assert json.loads(response_body) == {
+            "status": "error",
+            "error": "Failed to request update check",
+        }
+        assert "/private/systemctl" not in response_body
 
 
 def test_route_is_registered_as_local_access_handler():

--- a/tests/test_update_check_api.py
+++ b/tests/test_update_check_api.py
@@ -114,7 +114,10 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
         response = self.fetch("/api/v1/update/check", method="POST", body="")
 
         assert response.code == 429
-        assert json.loads(response.body)["retry_after_seconds"] == 4_000
+        assert (
+            json.loads(response.body)["retry_after_seconds"]
+            == HAWKBIT_CHECK_COOLDOWN_SECONDS - 1
+        )
         run.assert_not_called()
 
     @patch("api.update.os_update_is_active", return_value=False)
@@ -230,8 +233,14 @@ class TestUpdateCheckHandler(AsyncHTTPTestCase):
         assert b"/private/systemctl" not in response.body
 
 
-def test_cooldown_exceeds_updater_start_limit_average():
-    assert HAWKBIT_CHECK_COOLDOWN_SECONDS > 20_000 / 5
+def test_cooldown_reserves_three_updater_starts_for_other_paths():
+    start_limit_interval = 20_000
+    start_limit_burst = 5
+    reserved_starts = 3
+
+    assert HAWKBIT_CHECK_COOLDOWN_SECONDS > start_limit_interval / (
+        start_limit_burst - reserved_starts
+    )
 
 
 def test_route_is_registered_as_local_access_handler():

--- a/tests/test_update_check_api.py
+++ b/tests/test_update_check_api.py
@@ -1,0 +1,86 @@
+import json
+import subprocess
+from unittest.mock import patch
+
+import tornado.web
+from tornado.testing import AsyncHTTPTestCase
+
+from api.api import API, APIVersion
+from api.base_handler import LocalAccessHandler
+from api.machine import OSStatus, UpdateOSStatus
+from api.update import UpdateCheckHandler
+
+
+class TestUpdateCheckHandler(AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application([(r"/api/v1/update/check", UpdateCheckHandler)])
+
+    def setUp(self):
+        super().setUp()
+        self.previous_status = UpdateOSStatus.last_status
+        UpdateOSStatus.last_status = OSStatus.IDLE
+
+    def tearDown(self):
+        UpdateOSStatus.last_status = self.previous_status
+        super().tearDown()
+
+    @patch("api.update.subprocess.run")
+    def test_restarts_existing_updater(self, run):
+        response = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert response.code == 200
+        assert json.loads(response.body) == {"status": "success"}
+        run.assert_called_once_with(
+            ["systemctl", "restart", "rauc-hawkbit-updater"], check=True
+        )
+
+    @patch("api.update.subprocess.run")
+    def test_rejects_active_update_without_restart(self, run):
+        for status in (OSStatus.DOWNLOADING, OSStatus.INSTALLING):
+            UpdateOSStatus.last_status = status
+
+            response = self.fetch("/api/v1/update/check", method="POST", body="")
+
+            assert response.code == 409
+
+        run.assert_not_called()
+
+    @patch("api.update.subprocess.run")
+    def test_rejects_non_loopback_proxy_address(self, run):
+        response = self.fetch(
+            "/api/v1/update/check",
+            method="POST",
+            body="",
+            headers={"X-Real-IP": "203.0.113.42"},
+        )
+
+        assert response.code == 403
+        run.assert_not_called()
+
+    @patch("api.update.subprocess.run")
+    def test_restart_failure_is_sanitized(self, run):
+        sensitive_detail = "token=secret /private/updater stderr detail"
+        run.side_effect = subprocess.CalledProcessError(
+            1,
+            ["systemctl", "restart", "rauc-hawkbit-updater"],
+            output=sensitive_detail,
+            stderr=sensitive_detail,
+        )
+
+        response = self.fetch("/api/v1/update/check", method="POST", body="")
+
+        assert response.code == 500
+        response_body = response.body.decode()
+        assert json.loads(response_body) == {
+            "status": "error",
+            "error": "Failed to request update check",
+        }
+        assert sensitive_detail not in response_body
+
+
+def test_route_is_registered_as_local_access_handler():
+    handler, kwargs = API._versions[APIVersion.V1][r"/update/check"]
+
+    assert handler is UpdateCheckHandler
+    assert issubclass(handler, LocalAccessHandler)
+    assert kwargs == {}


### PR DESCRIPTION
<!-- linear-agent-orchestrator:pr-description:start -->
## Summary
- Existing branch head 857f6f5 already satisfies the backend SW-8 acceptance criteria. No additional source changes were necessary.
- Root cause: The original implementation restarted the Hawkbit updater synchronously in Tornado and lacked restart-safe cooldown, emulation safety, and direct shared local-access coverage. Those issues are already corrected on the current branch.

## Validation
- `git diff --check`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-8-attempt-6-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run flake8 --exclude=.venv-wsl .`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-8-attempt-6-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run black --check --diff .`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-8-attempt-6-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run pytest -q`

Linear: [SW-8](https://linear.app/meticulous-home/issue/SW-8/optimize-hawkbit-polling-frequency)

> Draft maintained by the local agent orchestrator. Human approval and merge are required.
<!-- linear-agent-orchestrator:pr-description:end -->