### PR TITLE
SW-111: Introduce an ESP32-owned UUID for Hawkbit Controller ID migration

### DIFF
--- a/api/machine.py
+++ b/api/machine.py
@@ -1,4 +1,6 @@
 import json
+from pathlib import Path
+import shutil
 import subprocess
 
 from hostname import HostnameManager
@@ -26,6 +28,21 @@ from config import (
 )
 
 logger = MeticulousLogger.getLogger(__name__)
+
+FACTORY_RESET_ROOT = Path("/meticulous-user")
+
+
+def cleanup_factory_reset_data(root: Path = FACTORY_RESET_ROOT):
+    """Remove the same non-hidden user data matched by the historical shell glob."""
+    if not root.exists():
+        return
+    for entry in root.iterdir():
+        if entry.name.startswith("."):
+            continue
+        if entry.is_dir() and not entry.is_symlink():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
 
 
 def get_machine_info():
@@ -180,7 +197,7 @@ class MachineResetHandler(LocalAccessHandler):
             self.write({"status": "success", "message": "Emulated mode"})
             return
         logger.warning("Performing factory reset")
-        subprocess.run("rm -rf /meticulous-user/*", shell=True)
+        cleanup_factory_reset_data()
         subprocess.run("reboot")
 
 

--- a/api/machine.py
+++ b/api/machine.py
@@ -39,10 +39,13 @@ def cleanup_factory_reset_data(root: Path = FACTORY_RESET_ROOT):
     for entry in root.iterdir():
         if entry.name.startswith("."):
             continue
-        if entry.is_dir() and not entry.is_symlink():
-            shutil.rmtree(entry)
-        else:
-            entry.unlink()
+        try:
+            if entry.is_dir() and not entry.is_symlink():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+        except OSError as error:
+            logger.warning("Could not remove factory reset entry %s: %s", entry, error)
 
 
 def get_machine_info():

--- a/device_identity.py
+++ b/device_identity.py
@@ -1,0 +1,77 @@
+import os
+import re
+import tempfile
+import uuid
+from pathlib import Path
+
+
+DEVICE_UUID_CACHE_PATH = Path(
+    os.getenv(
+        "DEVICE_UUID_CACHE_PATH",
+        "/meticulous-user/.device-identity/device-uuid",
+    )
+)
+
+DEVICE_UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def is_valid_device_uuid(device_uuid: str) -> bool:
+    return bool(DEVICE_UUID_PATTERN.fullmatch(device_uuid))
+
+
+def generate_device_uuid() -> str:
+    """Generate a canonical UUIDv4 using the VAR-SOM OS entropy source."""
+    return str(uuid.uuid4())
+
+
+def get_device_uuid_assignment(
+    reported_uuid: str,
+    protocol_supported: bool,
+    pending_assignment: str | None,
+) -> str | None:
+    """Return the UUID to assign without consulting the VAR-SOM cache."""
+    if is_valid_device_uuid(reported_uuid) or not protocol_supported:
+        return None
+    if pending_assignment and is_valid_device_uuid(pending_assignment):
+        return pending_assignment
+    return generate_device_uuid()
+
+
+def update_device_uuid_cache(device_uuid: str) -> bool:
+    """Persist the ESP-owned UUID and return whether the cache changed."""
+    if not is_valid_device_uuid(device_uuid):
+        raise ValueError("Invalid ESP device UUID")
+
+    try:
+        cached_uuid = DEVICE_UUID_CACHE_PATH.read_text(encoding="ascii").strip()
+    except (FileNotFoundError, UnicodeError):
+        cached_uuid = ""
+
+    if cached_uuid == device_uuid:
+        DEVICE_UUID_CACHE_PATH.parent.chmod(0o700)
+        DEVICE_UUID_CACHE_PATH.chmod(0o600)
+        return False
+
+    cache_directory = DEVICE_UUID_CACHE_PATH.parent
+    cache_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    cache_directory.chmod(0o700)
+
+    file_descriptor, temporary_path_string = tempfile.mkstemp(
+        prefix=".device-uuid.",
+        dir=cache_directory,
+        text=True,
+    )
+    temporary_path = Path(temporary_path_string)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="ascii") as temporary_file:
+            temporary_file.write(f"{device_uuid}\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        temporary_path.chmod(0o600)
+        os.replace(temporary_path, DEVICE_UUID_CACHE_PATH)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+    return True

--- a/device_identity.py
+++ b/device_identity.py
@@ -6,10 +6,7 @@ from pathlib import Path
 
 
 DEVICE_UUID_CACHE_PATH = Path(
-    os.getenv(
-        "DEVICE_UUID_CACHE_PATH",
-        "/meticulous-user/.device-identity/device-uuid",
-    )
+    os.getenv("DEVICE_UUID_CACHE_PATH", "/meticulous-user/.device-identity/device-uuid")
 )
 
 DEVICE_UUID_PATTERN = re.compile(

--- a/device_identity.py
+++ b/device_identity.py
@@ -4,7 +4,6 @@ import tempfile
 import uuid
 from pathlib import Path
 
-
 DEVICE_UUID_CACHE_PATH = Path(
     os.getenv("DEVICE_UUID_CACHE_PATH", "/meticulous-user/.device-identity/device-uuid")
 )

--- a/esp_serial/data.py
+++ b/esp_serial/data.py
@@ -174,6 +174,8 @@ class ESPInfo:
     scaleModule: str = ""
     partialRetraction: float = 45.0
     autoPurgeAfterShot: bool = False
+    deviceUUID: str = ""
+    deviceUUIDSupported: bool = False
 
     def from_args(args):
         espPinout = 0
@@ -183,7 +185,22 @@ class ESPInfo:
         except Exception:
             pass
         try:
-            if len(args) >= 10:
+            if len(args) >= 11:
+                info = ESPInfo(
+                    args[0],
+                    espPinout,
+                    float(args[2]),
+                    args[3],
+                    args[4],
+                    args[5],
+                    args[6],
+                    args[7],
+                    float(args[8]),
+                    args[9].lower() == "true",
+                    args[10],
+                    True,
+                )
+            elif len(args) >= 10:
                 info = ESPInfo(
                     args[0],
                     espPinout,
@@ -240,6 +257,8 @@ class ESPInfo:
             str(self.partialRetraction),
             "true" if self.autoPurgeAfterShot else "false",
         ]
+        if self.deviceUUIDSupported:
+            args.append(self.deviceUUID)
         return args
 
     def to_sio(self):

--- a/machine.py
+++ b/machine.py
@@ -1119,7 +1119,12 @@ Build Date: {build_date}
     def _restartHawkbitUpdater():
         try:
             restart_result = subprocess.run(
-                ["systemctl", "restart", "rauc-hawkbit-updater.service"],
+                [
+                    "systemctl",
+                    "--no-block",
+                    "restart",
+                    "rauc-hawkbit-updater.service",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=Machine.HAWKBIT_UPDATER_RESTART_TIMEOUT_SECONDS,

--- a/machine.py
+++ b/machine.py
@@ -43,6 +43,11 @@ from esp_serial.data import (
     HeaterTimeoutInfo,
 )
 from esp_serial.esp_tool_wrapper import ESPToolWrapper
+from device_identity import (
+    get_device_uuid_assignment,
+    is_valid_device_uuid,
+    update_device_uuid_cache,
+)
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
 from shot_debug_manager import ShotDebugManager
@@ -159,6 +164,7 @@ class Machine:
     aborted_by_motor_consumtion = False
 
     esp_restart_request = False
+    pending_device_uuid_assignment: str | None = None
 
     @staticmethod
     def get_somrev():
@@ -385,6 +391,7 @@ class Machine:
                     info_requested = False
                     Machine.infoReady = False
                     Machine.profileReady = False
+                    Machine.pending_device_uuid_assignment = None
                     is_valid_message = False
                     collect_tracing_info = False
 
@@ -430,6 +437,13 @@ class Machine:
                         sensor = SensorData.from_args(sensorArgs)
                     case ["ESPInfo", *infoArgs]:
                         info = ESPInfo.from_args(infoArgs)
+                    case ["device_uuid_response", response]:
+                        if response == "ERROR_WRITE_FAILED":
+                            logger.error("ESP32 failed to persist its assigned device UUID")
+                        elif response.startswith("ERROR_"):
+                            logger.error("ESP32 rejected the device UUID assignment")
+                        else:
+                            logger.info("ESP32 accepted the device UUID assignment command")
                     case ["Notify", *notifyArgs]:
                         notify = MachineNotify(
                             notifyArgs[0], ",".join(notifyArgs[1:]).replace(";", "\n")
@@ -647,8 +661,11 @@ class Machine:
                         MeticulousConfig[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     )
                     Machine.setPartialRetraction(backend_partial_retraction)
-                    backend_auto_purge = bool(MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE])
+                    backend_auto_purge = bool(
+                        MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE]
+                    )
                     Machine.setAutoPurgeAfterShot(backend_auto_purge)
+                    Machine.syncDeviceUUID(info.deviceUUID, info.deviceUUIDSupported)
 
                     if (
                         info.serialNumber != ""
@@ -952,6 +969,57 @@ Build Date: {build_date}
 
         MeticulousConfig.save()
         # TODO FIXME IMPLEMENT THIS!!!!
+
+    def syncDeviceUUID(device_uuid: str, device_uuid_supported: bool):
+        if is_valid_device_uuid(device_uuid):
+            Machine.pending_device_uuid_assignment = None
+        elif not device_uuid_supported:
+            Machine.pending_device_uuid_assignment = None
+            return
+        else:
+            if device_uuid:
+                logger.error("ESP32 reported an invalid device UUID")
+
+            Machine.pending_device_uuid_assignment = get_device_uuid_assignment(
+                device_uuid,
+                device_uuid_supported,
+                Machine.pending_device_uuid_assignment,
+            )
+
+            Machine.writeStr(
+                "device_uuid,assign," + Machine.pending_device_uuid_assignment + "\x03"
+            )
+            return
+
+        try:
+            cache_changed = update_device_uuid_cache(device_uuid)
+        except OSError:
+            logger.exception("Failed to update OTA device UUID cache")
+            return
+
+        if not cache_changed:
+            return
+
+        logger.info("Updated OTA device UUID cache from ESP32")
+        if Machine.emulated:
+            return
+
+        try:
+            restart_result = subprocess.run(
+                ["systemctl", "try-restart", "rauc-hawkbit-updater.service"],
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            logger.exception(
+                "Could not restart rauc-hawkbit-updater after updating device UUID cache"
+            )
+            return
+
+        if restart_result.returncode != 0:
+            logger.warning(
+                "Could not restart rauc-hawkbit-updater after updating device UUID cache"
+            )
 
     def setPartialRetraction(partial_retraction: float):
         desired_value = float(partial_retraction)

--- a/machine.py
+++ b/machine.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 from named_thread import NamedThread
+import threading
 import time
 from enum import Enum
 import sentry_sdk
@@ -165,6 +166,12 @@ class Machine:
 
     esp_restart_request = False
     pending_device_uuid_assignment: str | None = None
+    device_uuid_assignment_attempts = 0
+    device_uuid_retry_timer: threading.Timer | None = None
+
+    DEVICE_UUID_MAX_ASSIGNMENT_ATTEMPTS = 3
+    DEVICE_UUID_RETRY_DELAY_SECONDS = 2.0
+    HAWKBIT_UPDATER_RESTART_TIMEOUT_SECONDS = 5
 
     @staticmethod
     def get_somrev():
@@ -391,7 +398,7 @@ class Machine:
                     info_requested = False
                     Machine.infoReady = False
                     Machine.profileReady = False
-                    Machine.pending_device_uuid_assignment = None
+                    Machine._resetDeviceUUIDEnrollment()
                     is_valid_message = False
                     collect_tracing_info = False
 
@@ -438,12 +445,7 @@ class Machine:
                     case ["ESPInfo", *infoArgs]:
                         info = ESPInfo.from_args(infoArgs)
                     case ["device_uuid_response", response]:
-                        if response == "ERROR_WRITE_FAILED":
-                            logger.error("ESP32 failed to persist its assigned device UUID")
-                        elif response.startswith("ERROR_"):
-                            logger.error("ESP32 rejected the device UUID assignment")
-                        else:
-                            logger.info("ESP32 accepted the device UUID assignment command")
+                        Machine.handleDeviceUUIDResponse(response)
                     case ["Notify", *notifyArgs]:
                         notify = MachineNotify(
                             notifyArgs[0], ",".join(notifyArgs[1:]).replace(";", "\n")
@@ -970,23 +972,22 @@ Build Date: {build_date}
 
     def syncDeviceUUID(device_uuid: str, device_uuid_supported: bool):
         if is_valid_device_uuid(device_uuid):
-            Machine.pending_device_uuid_assignment = None
+            Machine._resetDeviceUUIDEnrollment()
         elif not device_uuid_supported:
-            Machine.pending_device_uuid_assignment = None
+            Machine._resetDeviceUUIDEnrollment()
             return
         else:
             if device_uuid:
-                logger.error("ESP32 reported an invalid device UUID")
+                logger.error("ESP32 reported an invalid device UUID: %r", device_uuid)
 
-            Machine.pending_device_uuid_assignment = get_device_uuid_assignment(
-                device_uuid,
-                device_uuid_supported,
-                Machine.pending_device_uuid_assignment,
-            )
-
-            Machine.writeStr(
-                "device_uuid,assign," + Machine.pending_device_uuid_assignment + "\x03"
-            )
+            if Machine.pending_device_uuid_assignment is None:
+                Machine.pending_device_uuid_assignment = get_device_uuid_assignment(
+                    device_uuid,
+                    device_uuid_supported,
+                    None,
+                )
+                Machine.device_uuid_assignment_attempts = 0
+                Machine._sendDeviceUUIDAssignment()
             return
 
         try:
@@ -1002,17 +1003,126 @@ Build Date: {build_date}
         if Machine.emulated:
             return
 
+        restart_thread = NamedThread(
+            "HawkbitRestart",
+            target=Machine._restartHawkbitUpdater,
+            daemon=True,
+        )
+        restart_thread.start()
+
+    def _resetDeviceUUIDEnrollment():
+        Machine._cancelDeviceUUIDRetry()
+        Machine.pending_device_uuid_assignment = None
+        Machine.device_uuid_assignment_attempts = 0
+
+    def _cancelDeviceUUIDRetry():
+        retry_timer = Machine.device_uuid_retry_timer
+        if retry_timer is not None:
+            retry_timer.cancel()
+        Machine.device_uuid_retry_timer = None
+
+    def _sendDeviceUUIDAssignment():
+        candidate = Machine.pending_device_uuid_assignment
+        if candidate is None:
+            return
+        if (
+            Machine.device_uuid_assignment_attempts
+            >= Machine.DEVICE_UUID_MAX_ASSIGNMENT_ATTEMPTS
+        ):
+            logger.error(
+                "ESP32 device UUID assignment exhausted %d attempts; "
+                "the OTA identity cache will remain unchanged until ESPInfo "
+                "confirms a valid UUID",
+                Machine.DEVICE_UUID_MAX_ASSIGNMENT_ATTEMPTS,
+            )
+            return
+
+        Machine.device_uuid_assignment_attempts += 1
+        Machine.writeStr("device_uuid,assign," + candidate + "\x03")
+
+    def _retryDeviceUUIDAssignment():
+        Machine.device_uuid_retry_timer = None
+        Machine._sendDeviceUUIDAssignment()
+
+    def handleDeviceUUIDResponse(response: str):
+        if response == "SUCCESS":
+            Machine._cancelDeviceUUIDRetry()
+            logger.info(
+                "ESP32 device UUID assignment response: SUCCESS; awaiting ESPInfo confirmation"
+            )
+            return
+
+        if response == "ALREADY_ASSIGNED":
+            Machine._cancelDeviceUUIDRetry()
+            logger.info(
+                "ESP32 device UUID assignment response: ALREADY_ASSIGNED; "
+                "awaiting ESPInfo confirmation of the stored UUID"
+            )
+            return
+
+        if response == "ERROR_WRITE_FAILED":
+            if Machine.pending_device_uuid_assignment is None:
+                logger.error(
+                    "ESP32 device UUID assignment response: ERROR_WRITE_FAILED, "
+                    "but no same-boot assignment is pending; no retry scheduled"
+                )
+                return
+
+            if (
+                Machine.device_uuid_assignment_attempts
+                >= Machine.DEVICE_UUID_MAX_ASSIGNMENT_ATTEMPTS
+            ):
+                logger.error(
+                    "ESP32 device UUID assignment response: ERROR_WRITE_FAILED; "
+                    "exhausted %d attempts and the OTA identity cache remains unchanged",
+                    Machine.DEVICE_UUID_MAX_ASSIGNMENT_ATTEMPTS,
+                )
+                return
+
+            if Machine.device_uuid_retry_timer is not None:
+                logger.warning(
+                    "ESP32 device UUID assignment response: ERROR_WRITE_FAILED; "
+                    "a bounded retry is already scheduled"
+                )
+                return
+
+            logger.warning(
+                "ESP32 device UUID assignment response: ERROR_WRITE_FAILED; "
+                "scheduling attempt %d of %d in %.1f seconds",
+                Machine.device_uuid_assignment_attempts + 1,
+                Machine.DEVICE_UUID_MAX_ASSIGNMENT_ATTEMPTS,
+                Machine.DEVICE_UUID_RETRY_DELAY_SECONDS,
+            )
+            retry_timer = threading.Timer(
+                Machine.DEVICE_UUID_RETRY_DELAY_SECONDS,
+                Machine._retryDeviceUUIDAssignment,
+            )
+            retry_timer.daemon = True
+            Machine.device_uuid_retry_timer = retry_timer
+            retry_timer.start()
+            return
+
+        if response in {"ERROR_INVALID_FORMAT", "ERROR_INVALID_UUID"}:
+            logger.error(
+                "ESP32 device UUID assignment response: %s; "
+                "the OTA identity cache remains unchanged",
+                response,
+            )
+            return
+
+        logger.error(
+            "ESP32 device UUID assignment response: %s; "
+            "unrecognized response and no retry scheduled",
+            response,
+        )
+
+    def _restartHawkbitUpdater():
         try:
             restart_result = subprocess.run(
-                [
-                    "systemctl",
-                    "--no-block",
-                    "try-restart",
-                    "rauc-hawkbit-updater.service",
-                ],
+                ["systemctl", "restart", "rauc-hawkbit-updater.service"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=Machine.HAWKBIT_UPDATER_RESTART_TIMEOUT_SECONDS,
             )
         except (OSError, subprocess.TimeoutExpired):
             logger.exception(
@@ -1022,7 +1132,10 @@ Build Date: {build_date}
 
         if restart_result.returncode != 0:
             logger.warning(
-                "Could not restart rauc-hawkbit-updater after updating device UUID cache"
+                "Could not restart rauc-hawkbit-updater after updating device UUID cache: "
+                "exit=%d stderr=%r",
+                restart_result.returncode,
+                restart_result.stderr,
             )
 
     def setPartialRetraction(partial_retraction: float):

--- a/machine.py
+++ b/machine.py
@@ -661,9 +661,7 @@ class Machine:
                         MeticulousConfig[CONFIG_USER][PROFILE_PARTIAL_RETRACTION]
                     )
                     Machine.setPartialRetraction(backend_partial_retraction)
-                    backend_auto_purge = bool(
-                        MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE]
-                    )
+                    backend_auto_purge = bool(MeticulousConfig[CONFIG_USER][PROFILE_AUTO_PURGE])
                     Machine.setAutoPurgeAfterShot(backend_auto_purge)
                     Machine.syncDeviceUUID(info.deviceUUID, info.deviceUUIDSupported)
 

--- a/machine.py
+++ b/machine.py
@@ -1004,11 +1004,17 @@ Build Date: {build_date}
 
         try:
             restart_result = subprocess.run(
-                ["systemctl", "try-restart", "rauc-hawkbit-updater.service"],
+                [
+                    "systemctl",
+                    "--no-block",
+                    "try-restart",
+                    "rauc-hawkbit-updater.service",
+                ],
                 capture_output=True,
                 text=True,
+                timeout=5,
             )
-        except OSError:
+        except (OSError, subprocess.TimeoutExpired):
             logger.exception(
                 "Could not restart rauc-hawkbit-updater after updating device UUID cache"
             )

--- a/tests/test_device_identity.py
+++ b/tests/test_device_identity.py
@@ -21,9 +21,7 @@ def test_validates_canonical_uuid_v4():
     assert device_identity.is_valid_device_uuid(FIRST_UUID)
     assert not device_identity.is_valid_device_uuid("")
     assert not device_identity.is_valid_device_uuid(FIRST_UUID.upper())
-    assert not device_identity.is_valid_device_uuid(
-        "123e4567-e89b-32d3-a456-426614174000"
-    )
+    assert not device_identity.is_valid_device_uuid("123e4567-e89b-32d3-a456-426614174000")
 
 
 def test_generates_canonical_uuid_v4():

--- a/tests/test_device_identity.py
+++ b/tests/test_device_identity.py
@@ -5,7 +5,6 @@ import pytest
 
 import device_identity
 
-
 FIRST_UUID = "123e4567-e89b-42d3-a456-426614174000"
 SECOND_UUID = "987e6543-e21b-45d3-b654-426614174999"
 

--- a/tests/test_device_identity.py
+++ b/tests/test_device_identity.py
@@ -1,0 +1,95 @@
+import os
+import stat
+
+import pytest
+
+import device_identity
+
+
+FIRST_UUID = "123e4567-e89b-42d3-a456-426614174000"
+SECOND_UUID = "987e6543-e21b-45d3-b654-426614174999"
+
+
+@pytest.fixture
+def cache_path(tmp_path, monkeypatch):
+    path = tmp_path / ".device-identity" / "device-uuid"
+    monkeypatch.setattr(device_identity, "DEVICE_UUID_CACHE_PATH", path)
+    return path
+
+
+def test_validates_canonical_uuid_v4():
+    assert device_identity.is_valid_device_uuid(FIRST_UUID)
+    assert not device_identity.is_valid_device_uuid("")
+    assert not device_identity.is_valid_device_uuid(FIRST_UUID.upper())
+    assert not device_identity.is_valid_device_uuid(
+        "123e4567-e89b-32d3-a456-426614174000"
+    )
+
+
+def test_generates_canonical_uuid_v4():
+    assert device_identity.is_valid_device_uuid(device_identity.generate_device_uuid())
+
+
+def test_valid_esp_uuid_never_requests_assignment():
+    assert device_identity.get_device_uuid_assignment(FIRST_UUID, True, SECOND_UUID) is None
+
+
+def test_unsupported_firmware_never_requests_assignment():
+    assert device_identity.get_device_uuid_assignment("", False, None) is None
+
+
+def test_missing_uuid_reuses_pending_assignment_without_reading_cache():
+    assert device_identity.get_device_uuid_assignment("", True, SECOND_UUID) == SECOND_UUID
+
+
+def test_missing_uuid_generates_new_assignment():
+    assignment = device_identity.get_device_uuid_assignment("", True, None)
+
+    assert device_identity.is_valid_device_uuid(assignment)
+
+
+def test_invalid_pending_assignment_is_replaced():
+    assignment = device_identity.get_device_uuid_assignment("", True, "invalid")
+
+    assert device_identity.is_valid_device_uuid(assignment)
+
+
+def test_creates_and_reuses_cache(cache_path):
+    assert device_identity.update_device_uuid_cache(FIRST_UUID)
+    assert cache_path.read_text(encoding="ascii") == f"{FIRST_UUID}\n"
+    if os.name != "nt":
+        assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+    cache_path.parent.chmod(0o755)
+    cache_path.chmod(0o644)
+    assert not device_identity.update_device_uuid_cache(FIRST_UUID)
+    if os.name != "nt":
+        assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+
+def test_esp_uuid_overwrites_different_var_som_cache(cache_path):
+    cache_path.parent.mkdir()
+    cache_path.write_text(f"{FIRST_UUID}\n", encoding="ascii")
+
+    assert device_identity.update_device_uuid_cache(SECOND_UUID)
+    assert cache_path.read_text(encoding="ascii") == f"{SECOND_UUID}\n"
+
+
+def test_esp_uuid_overwrites_non_ascii_var_som_cache(cache_path):
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"\xff\xfe")
+
+    assert device_identity.update_device_uuid_cache(FIRST_UUID)
+    assert cache_path.read_text(encoding="ascii") == f"{FIRST_UUID}\n"
+
+
+def test_rejects_invalid_uuid_without_changing_cache(cache_path):
+    cache_path.parent.mkdir()
+    cache_path.write_text(f"{FIRST_UUID}\n", encoding="ascii")
+
+    with pytest.raises(ValueError):
+        device_identity.update_device_uuid_cache("invalid")
+
+    assert cache_path.read_text(encoding="ascii") == f"{FIRST_UUID}\n"

--- a/tests/test_factory_reset.py
+++ b/tests/test_factory_reset.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+
+# GPIO access is available only on the target machine.
+sys.modules.setdefault("gpiod", MagicMock())
+api_machine = importlib.import_module("api.machine")
+
+
+def test_factory_reset_cleanup_preserves_hidden_identity_cache(tmp_path):
+    identity_cache = tmp_path / ".device-identity" / "device-uuid"
+    identity_cache.parent.mkdir()
+    identity_cache.write_text(
+        "123e4567-e89b-42d3-a456-426614174000\n",
+        encoding="ascii",
+    )
+    ordinary_file = tmp_path / "settings.json"
+    ordinary_file.write_text("user data", encoding="utf-8")
+    ordinary_directory = tmp_path / "profiles"
+    ordinary_directory.mkdir()
+    (ordinary_directory / "profile.json").write_text("{}", encoding="utf-8")
+
+    api_machine.cleanup_factory_reset_data(tmp_path)
+
+    assert identity_cache.read_text(encoding="ascii") == (
+        "123e4567-e89b-42d3-a456-426614174000\n"
+    )
+    assert not ordinary_file.exists()
+    assert not ordinary_directory.exists()

--- a/tests/test_factory_reset.py
+++ b/tests/test_factory_reset.py
@@ -12,8 +12,7 @@ def test_factory_reset_cleanup_preserves_hidden_identity_cache(tmp_path):
     identity_cache = tmp_path / ".device-identity" / "device-uuid"
     identity_cache.parent.mkdir()
     identity_cache.write_text(
-        "123e4567-e89b-42d3-a456-426614174000\n",
-        encoding="ascii",
+        "123e4567-e89b-42d3-a456-426614174000\n", encoding="ascii"
     )
     ordinary_file = tmp_path / "settings.json"
     ordinary_file.write_text("user data", encoding="utf-8")

--- a/tests/test_factory_reset.py
+++ b/tests/test_factory_reset.py
@@ -12,7 +12,8 @@ def test_factory_reset_cleanup_preserves_hidden_identity_cache(tmp_path):
     identity_cache = tmp_path / ".device-identity" / "device-uuid"
     identity_cache.parent.mkdir()
     identity_cache.write_text(
-        "123e4567-e89b-42d3-a456-426614174000\n", encoding="ascii"
+        "123e4567-e89b-42d3-a456-426614174000\n",
+        encoding="ascii",
     )
     ordinary_file = tmp_path / "settings.json"
     ordinary_file.write_text("user data", encoding="utf-8")

--- a/tests/test_factory_reset.py
+++ b/tests/test_factory_reset.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 import sys
 from unittest.mock import MagicMock
 
@@ -27,3 +28,31 @@ def test_factory_reset_cleanup_preserves_hidden_identity_cache(tmp_path):
     )
     assert not ordinary_file.exists()
     assert not ordinary_directory.exists()
+
+
+def test_factory_reset_cleanup_continues_after_deletion_error(tmp_path, monkeypatch, caplog):
+    undeletable_file = tmp_path / "undeletable.json"
+    undeletable_file.write_text("in use", encoding="utf-8")
+    removable_file = tmp_path / "removable.json"
+    removable_file.write_text("user data", encoding="utf-8")
+    original_iterdir = Path.iterdir
+    original_unlink = Path.unlink
+
+    def ordered_iterdir(path):
+        if path == tmp_path:
+            return iter((undeletable_file, removable_file))
+        return original_iterdir(path)
+
+    def unlink_with_error(path, *args, **kwargs):
+        if path == undeletable_file:
+            raise OSError("file is busy")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "iterdir", ordered_iterdir)
+    monkeypatch.setattr(Path, "unlink", unlink_with_error)
+
+    api_machine.cleanup_factory_reset_data(tmp_path)
+
+    assert undeletable_file.exists()
+    assert not removable_file.exists()
+    assert "Could not remove factory reset entry" in caplog.text

--- a/tests/test_factory_reset.py
+++ b/tests/test_factory_reset.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 from unittest.mock import MagicMock
 
-
 # GPIO access is available only on the target machine.
 sys.modules.setdefault("gpiod", MagicMock())
 api_machine = importlib.import_module("api.machine")

--- a/tests/test_machine_device_uuid.py
+++ b/tests/test_machine_device_uuid.py
@@ -1,11 +1,18 @@
 import asyncio
+import importlib
 import subprocess
+import sys
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
-import machine
-from machine import Machine
+# GPIO access is available only on the target machine. Isolate it here so this
+# machine-level test can exercise the UUID synchronization logic with CI's dev
+# dependencies, without adding a hardware-only package to that environment.
+sys.modules.setdefault("gpiod", MagicMock())
+machine = importlib.import_module("machine")
+Machine = machine.Machine
 
 
 FIRST_UUID = "123e4567-e89b-42d3-a456-426614174000"
@@ -32,7 +39,9 @@ def test_missing_uuid_reuses_pending_assignment_within_boot(monkeypatch):
     generated_assignments = []
 
     def assign(reported_uuid, protocol_supported, pending_assignment):
-        generated_assignments.append((reported_uuid, protocol_supported, pending_assignment))
+        generated_assignments.append(
+            (reported_uuid, protocol_supported, pending_assignment)
+        )
         return pending_assignment or FIRST_UUID
 
     monkeypatch.setattr(Machine, "writeStr", writes.append)

--- a/tests/test_machine_device_uuid.py
+++ b/tests/test_machine_device_uuid.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+
 # GPIO access is available only on the target machine. Isolate it here so this
 # machine-level test can exercise the UUID synchronization logic with CI's dev
 # dependencies, without adding a hardware-only package to that environment.
@@ -21,6 +22,8 @@ SECOND_UUID = "987e6543-e21b-45d3-b654-426614174999"
 @pytest.fixture(autouse=True)
 def reset_machine_device_uuid_state(monkeypatch):
     monkeypatch.setattr(Machine, "pending_device_uuid_assignment", None)
+    monkeypatch.setattr(Machine, "device_uuid_assignment_attempts", 0)
+    monkeypatch.setattr(Machine, "device_uuid_retry_timer", None)
     monkeypatch.setattr(Machine, "emulated", False)
 
 
@@ -38,9 +41,7 @@ def test_missing_uuid_reuses_pending_assignment_within_boot(monkeypatch):
     generated_assignments = []
 
     def assign(reported_uuid, protocol_supported, pending_assignment):
-        generated_assignments.append(
-            (reported_uuid, protocol_supported, pending_assignment)
-        )
+        generated_assignments.append((reported_uuid, protocol_supported, pending_assignment))
         return pending_assignment or FIRST_UUID
 
     monkeypatch.setattr(Machine, "writeStr", writes.append)
@@ -50,11 +51,8 @@ def test_missing_uuid_reuses_pending_assignment_within_boot(monkeypatch):
     Machine.syncDeviceUUID("", True)
     Machine.syncDeviceUUID("invalid", True)
 
-    assert generated_assignments == [("", True, None), ("invalid", True, FIRST_UUID)]
-    assert writes == [
-        f"device_uuid,assign,{FIRST_UUID}\x03",
-        f"device_uuid,assign,{FIRST_UUID}\x03",
-    ]
+    assert generated_assignments == [("", True, None)]
+    assert writes == [f"device_uuid,assign,{FIRST_UUID}\x03"]
     assert Machine.pending_device_uuid_assignment == FIRST_UUID
 
 
@@ -111,39 +109,133 @@ def test_confirmed_uuid_updates_cache_without_restart_when_unchanged(monkeypatch
     assert Machine.pending_device_uuid_assignment is None
 
 
-def test_changed_cache_queues_bounded_updater_restart(monkeypatch):
-    calls = []
+def test_changed_cache_starts_background_updater_restart(monkeypatch):
+    started_threads = []
+
+    class FakeThread:
+        def __init__(self, name, target, daemon):
+            started_threads.append((name, target, daemon, self))
+
+        def start(self):
+            self.started = True
+
     monkeypatch.setattr(machine, "update_device_uuid_cache", lambda _device_uuid: True)
+    monkeypatch.setattr(machine, "NamedThread", FakeThread)
+    monkeypatch.setattr(machine.subprocess, "run", pytest.fail)
+
+    Machine.syncDeviceUUID(FIRST_UUID, True)
+
+    assert len(started_threads) == 1
+    name, target, daemon, thread = started_threads[0]
+    assert name == "HawkbitRestart"
+    assert target == Machine._restartHawkbitUpdater
+    assert daemon is True
+    assert thread.started
+
+
+def test_updater_restart_starts_inactive_unit_and_is_bounded(monkeypatch):
+    calls = []
     monkeypatch.setattr(
         machine.subprocess,
         "run",
         lambda *args, **kwargs: calls.append((args, kwargs))
-        or subprocess.CompletedProcess(args[0], 0),
+        or subprocess.CompletedProcess(args[0], 0, "", ""),
     )
 
-    Machine.syncDeviceUUID(FIRST_UUID, True)
+    Machine._restartHawkbitUpdater()
 
     assert calls == [
         (
-            (
-                [
-                    "systemctl",
-                    "--no-block",
-                    "try-restart",
-                    "rauc-hawkbit-updater.service",
-                ],
-            ),
-            {"capture_output": True, "text": True, "timeout": 5},
+            (["systemctl", "restart", "rauc-hawkbit-updater.service"],),
+            {
+                "capture_output": True,
+                "text": True,
+                "timeout": Machine.HAWKBIT_UPDATER_RESTART_TIMEOUT_SECONDS,
+            },
         )
     ]
 
 
 def test_updater_restart_timeout_does_not_escape(monkeypatch):
-    monkeypatch.setattr(machine, "update_device_uuid_cache", lambda _device_uuid: True)
-
     def timeout(*args, **kwargs):
         raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
 
     monkeypatch.setattr(machine.subprocess, "run", timeout)
 
-    Machine.syncDeviceUUID(FIRST_UUID, True)
+    Machine._restartHawkbitUpdater()
+
+
+@pytest.mark.parametrize(
+    ("response", "level"),
+    [
+        ("SUCCESS", "info"),
+        ("ALREADY_ASSIGNED", "info"),
+        ("ERROR_INVALID_FORMAT", "error"),
+        ("ERROR_INVALID_UUID", "error"),
+        ("UNEXPECTED_RESPONSE", "error"),
+    ],
+)
+def test_each_firmware_response_is_logged_exactly(monkeypatch, response, level):
+    log = MagicMock()
+    monkeypatch.setattr(machine, "logger", log)
+    Machine.pending_device_uuid_assignment = FIRST_UUID
+    Machine.device_uuid_assignment_attempts = 1
+
+    Machine.handleDeviceUUIDResponse(response)
+
+    messages = [str(call) for call in getattr(log, level).call_args_list]
+    assert any(response in message for message in messages)
+
+
+def test_write_failure_retries_same_candidate_after_non_busy_delay(monkeypatch):
+    log = MagicMock()
+    writes = []
+    timers = []
+
+    class FakeTimer:
+        def __init__(self, delay, callback):
+            self.delay = delay
+            self.callback = callback
+            self.daemon = False
+            self.started = False
+            timers.append(self)
+
+        def start(self):
+            self.started = True
+
+        def cancel(self):
+            pass
+
+    monkeypatch.setattr(machine.threading, "Timer", FakeTimer)
+    monkeypatch.setattr(machine, "logger", log)
+    monkeypatch.setattr(Machine, "writeStr", writes.append)
+    Machine.pending_device_uuid_assignment = FIRST_UUID
+    Machine.device_uuid_assignment_attempts = 1
+
+    Machine.handleDeviceUUIDResponse("ERROR_WRITE_FAILED")
+
+    assert writes == []
+    assert len(timers) == 1
+    assert timers[0].delay == Machine.DEVICE_UUID_RETRY_DELAY_SECONDS
+    assert timers[0].started
+    assert timers[0].daemon
+    assert "ERROR_WRITE_FAILED" in str(log.warning.call_args)
+
+    timers[0].callback()
+
+    assert writes == [f"device_uuid,assign,{FIRST_UUID}\x03"]
+    assert Machine.device_uuid_assignment_attempts == 2
+
+
+def test_persistent_write_failures_stop_after_bounded_attempts(monkeypatch):
+    log = MagicMock()
+    monkeypatch.setattr(machine, "logger", log)
+    monkeypatch.setattr(machine.threading, "Timer", pytest.fail)
+    monkeypatch.setattr(Machine, "writeStr", pytest.fail)
+    Machine.pending_device_uuid_assignment = FIRST_UUID
+    Machine.device_uuid_assignment_attempts = Machine.DEVICE_UUID_MAX_ASSIGNMENT_ATTEMPTS
+
+    Machine.handleDeviceUUIDResponse("ERROR_WRITE_FAILED")
+
+    assert "ERROR_WRITE_FAILED" in str(log.error.call_args)
+    assert "exhausted" in str(log.error.call_args)

--- a/tests/test_machine_device_uuid.py
+++ b/tests/test_machine_device_uuid.py
@@ -1,0 +1,141 @@
+import asyncio
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import machine
+from machine import Machine
+
+
+FIRST_UUID = "123e4567-e89b-42d3-a456-426614174000"
+SECOND_UUID = "987e6543-e21b-45d3-b654-426614174999"
+
+
+@pytest.fixture(autouse=True)
+def reset_machine_device_uuid_state(monkeypatch):
+    monkeypatch.setattr(Machine, "pending_device_uuid_assignment", None)
+    monkeypatch.setattr(Machine, "emulated", False)
+
+
+def test_unsupported_firmware_receives_no_assignment(monkeypatch):
+    monkeypatch.setattr(Machine, "writeStr", pytest.fail)
+    monkeypatch.setattr(machine, "update_device_uuid_cache", pytest.fail)
+
+    Machine.syncDeviceUUID("", False)
+
+    assert Machine.pending_device_uuid_assignment is None
+
+
+def test_missing_uuid_reuses_pending_assignment_within_boot(monkeypatch):
+    writes = []
+    generated_assignments = []
+
+    def assign(reported_uuid, protocol_supported, pending_assignment):
+        generated_assignments.append((reported_uuid, protocol_supported, pending_assignment))
+        return pending_assignment or FIRST_UUID
+
+    monkeypatch.setattr(Machine, "writeStr", writes.append)
+    monkeypatch.setattr(machine, "get_device_uuid_assignment", assign)
+    monkeypatch.setattr(machine, "update_device_uuid_cache", pytest.fail)
+
+    Machine.syncDeviceUUID("", True)
+    Machine.syncDeviceUUID("invalid", True)
+
+    assert generated_assignments == [("", True, None), ("invalid", True, FIRST_UUID)]
+    assert writes == [
+        f"device_uuid,assign,{FIRST_UUID}\x03",
+        f"device_uuid,assign,{FIRST_UUID}\x03",
+    ]
+    assert Machine.pending_device_uuid_assignment == FIRST_UUID
+
+
+def test_esp_boot_clears_pending_assignment(monkeypatch):
+    class EndRead(Exception):
+        pass
+
+    class BootPort:
+        def __init__(self):
+            self.message = b"rst:0x1 (POWERON_RESET),boot:0x8 (SPI_FAST_FLASH_BOOT)\n"
+
+        @property
+        def in_waiting(self):
+            return len(self.message)
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, _content):
+            pass
+
+        def read(self, _size):
+            if not self.message:
+                raise EndRead
+            message, self.message = self.message, b""
+            return message
+
+    monkeypatch.setattr(Machine, "_connection", SimpleNamespace(port=BootPort()))
+    monkeypatch.setattr(Machine, "_stopESPcomm", False)
+    monkeypatch.setattr(Machine, "infoReady", False)
+    monkeypatch.setattr(Machine, "reset_count", 0)
+    monkeypatch.setattr(Machine, "esp_restart_request", True)
+    Machine.pending_device_uuid_assignment = FIRST_UUID
+
+    with pytest.raises(EndRead):
+        asyncio.run(Machine._read_data())
+
+    assert Machine.pending_device_uuid_assignment is None
+
+
+def test_confirmed_uuid_updates_cache_without_restart_when_unchanged(monkeypatch):
+    Machine.pending_device_uuid_assignment = SECOND_UUID
+    cache_updates = []
+    monkeypatch.setattr(
+        machine,
+        "update_device_uuid_cache",
+        lambda device_uuid: cache_updates.append(device_uuid) and False,
+    )
+    monkeypatch.setattr(machine.subprocess, "run", pytest.fail)
+
+    Machine.syncDeviceUUID(FIRST_UUID, True)
+
+    assert cache_updates == [FIRST_UUID]
+    assert Machine.pending_device_uuid_assignment is None
+
+
+def test_changed_cache_queues_bounded_updater_restart(monkeypatch):
+    calls = []
+    monkeypatch.setattr(machine, "update_device_uuid_cache", lambda _device_uuid: True)
+    monkeypatch.setattr(
+        machine.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs))
+        or subprocess.CompletedProcess(args[0], 0),
+    )
+
+    Machine.syncDeviceUUID(FIRST_UUID, True)
+
+    assert calls == [
+        (
+            (
+                [
+                    "systemctl",
+                    "--no-block",
+                    "try-restart",
+                    "rauc-hawkbit-updater.service",
+                ],
+            ),
+            {"capture_output": True, "text": True, "timeout": 5},
+        )
+    ]
+
+
+def test_updater_restart_timeout_does_not_escape(monkeypatch):
+    monkeypatch.setattr(machine, "update_device_uuid_cache", lambda _device_uuid: True)
+
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(machine.subprocess, "run", timeout)
+
+    Machine.syncDeviceUUID(FIRST_UUID, True)

--- a/tests/test_machine_device_uuid.py
+++ b/tests/test_machine_device_uuid.py
@@ -133,7 +133,7 @@ def test_changed_cache_starts_background_updater_restart(monkeypatch):
     assert thread.started
 
 
-def test_updater_restart_starts_inactive_unit_and_is_bounded(monkeypatch):
+def test_updater_restart_is_enqueued_for_inactive_unit_and_is_bounded(monkeypatch):
     calls = []
     monkeypatch.setattr(
         machine.subprocess,
@@ -146,7 +146,14 @@ def test_updater_restart_starts_inactive_unit_and_is_bounded(monkeypatch):
 
     assert calls == [
         (
-            (["systemctl", "restart", "rauc-hawkbit-updater.service"],),
+            (
+                [
+                    "systemctl",
+                    "--no-block",
+                    "restart",
+                    "rauc-hawkbit-updater.service",
+                ],
+            ),
             {
                 "capture_output": True,
                 "text": True,
@@ -156,13 +163,36 @@ def test_updater_restart_starts_inactive_unit_and_is_bounded(monkeypatch):
     ]
 
 
-def test_updater_restart_timeout_does_not_escape(monkeypatch):
-    def timeout(*args, **kwargs):
-        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+@pytest.mark.parametrize(
+    "error",
+    [OSError("systemctl unavailable"), subprocess.TimeoutExpired("systemctl", 5)],
+)
+def test_updater_restart_command_errors_do_not_escape(monkeypatch, error):
+    log = MagicMock()
 
-    monkeypatch.setattr(machine.subprocess, "run", timeout)
+    def fail(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(machine, "logger", log)
+    monkeypatch.setattr(machine.subprocess, "run", fail)
 
     Machine._restartHawkbitUpdater()
+
+    log.exception.assert_called_once()
+
+
+def test_updater_restart_nonzero_result_is_logged(monkeypatch):
+    log = MagicMock()
+    monkeypatch.setattr(machine, "logger", log)
+    monkeypatch.setattr(
+        machine.subprocess,
+        "run",
+        lambda *args, **_kwargs: subprocess.CompletedProcess(args[0], 1, "", "failed"),
+    )
+
+    Machine._restartHawkbitUpdater()
+
+    log.warning.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_machine_device_uuid.py
+++ b/tests/test_machine_device_uuid.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-
 # GPIO access is available only on the target machine. Isolate it here so this
 # machine-level test can exercise the UUID synchronization logic with CI's dev
 # dependencies, without adding a hardware-only package to that environment.

--- a/tests/test_machine_message_parsing.py
+++ b/tests/test_machine_message_parsing.py
@@ -240,6 +240,7 @@ class TestESPInfo:
         assert info.batchNumber == "B456"
         assert info.buildDate == "2024-01-01"
         assert info.scaleModule == "scale1"
+        assert not info.deviceUUIDSupported
 
     def test_parse_minimal(self):
         args = ["0.9.1", "1", "23.0"]
@@ -266,13 +267,69 @@ class TestESPInfo:
         assert sio["serial_number"] == "SN123"
 
     def test_roundtrip_to_args(self):
-        args = ["1.2.3", "2", "24.5", "black", "SN123", "B456", "2024-01-01", "scale1"]
+        args = [
+            "1.2.3",
+            "2",
+            "24.5",
+            "black",
+            "SN123",
+            "B456",
+            "2024-01-01",
+            "scale1",
+            "45.0",
+            "false",
+            "123e4567-e89b-42d3-a456-426614174000",
+        ]
         info = ESPInfo.from_args(args)
         output = info.to_args()
         reparsed = ESPInfo.from_args(output)
         assert reparsed.firmwareV == info.firmwareV
         assert reparsed.mainVoltage == info.mainVoltage
         assert reparsed.color == info.color
+        assert reparsed.deviceUUID == info.deviceUUID
+        assert reparsed.deviceUUIDSupported
+
+    def test_parse_device_uuid_without_exposing_it_to_sio(self):
+        device_uuid = "123e4567-e89b-42d3-a456-426614174000"
+        args = [
+            "1.2.3",
+            "2",
+            "24.5",
+            "black",
+            "SN123",
+            "B456",
+            "2024-01-01",
+            "scale1",
+            "45.0",
+            "false",
+            device_uuid,
+        ]
+
+        info = ESPInfo.from_args(args)
+
+        assert info.deviceUUID == device_uuid
+        assert info.deviceUUIDSupported
+        assert "device_uuid" not in info.to_sio()
+
+    def test_empty_device_uuid_still_reports_protocol_support(self):
+        args = [
+            "1.2.3",
+            "2",
+            "24.5",
+            "black",
+            "SN123",
+            "B456",
+            "2024-01-01",
+            "scale1",
+            "45.0",
+            "false",
+            "",
+        ]
+
+        info = ESPInfo.from_args(args)
+
+        assert info.deviceUUID == ""
+        assert info.deviceUUIDSupported
 
 
 class TestButtonEventData:

--- a/tests/test_machine_message_parsing.py
+++ b/tests/test_machine_message_parsing.py
@@ -307,9 +307,30 @@ class TestESPInfo:
 
         info = ESPInfo.from_args(args)
 
+        payload = info.to_sio()
+
+        def contains_value(value):
+            if isinstance(value, dict):
+                return any(contains_value(item) for item in value.values())
+            if isinstance(value, (list, tuple)):
+                return any(contains_value(item) for item in value)
+            return value == device_uuid
+
         assert info.deviceUUID == device_uuid
         assert info.deviceUUIDSupported
-        assert "device_uuid" not in info.to_sio()
+        assert set(payload) == {
+            "firmware_version",
+            "esp_pinout",
+            "main_voltage",
+            "color",
+            "serial_number",
+            "batch_number",
+            "build_date",
+            "scale_module",
+            "partial_retraction",
+            "auto_purge_after_shot",
+        }
+        assert not contains_value(payload)
 
     def test_empty_device_uuid_still_reports_protocol_support(self):
         args = [


### PR DESCRIPTION
<!-- linear-agent-orchestrator:pr-description:start -->
## Summary
- Updater restarts are now asynchronously enqueued with `systemctl --no-block restart`. Focused tests assert the command and cover OSError, TimeoutExpired, and nonzero exits while preserving the existing background thread and bounded subprocess guard.
- Root cause: Blocking `systemctl restart` made the five-second subprocess timeout include the service startup lifecycle, causing valid slow startups to be falsely reported as restart failures.

## Validation
- `git diff --check`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-111-attempt-2-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run flake8 --exclude=.venv-wsl .`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-111-attempt-2-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run black --check --diff .`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-111-attempt-2-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run pytest -q`

Linear: [SW-111](https://linear.app/meticulous-home/issue/SW-111/introduce-an-esp32-owned-uuid-for-hawkbit-controller-id-migration)

> Draft maintained by the local agent orchestrator. Human approval and merge are required.
<!-- linear-agent-orchestrator:pr-description:end -->