### PR TITLE
SW-112: Improve ESP32 crash and firmware-update diagnostics in Sentry

### DIFF
--- a/esp_observability.py
+++ b/esp_observability.py
@@ -305,6 +305,11 @@ class ESPObservability:
             and self.recovery_deadline is not None
             and now > self.recovery_deadline
         ):
+            events = []
+            if self._panic_lines and not self.panic_reported:
+                self.panic_reported = True
+                self.reset_reported = True
+                events.append(self._panic_diagnostic("UNKNOWN", ""))
             phase = self.phase.value
             event = ESPDiagnostic(
                 title="ESP32 did not recover after firmware update",
@@ -319,7 +324,7 @@ class ESPObservability:
             )
             self._return_to_normal(now)
             self.timeout_reported = True
-            return [event]
+            return events + [event]
 
         if (
             not self._update_active
@@ -330,6 +335,11 @@ class ESPObservability:
             and self.recovery_deadline is not None
             and now > self.recovery_deadline
         ):
+            events = []
+            if self._panic_lines and not self.panic_reported:
+                self.panic_reported = True
+                self.reset_reported = True
+                events.append(self._panic_diagnostic("UNKNOWN", ""))
             phase = self.phase.value
             operation = (
                 "unexpected_reset"
@@ -338,7 +348,7 @@ class ESPObservability:
             )
             self._return_to_normal(now)
             self.timeout_reported = True
-            return [
+            return events + [
                 ESPDiagnostic(
                     title="ESP32 valid-message timeout",
                     level="error",

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -323,7 +323,8 @@ class ESPObservability:
 
         if (
             not self._update_active
-            and self.phase in {
+            and self.phase
+            in {
                 ESPCommunicationPhase.EXPECTED_RESET,
                 ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
             }

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -44,15 +44,6 @@ class ESPObservability:
     MAX_PANIC_LINES = 80
     MAX_PANIC_BYTES = 8192
 
-    PANIC_MARKERS = (
-        "guru meditation error",
-        "abort() was called",
-        "register dump",
-        "backtrace",
-        "assert failed",
-        "stack smashing protect failure",
-        "heap corruption",
-    )
     GURU_MEDITATION_PATTERN = re.compile(
         r"Guru Meditation Error:\s*Core\s+(\d+)\s+panic'ed(?:\s+\(([^)]+)\))?",
         re.IGNORECASE,
@@ -92,6 +83,7 @@ class ESPObservability:
         self._resolved_panic_incident = False
         self.timeout_reported = False
         self._collecting_panic = False
+        self._panic_deadline = None
         self._panic_lines: list[str] = []
         self._panic_bytes = 0
         self._panic_core = None
@@ -120,11 +112,15 @@ class ESPObservability:
 
     def begin_update(
         self, expected_firmware: str | None, previous_firmware: str | None, now: float
-    ) -> None:
+    ) -> list[ESPDiagnostic]:
+        previous_firmware = self._clean_version(previous_firmware)
+        if previous_firmware is not None:
+            self.previous_firmware = previous_firmware
+        events = self._pending_panic_diagnostics()
         self.phase = ESPCommunicationPhase.FLASHING
         self._update_active = True
         self.expected_firmware = self._clean_version(expected_firmware)
-        self.previous_firmware = self._clean_version(previous_firmware)
+        self.previous_firmware = previous_firmware
         self.boot_seen = False
         self.recovery_deadline = None
         self.pending_unexpected_reset = False
@@ -132,6 +128,7 @@ class ESPObservability:
         self.panic_reported = False
         self.timeout_reported = False
         self._clear_panic()
+        return events
 
     def finish_flashing(self, now: float) -> None:
         self.phase = ESPCommunicationPhase.WAITING_FOR_BOOT
@@ -162,29 +159,39 @@ class ESPObservability:
             and " (SPI_FAST_FLASH_BOOT)" in normalized
         )
 
-        if any(marker in lowered for marker in self.PANIC_MARKERS):
-            starts_panic_incident = (
-                "guru meditation error" in lowered
-                or "abort() was called" in lowered
-                or "assert failed" in lowered
-                or "stack smashing protect failure" in lowered
-                or "heap corruption" in lowered
-            )
-            if not self._collecting_panic and starts_panic_incident:
+        starts_panic_incident = (
+            "guru meditation error" in lowered
+            or "abort() was called" in lowered
+            or "assert failed" in lowered
+            or "stack smashing protect failure" in lowered
+            or "heap corruption" in lowered
+        )
+        if starts_panic_incident:
+            if not self._collecting_panic:
                 self._resolved_panic_incident = False
                 self.panic_reported = False
+                self._clear_panic()
+                self._panic_deadline = now + self.VALID_MESSAGE_TIMEOUT_SECONDS
             self._collecting_panic = True
             guru_match = self.GURU_MEDITATION_PATTERN.search(normalized)
             if guru_match:
                 self._panic_core = guru_match.group(1)
                 self._panic_reason = guru_match.group(2)
+            elif "abort() was called" in lowered:
+                self._panic_reason = "abort"
+            elif "assert failed" in lowered:
+                self._panic_reason = "assert failed"
+            elif "stack smashing protect failure" in lowered:
+                self._panic_reason = "stack smashing protect failure"
+            elif "heap corruption" in lowered:
+                self._panic_reason = "heap corruption"
             abort_match = self.ABORT_PATTERN.search(normalized)
             if abort_match:
                 self._panic_core = abort_match.group(1)
                 self._panic_reason = "abort"
 
         debug_match = self.DEBUG_EXCEPTION_PATTERN.search(normalized)
-        if debug_match:
+        if self._collecting_panic and debug_match:
             detail = debug_match.group(1).strip().rstrip(".")
             location_match = re.fullmatch(r"(.+?)\s*\(([^()]*)\)", detail)
             if location_match:
@@ -195,12 +202,14 @@ class ESPObservability:
 
         if self._collecting_panic and not is_boot_banner:
             self._append_panic_line(normalized)
+            self._panic_deadline = now + self.VALID_MESSAGE_TIMEOUT_SECONDS
 
         if not is_boot_banner:
             return events
 
         self.boot_seen = True
         self._collecting_panic = False
+        self._panic_deadline = None
         if self.update_in_progress:
             self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
             return events
@@ -213,7 +222,7 @@ class ESPObservability:
             return events
 
         self.pending_unexpected_reset = True
-        self.reset_reported = False
+        self.reset_reported = self._resolved_panic_incident
         self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
         self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
         self._recent_unexpected_boots.append(now)
@@ -243,10 +252,7 @@ class ESPObservability:
         if reason == "PANIC" and self._resolved_panic_incident:
             return []
         if reason == "PANIC" or self._panic_lines:
-            self.panic_reported = True
-            self._resolved_panic_incident = True
-            self.reset_reported = True
-            return [self._panic_diagnostic(reason, code)]
+            return self._finalize_panic(reason, code, force=reason == "PANIC")
         if not self.pending_unexpected_reset or self.reset_reported:
             return []
 
@@ -271,10 +277,7 @@ class ESPObservability:
         self.timeout_reported = False
 
         if self._panic_lines and not self.panic_reported:
-            self.panic_reported = True
-            self._resolved_panic_incident = True
-            self.reset_reported = True
-            events = [self._panic_diagnostic("UNKNOWN", "")]
+            events = self._pending_panic_diagnostics()
         elif self.pending_unexpected_reset and not self.reset_reported:
             self.reset_reported = True
             events = [
@@ -289,9 +292,16 @@ class ESPObservability:
         else:
             events = []
 
-        recovering_unexpected_reset = self.pending_unexpected_reset and not self._update_active
+        recovering_non_update_reset = (
+            not self._update_active
+            and self.phase
+            in {
+                ESPCommunicationPhase.EXPECTED_RESET,
+                ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+            }
+        )
         if message_type != "ESPInfo":
-            if recovering_unexpected_reset:
+            if recovering_non_update_reset:
                 self._return_to_normal(now)
             return events
 
@@ -302,7 +312,7 @@ class ESPObservability:
             if self.expected_firmware is None or observed_firmware != self.expected_firmware:
                 return events
             self._return_to_normal(now)
-        elif recovering_unexpected_reset:
+        elif recovering_non_update_reset:
             self._return_to_normal(now)
         elif self.phase in {
             ESPCommunicationPhase.EXPECTED_RESET,
@@ -317,6 +327,15 @@ class ESPObservability:
         return events
 
     def check_timeouts(self, now: float) -> list[ESPDiagnostic]:
+        if (
+            self._collecting_panic
+            and self._panic_deadline is not None
+            and now > self._panic_deadline
+        ):
+            events = self._pending_panic_diagnostics()
+            self.timeout_reported = True
+            return events
+
         if (
             self.update_in_progress
             and self.recovery_deadline is not None
@@ -395,12 +414,19 @@ class ESPObservability:
         return []
 
     def _pending_panic_diagnostics(self) -> list[ESPDiagnostic]:
-        if not self._panic_lines or self.panic_reported:
+        return self._finalize_panic("UNKNOWN", "")
+
+    def _finalize_panic(
+        self, reason: str, code: str, force: bool = False
+    ) -> list[ESPDiagnostic]:
+        if (not self._panic_lines and not force) or self.panic_reported:
             return []
+        event = self._panic_diagnostic(reason, code)
         self.panic_reported = True
         self._resolved_panic_incident = True
         self.reset_reported = True
-        return [self._panic_diagnostic("UNKNOWN", "")]
+        self._clear_panic()
+        return [event]
 
     def _panic_diagnostic(self, reason: str, code: str) -> ESPDiagnostic:
         tags = {"reset_reason": reason, "reset_reason_code": code}
@@ -479,6 +505,7 @@ class ESPObservability:
 
     def _clear_panic(self) -> None:
         self._collecting_panic = False
+        self._panic_deadline = None
         self._panic_lines = []
         self._panic_bytes = 0
         self._panic_core = None

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -305,7 +305,8 @@ class ESPObservability:
 
         if (
             not self._update_active
-            and self.phase in {
+            and self.phase
+            in {
                 ESPCommunicationPhase.EXPECTED_RESET,
                 ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
             }

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -101,7 +101,7 @@ class ESPObservability:
         }
 
     def begin_expected_reset(self, now: float) -> None:
-        self.phase = ESPCommunicationPhase.EXPECTED_RESET
+        self.phase = ESPCommunicationPhase.WAITING_FOR_BOOT
         self._update_active = False
         self.boot_seen = False
         self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
@@ -213,7 +213,10 @@ class ESPObservability:
             self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
             return events
 
-        if self.phase == ESPCommunicationPhase.EXPECTED_RESET or (
+        if self.phase in {
+            ESPCommunicationPhase.EXPECTED_RESET,
+            ESPCommunicationPhase.WAITING_FOR_BOOT,
+        } or (
             self.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
             and not self.pending_unexpected_reset
         ):
@@ -358,6 +361,7 @@ class ESPObservability:
             and self.phase
             in {
                 ESPCommunicationPhase.EXPECTED_RESET,
+                ESPCommunicationPhase.WAITING_FOR_BOOT,
                 ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
             }
             and self.recovery_deadline is not None

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -351,7 +351,9 @@ class ESPObservability:
         ):
             events = self._pending_panic_diagnostics()
             phase = self.phase.value
-            operation = "unexpected_reset" if self.pending_unexpected_reset else "expected_reset"
+            operation = (
+                "unexpected_reset" if self.pending_unexpected_reset else "expected_reset"
+            )
             self._return_to_normal(now)
             self.timeout_reported = True
             return events + [

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -89,6 +89,7 @@ class ESPObservability:
         self.pending_unexpected_reset = False
         self.reset_reported = False
         self.panic_reported = False
+        self._resolved_panic_incident = False
         self.timeout_reported = False
         self._collecting_panic = False
         self._panic_lines: list[str] = []
@@ -162,6 +163,16 @@ class ESPObservability:
         )
 
         if any(marker in lowered for marker in self.PANIC_MARKERS):
+            starts_panic_incident = (
+                "guru meditation error" in lowered
+                or "abort() was called" in lowered
+                or "assert failed" in lowered
+                or "stack smashing protect failure" in lowered
+                or "heap corruption" in lowered
+            )
+            if not self._collecting_panic and starts_panic_incident:
+                self._resolved_panic_incident = False
+                self.panic_reported = False
             self._collecting_panic = True
             guru_match = self.GURU_MEDITATION_PATTERN.search(normalized)
             if guru_match:
@@ -229,8 +240,11 @@ class ESPObservability:
         code = code.strip()
         if self.panic_reported:
             return []
+        if reason == "PANIC" and self._resolved_panic_incident:
+            return []
         if reason == "PANIC" or self._panic_lines:
             self.panic_reported = True
+            self._resolved_panic_incident = True
             self.reset_reported = True
             return [self._panic_diagnostic(reason, code)]
         if not self.pending_unexpected_reset or self.reset_reported:
@@ -258,6 +272,7 @@ class ESPObservability:
 
         if self._panic_lines and not self.panic_reported:
             self.panic_reported = True
+            self._resolved_panic_incident = True
             self.reset_reported = True
             events = [self._panic_diagnostic("UNKNOWN", "")]
         elif self.pending_unexpected_reset and not self.reset_reported:
@@ -297,6 +312,8 @@ class ESPObservability:
 
         if observed_firmware:
             self.previous_firmware = observed_firmware
+        if message_type == "ESPInfo" and self.phase == ESPCommunicationPhase.NORMAL:
+            self._resolved_panic_incident = False
         return events
 
     def check_timeouts(self, now: float) -> list[ESPDiagnostic]:
@@ -305,11 +322,7 @@ class ESPObservability:
             and self.recovery_deadline is not None
             and now > self.recovery_deadline
         ):
-            events = []
-            if self._panic_lines and not self.panic_reported:
-                self.panic_reported = True
-                self.reset_reported = True
-                events.append(self._panic_diagnostic("UNKNOWN", ""))
+            events = self._pending_panic_diagnostics()
             phase = self.phase.value
             event = ESPDiagnostic(
                 title="ESP32 did not recover after firmware update",
@@ -328,24 +341,17 @@ class ESPObservability:
 
         if (
             not self._update_active
-            and self.phase in {
+            and self.phase
+            in {
                 ESPCommunicationPhase.EXPECTED_RESET,
                 ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
             }
             and self.recovery_deadline is not None
             and now > self.recovery_deadline
         ):
-            events = []
-            if self._panic_lines and not self.panic_reported:
-                self.panic_reported = True
-                self.reset_reported = True
-                events.append(self._panic_diagnostic("UNKNOWN", ""))
+            events = self._pending_panic_diagnostics()
             phase = self.phase.value
-            operation = (
-                "unexpected_reset"
-                if self.pending_unexpected_reset
-                else "expected_reset"
-            )
+            operation = "unexpected_reset" if self.pending_unexpected_reset else "expected_reset"
             self._return_to_normal(now)
             self.timeout_reported = True
             return events + [
@@ -385,6 +391,14 @@ class ESPObservability:
                 )
             ]
         return []
+
+    def _pending_panic_diagnostics(self) -> list[ESPDiagnostic]:
+        if not self._panic_lines or self.panic_reported:
+            return []
+        self.panic_reported = True
+        self._resolved_panic_incident = True
+        self.reset_reported = True
+        return [self._panic_diagnostic("UNKNOWN", "")]
 
     def _panic_diagnostic(self, reason: str, code: str) -> ESPDiagnostic:
         tags = {"reset_reason": reason, "reset_reason_code": code}

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -274,9 +274,7 @@ class ESPObservability:
         else:
             events = []
 
-        recovering_unexpected_reset = (
-            self.pending_unexpected_reset and not self._update_active
-        )
+        recovering_unexpected_reset = self.pending_unexpected_reset and not self._update_active
         if message_type != "ESPInfo":
             if recovering_unexpected_reset:
                 self._return_to_normal(now)
@@ -325,8 +323,7 @@ class ESPObservability:
 
         if (
             not self._update_active
-            and self.phase
-            in {
+            and self.phase in {
                 ESPCommunicationPhase.EXPECTED_RESET,
                 ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
             }
@@ -355,7 +352,11 @@ class ESPObservability:
                 )
             ]
 
-        if self.phase != ESPCommunicationPhase.NORMAL or self.pending_unexpected_reset:
+        if (
+            self.phase != ESPCommunicationPhase.NORMAL
+            or self.pending_unexpected_reset
+            or self._collecting_panic
+        ):
             return []
 
         elapsed = now - self.last_valid_message

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -21,6 +21,20 @@ class ESPDiagnostic:
     context: dict[str, object] = field(default_factory=dict)
 
 
+def should_start_firmware_update(
+    available_firmware: object,
+    running_firmware: object,
+    update_in_progress: bool,
+    flashing_disallowed: bool,
+) -> bool:
+    return (
+        available_firmware is not None
+        and available_firmware != running_firmware
+        and not update_in_progress
+        and not flashing_disallowed
+    )
+
+
 class ESPObservability:
     VALID_MESSAGE_TIMEOUT_SECONDS = 2.0
     UPDATE_RECOVERY_TIMEOUT_SECONDS = 30.0

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -1,0 +1,449 @@
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+import re
+
+
+class ESPCommunicationPhase(Enum):
+    NORMAL = "normal"
+    EXPECTED_RESET = "expected_reset"
+    FLASHING = "flashing"
+    WAITING_FOR_BOOT = "waiting_for_boot"
+    WAITING_FOR_PROTOCOL = "waiting_for_protocol"
+
+
+@dataclass(frozen=True)
+class ESPDiagnostic:
+    title: str
+    level: str
+    fingerprint: str
+    tags: dict[str, str] = field(default_factory=dict)
+    context: dict[str, object] = field(default_factory=dict)
+
+
+class ESPObservability:
+    VALID_MESSAGE_TIMEOUT_SECONDS = 2.0
+    UPDATE_RECOVERY_TIMEOUT_SECONDS = 30.0
+    RESET_RECOVERY_TIMEOUT_SECONDS = 15.0
+    BOOT_LOOP_WINDOW_SECONDS = 60.0
+    BOOT_LOOP_THRESHOLD = 3
+    MAX_PANIC_LINES = 80
+    MAX_PANIC_BYTES = 8192
+
+    PANIC_MARKERS = (
+        "guru meditation error",
+        "abort() was called",
+        "register dump",
+        "backtrace",
+        "assert failed",
+        "stack smashing protect failure",
+        "heap corruption",
+    )
+    GURU_MEDITATION_PATTERN = re.compile(
+        r"Guru Meditation Error:\s*Core\s+(\d+)\s+panic'ed(?:\s+\(([^)]+)\))?",
+        re.IGNORECASE,
+    )
+    ABORT_PATTERN = re.compile(
+        r"abort\(\) was called at PC\s+\S+\s+on core\s+(\d+)",
+        re.IGNORECASE,
+    )
+    DEBUG_EXCEPTION_PATTERN = re.compile(
+        r"Debug exception reason:\s*(.+)", re.IGNORECASE
+    )
+    PANIC_CAUSE_ALIASES = {
+        "abort": "abort",
+        "stack canary watchpoint triggered": "stack-canary",
+        "loadprohibited": "load-prohibited",
+        "storeprohibited": "store-prohibited",
+        "illegalinstruction": "illegal-instruction",
+        "integerdividebyzero": "integer-divide-by-zero",
+        "cache error": "cache-error",
+        "interrupt wdt timeout on cpu0": "interrupt-watchdog",
+        "interrupt wdt timeout on cpu1": "interrupt-watchdog",
+        "task watchdog got triggered": "task-watchdog",
+        "stack smashing protect failure": "stack-smashing",
+        "heap corruption": "heap-corruption",
+        "assert failed": "assert",
+    }
+
+    def __init__(self, now: float = 0.0):
+        self.phase = ESPCommunicationPhase.EXPECTED_RESET
+        self.last_valid_message = now
+        self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
+        self.expected_firmware = None
+        self._update_active = False
+        self.previous_firmware = None
+        self.boot_seen = False
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self.panic_reported = False
+        self.timeout_reported = False
+        self._collecting_panic = False
+        self._panic_lines: list[str] = []
+        self._panic_bytes = 0
+        self._panic_core = None
+        self._panic_reason = None
+        self._exception_reason = None
+        self._panic_location = None
+        self._recent_unexpected_boots: deque[float] = deque()
+
+    @property
+    def update_in_progress(self) -> bool:
+        return self._update_active and self.phase in {
+            ESPCommunicationPhase.FLASHING,
+            ESPCommunicationPhase.WAITING_FOR_BOOT,
+            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+        }
+
+    def begin_expected_reset(self, now: float) -> None:
+        self.phase = ESPCommunicationPhase.EXPECTED_RESET
+        self._update_active = False
+        self.boot_seen = False
+        self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self.panic_reported = False
+        self.timeout_reported = False
+
+    def begin_update(
+        self, expected_firmware: str | None, previous_firmware: str | None, now: float
+    ) -> None:
+        self.phase = ESPCommunicationPhase.FLASHING
+        self._update_active = True
+        self.expected_firmware = self._clean_version(expected_firmware)
+        self.previous_firmware = self._clean_version(previous_firmware)
+        self.boot_seen = False
+        self.recovery_deadline = None
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self.panic_reported = False
+        self.timeout_reported = False
+        self._clear_panic()
+
+    def finish_flashing(self, now: float) -> None:
+        self.phase = ESPCommunicationPhase.WAITING_FOR_BOOT
+        self.recovery_deadline = now + self.UPDATE_RECOVERY_TIMEOUT_SECONDS
+
+    def fail_flashing(self, detail: str, stage: str, now: float) -> ESPDiagnostic:
+        event = ESPDiagnostic(
+            title="ESP32 firmware update failed",
+            level="error",
+            fingerprint="esp32-firmware-update-failed",
+            tags={"stage": stage},
+            context={
+                "detail": detail[:1000],
+                "expected_firmware": self.expected_firmware,
+                "previous_firmware": self.previous_firmware,
+            },
+        )
+        self._return_to_normal(now)
+        return event
+
+    def observe_raw_line(self, line: str, now: float) -> list[ESPDiagnostic]:
+        events: list[ESPDiagnostic] = []
+        normalized = line.strip("\r\n")
+        lowered = normalized.lower()
+        is_boot_banner = (
+            normalized.startswith("rst:0x")
+            and "boot:0x" in normalized
+            and " (SPI_FAST_FLASH_BOOT)" in normalized
+        )
+
+        if any(marker in lowered for marker in self.PANIC_MARKERS):
+            self._collecting_panic = True
+            guru_match = self.GURU_MEDITATION_PATTERN.search(normalized)
+            if guru_match:
+                self._panic_core = guru_match.group(1)
+                self._panic_reason = guru_match.group(2)
+            abort_match = self.ABORT_PATTERN.search(normalized)
+            if abort_match:
+                self._panic_core = abort_match.group(1)
+                self._panic_reason = "abort"
+
+        debug_match = self.DEBUG_EXCEPTION_PATTERN.search(normalized)
+        if debug_match:
+            detail = debug_match.group(1).strip().rstrip(".")
+            location_match = re.fullmatch(r"(.+?)\s*\(([^()]*)\)", detail)
+            if location_match:
+                self._exception_reason = location_match.group(1).strip()
+                self._panic_location = location_match.group(2).strip() or None
+            else:
+                self._exception_reason = detail
+
+        if self._collecting_panic and not is_boot_banner:
+            self._append_panic_line(normalized)
+
+        if not is_boot_banner:
+            return events
+
+        self.boot_seen = True
+        self._collecting_panic = False
+        if self.update_in_progress:
+            self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+            return events
+
+        if self.phase in {
+            ESPCommunicationPhase.EXPECTED_RESET,
+            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+        }:
+            self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+            return events
+
+        self.pending_unexpected_reset = True
+        self.reset_reported = False
+        self._recent_unexpected_boots.append(now)
+        cutoff = now - self.BOOT_LOOP_WINDOW_SECONDS
+        while (
+            self._recent_unexpected_boots
+            and self._recent_unexpected_boots[0] < cutoff
+        ):
+            self._recent_unexpected_boots.popleft()
+        if len(self._recent_unexpected_boots) == self.BOOT_LOOP_THRESHOLD:
+            events.append(
+                ESPDiagnostic(
+                    title="ESP32 firmware boot loop detected",
+                    level="critical",
+                    fingerprint="esp32-firmware-boot-loop",
+                    context={
+                        "resets": len(self._recent_unexpected_boots),
+                        "window_seconds": self.BOOT_LOOP_WINDOW_SECONDS,
+                        "previous_firmware": self.previous_firmware,
+                    },
+                )
+            )
+        return events
+
+    def observe_boot_reason(
+        self, reason: str, code: str, now: float
+    ) -> list[ESPDiagnostic]:
+        reason = reason.strip().upper() or "UNKNOWN"
+        code = code.strip()
+        if self.panic_reported:
+            return []
+        if reason == "PANIC" or self._panic_lines:
+            self.panic_reported = True
+            self.reset_reported = True
+            return [self._panic_diagnostic(reason, code)]
+        if not self.pending_unexpected_reset or self.reset_reported:
+            return []
+
+        self.reset_reported = True
+        return [
+            ESPDiagnostic(
+                title="ESP32 unexpected reset detected",
+                level="error",
+                fingerprint=f"esp32-unexpected-reset-{reason.lower()}",
+                tags={"reset_reason": reason, "reset_reason_code": code},
+                context={"previous_firmware": self.previous_firmware},
+            )
+        ]
+
+    def observe_valid_message(
+        self,
+        message_type: str,
+        now: float,
+        firmware_version: str | None = None,
+    ) -> list[ESPDiagnostic]:
+        self.last_valid_message = now
+        self.timeout_reported = False
+
+        if self._panic_lines and not self.panic_reported:
+            self.panic_reported = True
+            self.reset_reported = True
+            events = [self._panic_diagnostic("UNKNOWN", "")]
+        elif self.pending_unexpected_reset and not self.reset_reported:
+            self.reset_reported = True
+            events = [
+                ESPDiagnostic(
+                    title="ESP32 unexpected reset detected",
+                    level="error",
+                    fingerprint="esp32-unexpected-reset-unknown",
+                    tags={"reset_reason": "UNKNOWN"},
+                    context={"previous_firmware": self.previous_firmware},
+                )
+            ]
+        else:
+            events = []
+
+        if message_type != "ESPInfo":
+            return events
+
+        observed_firmware = self._clean_version(firmware_version)
+        if self.update_in_progress:
+            if not self.boot_seen:
+                return events
+            if self.expected_firmware and observed_firmware != self.expected_firmware:
+                return events
+            self._return_to_normal(now)
+        elif self.phase in {
+            ESPCommunicationPhase.EXPECTED_RESET,
+            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+        }:
+            self._return_to_normal(now)
+        elif self.pending_unexpected_reset:
+            self.pending_unexpected_reset = False
+            self._clear_panic()
+
+        if observed_firmware:
+            self.previous_firmware = observed_firmware
+        return events
+
+    def check_timeouts(self, now: float) -> list[ESPDiagnostic]:
+        if (
+            self.update_in_progress
+            and self.recovery_deadline is not None
+            and now > self.recovery_deadline
+        ):
+            phase = self.phase.value
+            event = ESPDiagnostic(
+                title="ESP32 did not recover after firmware update",
+                level="critical",
+                fingerprint="esp32-firmware-update-recovery-failed",
+                tags={"recovery_phase": phase},
+                context={
+                    "expected_firmware": self.expected_firmware,
+                    "previous_firmware": self.previous_firmware,
+                    "timeout_seconds": self.UPDATE_RECOVERY_TIMEOUT_SECONDS,
+                },
+            )
+            self._return_to_normal(now)
+            self.timeout_reported = True
+            return [event]
+
+        if (
+            not self._update_active
+            and self.phase
+            in {
+                ESPCommunicationPhase.EXPECTED_RESET,
+                ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+            }
+            and self.recovery_deadline is not None
+            and now > self.recovery_deadline
+        ):
+            phase = self.phase.value
+            self._return_to_normal(now)
+            self.timeout_reported = True
+            return [
+                ESPDiagnostic(
+                    title="ESP32 valid-message timeout",
+                    level="error",
+                    fingerprint="esp32-valid-message-timeout",
+                    tags={"operation": "expected_reset"},
+                    context={
+                        "recovery_phase": phase,
+                        "threshold_seconds": self.RESET_RECOVERY_TIMEOUT_SECONDS,
+                        "last_known_firmware": self.previous_firmware,
+                    },
+                )
+            ]
+
+        if self.phase != ESPCommunicationPhase.NORMAL or self.pending_unexpected_reset:
+            return []
+
+        elapsed = now - self.last_valid_message
+        if elapsed > self.VALID_MESSAGE_TIMEOUT_SECONDS and not self.timeout_reported:
+            self.timeout_reported = True
+            return [
+                ESPDiagnostic(
+                    title="ESP32 valid-message timeout",
+                    level="error",
+                    fingerprint="esp32-valid-message-timeout",
+                    context={
+                        "elapsed_seconds": round(elapsed, 3),
+                        "threshold_seconds": self.VALID_MESSAGE_TIMEOUT_SECONDS,
+                        "last_known_firmware": self.previous_firmware,
+                    },
+                )
+            ]
+        return []
+
+    def _panic_diagnostic(self, reason: str, code: str) -> ESPDiagnostic:
+        tags = {"reset_reason": reason, "reset_reason_code": code}
+        context: dict[str, object] = {
+            "reset_reason": reason,
+            "previous_firmware": self.previous_firmware,
+        }
+        structured_fields = {
+            "panic_reason": self._panic_reason,
+            "exception_reason": self._exception_reason,
+            "panic_location": self._panic_location,
+            "core": self._panic_core,
+        }
+        for key, value in structured_fields.items():
+            if value:
+                context[key] = value
+                if key != "panic_location":
+                    tags[key] = value
+        if code:
+            context["reset_reason_code"] = code
+        if self._panic_lines:
+            context["panic_output"] = "\n".join(self._panic_lines)
+            context["backtrace"] = "\n".join(
+                line for line in self._panic_lines if "backtrace" in line.lower()
+            )
+            context["panic_output_truncated"] = (
+                len(self._panic_lines) >= self.MAX_PANIC_LINES
+                or self._panic_bytes >= self.MAX_PANIC_BYTES
+            )
+        cause = self._normalized_panic_cause()
+        return ESPDiagnostic(
+            title="ESP32 firmware panic detected",
+            level="critical",
+            fingerprint=f"esp32-firmware-panic-{cause}",
+            tags=tags,
+            context=context,
+        )
+
+    def _normalized_panic_cause(self) -> str:
+        candidates = (self._exception_reason, self._panic_reason)
+        for candidate in candidates:
+            if not candidate:
+                continue
+            normalized = candidate.strip().lower().rstrip(".")
+            cause = self.PANIC_CAUSE_ALIASES.get(normalized)
+            if cause:
+                return cause
+        return "unknown"
+
+    def _append_panic_line(self, line: str) -> None:
+        if len(self._panic_lines) >= self.MAX_PANIC_LINES:
+            return
+        encoded_size = len(line.encode("utf-8", errors="replace")) + 1
+        remaining = self.MAX_PANIC_BYTES - self._panic_bytes
+        if remaining <= 0:
+            return
+        if encoded_size > remaining:
+            line = line.encode("utf-8", errors="replace")[:remaining].decode(
+                "utf-8", errors="ignore"
+            )
+            encoded_size = len(line.encode("utf-8", errors="replace"))
+        self._panic_lines.append(line)
+        self._panic_bytes += encoded_size
+
+    def _return_to_normal(self, now: float) -> None:
+        self.phase = ESPCommunicationPhase.NORMAL
+        self.last_valid_message = now
+        self.recovery_deadline = None
+        self.expected_firmware = None
+        self._update_active = False
+        self.boot_seen = False
+        self.pending_unexpected_reset = False
+        self.reset_reported = False
+        self.panic_reported = False
+        self._clear_panic()
+
+    def _clear_panic(self) -> None:
+        self._collecting_panic = False
+        self._panic_lines = []
+        self._panic_bytes = 0
+        self._panic_core = None
+        self._panic_reason = None
+        self._exception_reason = None
+        self._panic_location = None
+
+    @staticmethod
+    def _clean_version(version: str | None) -> str | None:
+        if version is None:
+            return None
+        cleaned = version.strip()
+        return cleaned or None

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -120,7 +120,6 @@ class ESPObservability:
         self.phase = ESPCommunicationPhase.FLASHING
         self._update_active = True
         self.expected_firmware = self._clean_version(expected_firmware)
-        self.previous_firmware = previous_firmware
         self.boot_seen = False
         self.recovery_deadline = None
         self.pending_unexpected_reset = False

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -288,8 +288,7 @@ class ESPObservability:
         }:
             self._return_to_normal(now)
         elif self.pending_unexpected_reset:
-            self.pending_unexpected_reset = False
-            self._clear_panic()
+            self._return_to_normal(now)
 
         if observed_firmware:
             self.previous_firmware = observed_firmware

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -292,14 +292,10 @@ class ESPObservability:
         else:
             events = []
 
-        recovering_non_update_reset = (
-            not self._update_active
-            and self.phase
-            in {
-                ESPCommunicationPhase.EXPECTED_RESET,
-                ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
-            }
-        )
+        recovering_non_update_reset = not self._update_active and self.phase in {
+            ESPCommunicationPhase.EXPECTED_RESET,
+            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
+        }
         if message_type != "ESPInfo":
             if recovering_non_update_reset:
                 self._return_to_normal(now)

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -194,15 +194,17 @@ class ESPObservability:
             self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
             return events
 
-        if self.phase in {
-            ESPCommunicationPhase.EXPECTED_RESET,
-            ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
-        }:
+        if self.phase == ESPCommunicationPhase.EXPECTED_RESET or (
+            self.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+            and not self.pending_unexpected_reset
+        ):
             self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
             return events
 
         self.pending_unexpected_reset = True
         self.reset_reported = False
+        self.phase = ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+        self.recovery_deadline = now + self.RESET_RECOVERY_TIMEOUT_SECONDS
         self._recent_unexpected_boots.append(now)
         cutoff = now - self.BOOT_LOOP_WINDOW_SECONDS
         while self._recent_unexpected_boots and self._recent_unexpected_boots[0] < cutoff:
@@ -272,7 +274,12 @@ class ESPObservability:
         else:
             events = []
 
+        recovering_unexpected_reset = (
+            self.pending_unexpected_reset and not self._update_active
+        )
         if message_type != "ESPInfo":
+            if recovering_unexpected_reset:
+                self._return_to_normal(now)
             return events
 
         observed_firmware = self._clean_version(firmware_version)
@@ -282,12 +289,12 @@ class ESPObservability:
             if self.expected_firmware is None or observed_firmware != self.expected_firmware:
                 return events
             self._return_to_normal(now)
+        elif recovering_unexpected_reset:
+            self._return_to_normal(now)
         elif self.phase in {
             ESPCommunicationPhase.EXPECTED_RESET,
             ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
         }:
-            self._return_to_normal(now)
-        elif self.pending_unexpected_reset:
             self._return_to_normal(now)
 
         if observed_firmware:
@@ -327,6 +334,11 @@ class ESPObservability:
             and now > self.recovery_deadline
         ):
             phase = self.phase.value
+            operation = (
+                "unexpected_reset"
+                if self.pending_unexpected_reset
+                else "expected_reset"
+            )
             self._return_to_normal(now)
             self.timeout_reported = True
             return [
@@ -334,7 +346,7 @@ class ESPObservability:
                     title="ESP32 valid-message timeout",
                     level="error",
                     fingerprint="esp32-valid-message-timeout",
-                    tags={"operation": "expected_reset"},
+                    tags={"operation": operation},
                     context={
                         "recovery_phase": phase,
                         "threshold_seconds": self.RESET_RECOVERY_TIMEOUT_SECONDS,

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -323,8 +323,7 @@ class ESPObservability:
 
         if (
             not self._update_active
-            and self.phase
-            in {
+            and self.phase in {
                 ESPCommunicationPhase.EXPECTED_RESET,
                 ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
             }

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -47,9 +47,7 @@ class ESPObservability:
         r"abort\(\) was called at PC\s+\S+\s+on core\s+(\d+)",
         re.IGNORECASE,
     )
-    DEBUG_EXCEPTION_PATTERN = re.compile(
-        r"Debug exception reason:\s*(.+)", re.IGNORECASE
-    )
+    DEBUG_EXCEPTION_PATTERN = re.compile(r"Debug exception reason:\s*(.+)", re.IGNORECASE)
     PANIC_CAUSE_ALIASES = {
         "abort": "abort",
         "stack canary watchpoint triggered": "stack-canary",
@@ -193,10 +191,7 @@ class ESPObservability:
         self.reset_reported = False
         self._recent_unexpected_boots.append(now)
         cutoff = now - self.BOOT_LOOP_WINDOW_SECONDS
-        while (
-            self._recent_unexpected_boots
-            and self._recent_unexpected_boots[0] < cutoff
-        ):
+        while self._recent_unexpected_boots and self._recent_unexpected_boots[0] < cutoff:
             self._recent_unexpected_boots.popleft()
         if len(self._recent_unexpected_boots) == self.BOOT_LOOP_THRESHOLD:
             events.append(
@@ -213,9 +208,7 @@ class ESPObservability:
             )
         return events
 
-    def observe_boot_reason(
-        self, reason: str, code: str, now: float
-    ) -> list[ESPDiagnostic]:
+    def observe_boot_reason(self, reason: str, code: str, now: float) -> list[ESPDiagnostic]:
         reason = reason.strip().upper() or "UNKNOWN"
         code = code.strip()
         if self.panic_reported:
@@ -312,8 +305,7 @@ class ESPObservability:
 
         if (
             not self._update_active
-            and self.phase
-            in {
+            and self.phase in {
                 ESPCommunicationPhase.EXPECTED_RESET,
                 ESPCommunicationPhase.WAITING_FOR_PROTOCOL,
             }

--- a/esp_observability.py
+++ b/esp_observability.py
@@ -265,7 +265,7 @@ class ESPObservability:
         if self.update_in_progress:
             if not self.boot_seen:
                 return events
-            if self.expected_firmware and observed_firmware != self.expected_firmware:
+            if self.expected_firmware is None or observed_firmware != self.expected_firmware:
                 return events
             self._return_to_normal(now)
         elif self.phase in {

--- a/machine.py
+++ b/machine.py
@@ -759,6 +759,7 @@ class Machine:
 
                     if (
                         needs_update
+                        and not Machine.esp_observability.update_in_progress
                         and not MeticulousConfig[CONFIG_USER][DISALLOW_FIRMWARE_FLASHING]
                     ):
                         info_string = f"Firmware {Machine.firmware_running.get('Release')}-{Machine.firmware_running['ExtraCommits']} is outdated, upgrading"

--- a/machine.py
+++ b/machine.py
@@ -822,16 +822,12 @@ class Machine:
                         valid_message_type, now, firmware_version
                     )
                 )
-                Machine.esp_restart_request = (
-                    Machine.esp_observability.phase.value != "normal"
-                )
+                Machine.esp_restart_request = Machine.esp_observability.phase.value != "normal"
                 Machine.reset_count = 0
                 AlarmManager.clear_alarm(AlarmType.ESP_DISCONNECTED)
                 AlarmManager.clear_alarm(AlarmType.ESP_RESTART)
 
-            Machine._report_esp_diagnostics(
-                Machine.esp_observability.check_timeouts(now)
-            )
+            Machine._report_esp_diagnostics(Machine.esp_observability.check_timeouts(now))
 
     def stopMotorIfHot(_shotData: ShotData, _sensorData: SensorData):
         from monitoring.motor_power_monitoring import MAX_ENERGY_ALLOWED
@@ -855,9 +851,7 @@ class Machine:
         Machine.action("scale_master_calibration")
 
     def startUpdate():
-        previous_firmware = (
-            Machine.esp_info.firmwareV if Machine.esp_info is not None else None
-        )
+        previous_firmware = Machine.esp_info.firmwareV if Machine.esp_info is not None else None
         Machine.esp_observability.begin_update(
             Machine.firmware_available_string,
             previous_firmware,
@@ -889,9 +883,7 @@ class Machine:
             )
         finally:
             Machine._stopESPcomm = False
-            Machine.esp_restart_request = (
-                Machine.esp_observability.phase.value != "normal"
-            )
+            Machine.esp_restart_request = Machine.esp_observability.phase.value != "normal"
 
         if error_msg:
             updateNotification = Notification(

--- a/machine.py
+++ b/machine.py
@@ -43,6 +43,7 @@ from esp_serial.data import (
     HeaterTimeoutInfo,
 )
 from esp_serial.esp_tool_wrapper import ESPToolWrapper
+from esp_observability import ESPDiagnostic, ESPObservability
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
 from shot_debug_manager import ShotDebugManager
@@ -143,6 +144,7 @@ class Machine:
     shot_start_time = 0
     emulated = False
     firmware_available = None
+    firmware_available_string = None
     firmware_running = None
     startTime = None
 
@@ -159,6 +161,57 @@ class Machine:
     aborted_by_motor_consumtion = False
 
     esp_restart_request = False
+    esp_observability = ESPObservability(time.monotonic())
+
+    @staticmethod
+    def _capture_esp_diagnostic(diagnostic: ESPDiagnostic):
+        with sentry_sdk.new_scope() as scope:
+            scope.set_client(ESPSentryClient)
+            for key, value in diagnostic.tags.items():
+                if value:
+                    scope.set_tag(key, value)
+            if diagnostic.context:
+                scope.set_context("esp-diagnostic", diagnostic.context)
+
+            firmware_version = (
+                diagnostic.context.get("previous_firmware")
+                or Machine.esp_observability.previous_firmware
+            )
+            event = {
+                "message": diagnostic.title,
+                "level": diagnostic.level,
+                "fingerprint": [diagnostic.fingerprint],
+            }
+            if firmware_version:
+                event["release"] = f"espresso-firmware@{firmware_version}"
+                scope.set_tag("firmware-version", firmware_version)
+            scope.capture_event(event)
+
+    @staticmethod
+    def _report_esp_diagnostics(diagnostics: list[ESPDiagnostic]):
+        for diagnostic in diagnostics:
+            logger.warning(f"{diagnostic.title}: tags={diagnostic.tags}")
+            Machine._capture_esp_diagnostic(diagnostic)
+            if diagnostic.title in {
+                "ESP32 firmware panic detected",
+                "ESP32 unexpected reset detected",
+                "ESP32 firmware boot loop detected",
+            }:
+                if AlarmManager.is_alarm_set(AlarmType.ESP_RESTART) is None:
+                    AlarmManager.set_alarm(
+                        AlarmType.ESP_RESTART, end_time=None, force=False, quiet=True
+                    )
+            elif diagnostic.title in {
+                "ESP32 valid-message timeout",
+                "ESP32 did not recover after firmware update",
+            }:
+                if AlarmManager.is_alarm_set(AlarmType.ESP_DISCONNECTED) is None:
+                    AlarmManager.set_alarm(
+                        AlarmType.ESP_DISCONNECTED,
+                        end_time=None,
+                        force=True,
+                        quiet=True,
+                    )
 
     @staticmethod
     def get_somrev():
@@ -239,14 +292,16 @@ class Machine:
             logger.info("The ESP is alive")
 
     def refreshAvailableFirmware():
+        Machine.firmware_available_string = ESPToolWrapper.get_version_from_firmware()
         Machine.firmware_available = Machine._parseVersionString(
-            ESPToolWrapper.get_version_from_firmware()
+            Machine.firmware_available_string
         )
         logger.info(f"Backend available firmware version: {Machine.firmware_available}")
         return Machine.firmware_available
 
     def init(sio):
         Machine.esp_restart_request = True
+        Machine.esp_observability = ESPObservability(time.monotonic())
         Machine._sio = sio
         Machine.refreshAvailableFirmware()
 
@@ -341,10 +396,6 @@ class Machine:
         profile_time = 0
         emulated_firmware = False
         previous_preheat_remaining = None
-        ESP_tracing_info = []
-        collect_tracing_info = False
-        previous_valid_message_timestamp = time.monotonic()
-
         logger.info("Starting to listen for esp32 messages")
         Machine.startTime = time.time()
         while True:
@@ -366,6 +417,10 @@ class Machine:
                     logger.info(data_str.strip("\r\n"))
 
                 data_str_sensors = data_str.strip("\r\n").split(",")
+                now = time.monotonic()
+                Machine._report_esp_diagnostics(
+                    Machine.esp_observability.observe_raw_line(data_str, now)
+                )
 
                 # potential message types
                 button_event = None
@@ -373,6 +428,8 @@ class Machine:
                 data = None
                 info = None
                 notify = None
+                boot_reason = None
+                valid_message_type = None
                 is_valid_message = True
 
                 if data_str.startswith("rst:0x") and all(
@@ -386,25 +443,14 @@ class Machine:
                     Machine.infoReady = False
                     Machine.profileReady = False
                     is_valid_message = False
-                    collect_tracing_info = False
 
-                if Machine.reset_count >= 3:
+                if (
+                    Machine.reset_count >= 3
+                    and not Machine.esp_observability.update_in_progress
+                ):
                     logger.warning("The ESP seems to be resetting, sending update now")
                     Machine.startUpdate()
                     Machine.reset_count = 0
-
-                if any(
-                    crash_check in data_str.lower()
-                    for crash_check in [
-                        "backtrace",
-                        "guru meditation error",
-                        "register dump",
-                    ]
-                ):
-                    collect_tracing_info = True
-
-                if collect_tracing_info:
-                    ESP_tracing_info.append(data_str)
 
                 if Machine.infoReady and not info_requested and Machine.esp_info is None:
                     logger.info(
@@ -420,22 +466,33 @@ class Machine:
                         "CCW" | "CW" | "push" | "pu_d" | "elng" | "ta_d" | "ta_l" | "strt"
                     ] as ev:
                         button_event = ButtonEventData.from_args(ev)
+                        valid_message_type = "Event"
                     case ["Event", *eventData]:
                         button_event = ButtonEventData.from_args(eventData)
+                        valid_message_type = "Event"
                     case ["Data", *dataArgs]:
                         data = ShotData.from_args(dataArgs)
+                        valid_message_type = "Data"
                     case ["Sensors", colorCodedString]:
                         sensor = SensorData.from_color_coded_args(colorCodedString)
+                        valid_message_type = "Sensors"
                     case ["Sensors", *sensorArgs]:
                         sensor = SensorData.from_args(sensorArgs)
+                        valid_message_type = "Sensors"
                     case ["ESPInfo", *infoArgs]:
                         info = ESPInfo.from_args(infoArgs)
+                        valid_message_type = "ESPInfo"
+                    case ["ESPBoot", reason, code]:
+                        boot_reason = (reason, code)
+                        valid_message_type = "ESPBoot"
                     case ["Notify", *notifyArgs]:
                         notify = MachineNotify(
                             notifyArgs[0], ",".join(notifyArgs[1:]).replace(";", "\n")
                         )
+                        valid_message_type = "Notify"
 
                     case ["HeaterTimeoutInfo", *timeoutArgs]:
+                        valid_message_type = "HeaterTimeoutInfo"
                         try:
                             heater_timeout_info = HeaterTimeoutInfo.from_args(timeoutArgs)
                             Machine.heater_timeout_info = heater_timeout_info
@@ -455,6 +512,7 @@ class Machine:
                                 exc_info=True,
                             )
                     case ["Log", *log_data]:
+                        valid_message_type = "Log"
 
                         def get_log_items(log_data: list[str]):
                             for data_str in log_data[2:]:
@@ -527,6 +585,13 @@ class Machine:
                     case [*_]:
                         logger.info(data_str.strip("\r\n"))
                         is_valid_message = False
+
+                if boot_reason is not None:
+                    Machine._report_esp_diagnostics(
+                        Machine.esp_observability.observe_boot_reason(
+                            boot_reason[0], boot_reason[1], now
+                        )
+                    )
 
                 old_ready = Machine.infoReady
 
@@ -743,52 +808,30 @@ class Machine:
                     )
                     NotificationManager.add_notification(Machine._espNotification)
 
-            # healthcheck:
-            # Notify Sentry if
-            # ESP has not sent a valid message in the last 500ms
-            # ESP has rebooted (append backtrace if there is one)
-            #
-            # - NOTE: If the ESP is rebooting, it will not send messages within those 500ms
-            #         So after a reboot we disable this timeout check and re-enable it once
-            #         it starts sending valid messages
-            #
-            # Notify user if
-            # ESP has rebooted
-
             now = time.monotonic()
 
-            if data_bytes is not None and is_valid_message:
-                previous_valid_message_timestamp = now
-                if Machine.esp_restart_request:
-                    logger.debug("clearing Machine.esp_restart_request flag")
-                Machine.esp_restart_request = False
+            if (
+                data_bytes is not None
+                and len(data_bytes) > 0
+                and is_valid_message
+                and valid_message_type is not None
+            ):
+                firmware_version = info.firmwareV if info is not None else None
+                Machine._report_esp_diagnostics(
+                    Machine.esp_observability.observe_valid_message(
+                        valid_message_type, now, firmware_version
+                    )
+                )
+                Machine.esp_restart_request = (
+                    Machine.esp_observability.phase.value != "normal"
+                )
                 Machine.reset_count = 0
                 AlarmManager.clear_alarm(AlarmType.ESP_DISCONNECTED)
                 AlarmManager.clear_alarm(AlarmType.ESP_RESTART)
 
-            if Machine.reset_count > 0 and not Machine.esp_restart_request:
-                if AlarmManager.is_alarm_set(AlarmType.ESP_RESTART) is None:
-                    # notify sentry
-                    with sentry_sdk.new_scope() as scope:
-                        if len(ESP_tracing_info) > 0:
-                            tracing_info = "\n".join(ESP_tracing_info)
-                            scope.set_extra("Tracing Info", tracing_info)
-                        sentry_sdk.capture_message("ESP has restarted unexpectedly", "critical")
-                    AlarmManager.set_alarm(
-                        AlarmType.ESP_RESTART, end_time=None, force=False, quiet=True
-                    )
-                    ESP_tracing_info = []
-
-            if now - previous_valid_message_timestamp > 0.5 and not Machine.esp_restart_request:
-                if AlarmManager.is_alarm_set(AlarmType.ESP_DISCONNECTED) is None:
-                    # notify sentry
-                    sentry_sdk.capture_message("ESP has stopped communicating", "error")
-                    AlarmManager.set_alarm(
-                        AlarmType.ESP_DISCONNECTED,
-                        end_time=None,
-                        force=True,
-                        quiet=True,
-                    )
+            Machine._report_esp_diagnostics(
+                Machine.esp_observability.check_timeouts(now)
+            )
 
     def stopMotorIfHot(_shotData: ShotData, _sensorData: SensorData):
         from monitoring.motor_power_monitoring import MAX_ENERGY_ALLOWED
@@ -812,11 +855,43 @@ class Machine:
         Machine.action("scale_master_calibration")
 
     def startUpdate():
-
+        previous_firmware = (
+            Machine.esp_info.firmwareV if Machine.esp_info is not None else None
+        )
+        Machine.esp_observability.begin_update(
+            Machine.firmware_available_string,
+            previous_firmware,
+            time.monotonic(),
+        )
         Machine._stopESPcomm = True
         Machine.esp_restart_request = True
-        error_msg = Machine._connection.sendUpdate()
-        Machine._stopESPcomm = False
+        error_msg = None
+        try:
+            error_msg = Machine._connection.sendUpdate()
+            if error_msg:
+                Machine._report_esp_diagnostics(
+                    [
+                        Machine.esp_observability.fail_flashing(
+                            str(error_msg), "flash", time.monotonic()
+                        )
+                    ]
+                )
+            else:
+                Machine.esp_observability.finish_flashing(time.monotonic())
+        except Exception as error:
+            error_msg = f"{type(error).__name__}: {error}"
+            Machine._report_esp_diagnostics(
+                [
+                    Machine.esp_observability.fail_flashing(
+                        error_msg, "exception", time.monotonic()
+                    )
+                ]
+            )
+        finally:
+            Machine._stopESPcomm = False
+            Machine.esp_restart_request = (
+                Machine.esp_observability.phase.value != "normal"
+            )
 
         if error_msg:
             updateNotification = Notification(
@@ -880,6 +955,7 @@ class Machine:
 
     def reset():
         Machine.esp_restart_request = True
+        Machine.esp_observability.begin_expected_reset(time.monotonic())
         Machine._connection.reset()
         Machine.infoReady = False
         Machine.profileReady = False

--- a/machine.py
+++ b/machine.py
@@ -592,10 +592,7 @@ class Machine:
                         logger.info(data_str.strip("\r\n"))
                         is_valid_message = False
 
-                if (
-                    (not is_valid_message or valid_message_type is None)
-                    and not is_boot_banner
-                ):
+                if (not is_valid_message or valid_message_type is None) and not is_boot_banner:
                     Machine._report_esp_diagnostics(
                         Machine.esp_observability.observe_raw_line(data_str, now)
                     )

--- a/machine.py
+++ b/machine.py
@@ -422,9 +422,14 @@ class Machine:
 
                 data_str_sensors = data_str.strip("\r\n").split(",")
                 now = time.monotonic()
-                Machine._report_esp_diagnostics(
-                    Machine.esp_observability.observe_raw_line(data_str, now)
+                is_boot_banner = data_str.startswith("rst:0x") and all(
+                    boot_check in data_str
+                    for boot_check in ["boot:0x", " (SPI_FAST_FLASH_BOOT)"]
                 )
+                if is_boot_banner:
+                    Machine._report_esp_diagnostics(
+                        Machine.esp_observability.observe_raw_line(data_str, now)
+                    )
 
                 # potential message types
                 button_event = None
@@ -436,10 +441,7 @@ class Machine:
                 valid_message_type = None
                 is_valid_message = True
 
-                if data_str.startswith("rst:0x") and all(
-                    boot_check in data_str
-                    for boot_check in ["boot:0x", " (SPI_FAST_FLASH_BOOT)"]
-                ):
+                if is_boot_banner:
                     Machine.reset_count += 1
                     Machine.startTime = time.time()
                     Machine.esp_info = None
@@ -589,6 +591,14 @@ class Machine:
                     case [*_]:
                         logger.info(data_str.strip("\r\n"))
                         is_valid_message = False
+
+                if (
+                    (not is_valid_message or valid_message_type is None)
+                    and not is_boot_banner
+                ):
+                    Machine._report_esp_diagnostics(
+                        Machine.esp_observability.observe_raw_line(data_str, now)
+                    )
 
                 if boot_reason is not None:
                     Machine._report_esp_diagnostics(
@@ -856,10 +866,12 @@ class Machine:
 
     def startUpdate():
         previous_firmware = Machine.esp_info.firmwareV if Machine.esp_info is not None else None
-        Machine.esp_observability.begin_update(
-            Machine.firmware_available_string,
-            previous_firmware,
-            time.monotonic(),
+        Machine._report_esp_diagnostics(
+            Machine.esp_observability.begin_update(
+                Machine.firmware_available_string,
+                previous_firmware,
+                time.monotonic(),
+            )
         )
         Machine._stopESPcomm = True
         Machine.esp_restart_request = True

--- a/machine.py
+++ b/machine.py
@@ -43,7 +43,11 @@ from esp_serial.data import (
     HeaterTimeoutInfo,
 )
 from esp_serial.esp_tool_wrapper import ESPToolWrapper
-from esp_observability import ESPDiagnostic, ESPObservability
+from esp_observability import (
+    ESPDiagnostic,
+    ESPObservability,
+    should_start_firmware_update,
+)
 from log import MeticulousLogger
 from notifications import Notification, NotificationManager, NotificationResponse
 from shot_debug_manager import ShotDebugManager
@@ -753,14 +757,13 @@ class Machine:
                         )
                         emulated_firmware = Machine.emulated
 
-                    needs_update = Machine.firmware_available is not None and (
-                        Machine.firmware_available != Machine.firmware_running
-                    )
-
-                    if (
-                        needs_update
-                        and not Machine.esp_observability.update_in_progress
-                        and not MeticulousConfig[CONFIG_USER][DISALLOW_FIRMWARE_FLASHING]
+                    if should_start_firmware_update(
+                        available_firmware=Machine.firmware_available,
+                        running_firmware=Machine.firmware_running,
+                        update_in_progress=Machine.esp_observability.update_in_progress,
+                        flashing_disallowed=MeticulousConfig[CONFIG_USER][
+                            DISALLOW_FIRMWARE_FLASHING
+                        ],
                     ):
                         info_string = f"Firmware {Machine.firmware_running.get('Release')}-{Machine.firmware_running['ExtraCommits']} is outdated, upgrading"
                         logger.info(info_string)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from types import ModuleType
 
 # Set environment variables before any application modules are imported.
 # This ensures config.py, log.py, etc. pick up test-friendly paths.
@@ -7,10 +8,28 @@ os.environ.setdefault("CONFIG_PATH", "/tmp/meticulous-test/config")
 os.environ.setdefault("LOG_PATH", "/tmp/meticulous-test/logs")
 os.environ.setdefault("HISTORY_PATH", "/tmp/meticulous-test/history")
 os.environ.setdefault("DEBUG_HISTORY_PATH", "/tmp/meticulous-test/history/debug")
+os.environ.setdefault("ALARMS_PATH", "/tmp/meticulous-test/alarms")
+os.environ.setdefault("MOTOR_ENERGY_PATH", "/tmp/meticulous-test/energy")
+os.environ.setdefault(
+    "SMOKE_VALIDATION_STATE_FILE", "/tmp/meticulous-test/smoke-validation.json"
+)
+os.environ.setdefault("USER_SOUNDS", "/tmp/meticulous-test/sounds")
 # The real redaction key lives in /root, which the test runner cannot read.
 # Without this every record would come out as the failure placeholder.
 os.makedirs("/tmp/meticulous-test", exist_ok=True)
 os.environ.setdefault("REDACTION_KEY_PATH", "/tmp/meticulous-test/.redaction_key")
+
+# machine.py imports the machine-only gpiod package through its UART and sound adapters.
+# Tests replace those adapters and must remain runnable with only the dev dependency group.
+gpiod = ModuleType("gpiod")
+
+
+class StubLineRequest:
+    DIRECTION_OUTPUT = 1
+
+
+gpiod.line_request = StubLineRequest
+sys.modules.setdefault("gpiod", gpiod)
 
 # Add the backend root to sys.path so imports like "from config import ..."
 # work without installing the package.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ os.environ.setdefault("LOG_PATH", "/tmp/meticulous-test/logs")
 os.environ.setdefault("HISTORY_PATH", "/tmp/meticulous-test/history")
 os.environ.setdefault("DEBUG_HISTORY_PATH", "/tmp/meticulous-test/history/debug")
 os.environ.setdefault("ALARMS_PATH", "/tmp/meticulous-test/alarms")
-os.environ.setdefault("MOTOR_ENERGY_PATH", "/tmp/meticulous-test/energy")
 os.environ.setdefault(
     "SMOKE_VALIDATION_STATE_FILE", "/tmp/meticulous-test/smoke-validation.json"
 )

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -134,11 +134,19 @@ def test_abort_waits_for_boot_reason_and_emits_once():
     assert monitor.observe_valid_message("ESPBoot", 3.1) == []
 
 
-def test_active_panic_collection_suppresses_normal_timeout():
+@pytest.mark.parametrize(
+    "panic_line",
+    [
+        "Guru Meditation Error: Core 1 panic'ed (LoadProhibited).",
+        "abort() was called at PC 0x420037e1 on core 0",
+    ],
+    ids=["guru", "abort"],
+)
+def test_active_panic_collection_suppresses_normal_timeout(panic_line):
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
 
-    monitor.observe_raw_line("abort() was called at PC 0x420037e1 on core 1", 3)
+    monitor.observe_raw_line(panic_line, 1)
 
     assert monitor.phase == ESPCommunicationPhase.NORMAL
     assert monitor.check_timeouts(3.1) == []
@@ -282,12 +290,11 @@ def test_recovery_timeout_reports_retained_panic_once(
 
     timeout = 32.1 if update_recovery else 18.1
     events = monitor.check_timeouts(timeout)
-    assert monitor.check_timeouts(timeout + 0.1) == []
-    assert monitor.observe_valid_message("ESPBoot", timeout + 0.2) == []
+    events += monitor.check_timeouts(timeout + 0.1)
+    events += monitor.observe_boot_reason("PANIC", "4", timeout + 0.2)
+    events += monitor.observe_valid_message("ESPBoot", timeout + 0.3)
 
-    panic_events = [
-        event for event in events if event.title == "ESP32 firmware panic detected"
-    ]
+    panic_events = [event for event in events if event.title == "ESP32 firmware panic detected"]
     assert len(panic_events) == 1
     panic = panic_events[0]
     assert panic.tags["reset_reason"] == "UNKNOWN"
@@ -304,6 +311,13 @@ def test_recovery_timeout_reports_retained_panic_once(
         else "ESP32 valid-message timeout"
     )
     assert titles(events).count(expected_recovery_title) == 1
+
+    capture_guru(monitor, reason="StoreProhibited", now=timeout + 1)
+    monitor.observe_raw_line(BOOT, timeout + 1.3)
+    new_events = monitor.observe_boot_reason("PANIC", "4", timeout + 1.4)
+    assert [event.fingerprint for event in new_events] == [
+        "esp32-firmware-panic-store-prohibited"
+    ]
 
 
 def test_unexpected_boot_protocol_message_clears_recovery_timeout():

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -90,6 +90,18 @@ def test_expected_api_reset_emits_no_error():
     assert monitor.phase == ESPCommunicationPhase.NORMAL
 
 
+@pytest.mark.parametrize("message_type", ["Data", "Sensors"])
+def test_any_valid_message_completes_non_update_expected_reset(message_type):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "current")
+    monitor.begin_expected_reset(1)
+
+    assert monitor.observe_valid_message(message_type, 2) == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+    assert monitor.recovery_deadline is None
+    assert monitor.check_timeouts(16.1) == []
+
+
 def test_exact_debug_exception_is_structured_and_correlated_with_boot_reason():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
@@ -142,14 +154,68 @@ def test_abort_waits_for_boot_reason_and_emits_once():
     ],
     ids=["guru", "abort"],
 )
-def test_active_panic_collection_suppresses_normal_timeout(panic_line):
+def test_silent_panic_is_finalized_without_duplicate_timeout(panic_line):
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
 
     monitor.observe_raw_line(panic_line, 1)
 
     assert monitor.phase == ESPCommunicationPhase.NORMAL
-    assert monitor.check_timeouts(3.1) == []
+    events = monitor.check_timeouts(3.4)
+    events += monitor.check_timeouts(4)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert monitor.observe_boot_reason("PANIC", "4", 5) == []
+
+
+def test_delayed_boot_reason_after_silent_panic_remains_deduplicated():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    capture_guru(monitor, now=1)
+    events = monitor.check_timeouts(3.3)
+
+    events += monitor.observe_raw_line(BOOT, 4)
+    events += monitor.observe_boot_reason("PANIC", "4", 4.1)
+    events += monitor.observe_valid_message("ESPBoot", 4.1)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+def test_normal_timeout_resumes_after_panic_recovery_traffic():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    capture_guru(monitor, now=1)
+    assert titles(monitor.check_timeouts(3.3)) == [
+        "ESP32 firmware panic detected"
+    ]
+
+    assert monitor.observe_valid_message("Data", 4) == []
+    assert titles(monitor.check_timeouts(6.1)) == ["ESP32 valid-message timeout"]
+
+
+@pytest.mark.parametrize("line", ["Register dump:", "Backtrace: 0x1:0x2"])
+def test_standalone_panic_evidence_does_not_suppress_timeout(line):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    assert monitor.observe_raw_line(line, 1) == []
+    events = monitor.check_timeouts(2.2)
+
+    assert titles(events) == ["ESP32 valid-message timeout"]
+
+
+def test_garbled_boot_after_panic_is_bounded_and_finalized_on_silence():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    capture_guru(monitor, now=1)
+    monitor.observe_raw_line("rst:garbled boot output", 1.3)
+
+    events = monitor.check_timeouts(3.4)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert "rst:garbled boot output" in events[0].context["panic_output"]
+    assert monitor.check_timeouts(4) == []
 
 
 def test_independent_panics_are_reported_after_esp_info_recovery():
@@ -172,6 +238,35 @@ def test_independent_panics_are_reported_after_esp_info_recovery():
         "esp32-firmware-panic-load-prohibited",
         "esp32-firmware-panic-store-prohibited",
     ]
+
+
+def test_valid_traffic_finalizes_panic_and_clears_evidence_for_next_incident():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    capture_guru(monitor, reason="LoadProhibited", now=1)
+
+    first_events = monitor.observe_valid_message("Data", 1.5)
+    capture_guru(monitor, reason="StoreProhibited", now=2)
+    second_events = monitor.observe_valid_message("Sensors", 2.5)
+
+    assert [event.fingerprint for event in first_events + second_events] == [
+        "esp32-firmware-panic-load-prohibited",
+        "esp32-firmware-panic-store-prohibited",
+    ]
+    assert "LoadProhibited" in first_events[0].context["panic_output"]
+    assert "LoadProhibited" not in second_events[0].context["panic_output"]
+
+
+def test_begin_update_emits_pending_panic_before_clearing_state():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    capture_guru(monitor, now=1)
+
+    events = monitor.begin_update("2.0.0", "1.2.3", 1.5)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert events[0].context["backtrace"].startswith("Backtrace:")
+    assert monitor.phase == ESPCommunicationPhase.FLASHING
 
 
 def test_older_firmware_valid_message_provides_one_unknown_reset_fallback():
@@ -398,6 +493,26 @@ def test_known_panic_causes_have_separate_fingerprints():
 
     assert load_event.fingerprint == "esp32-firmware-panic-load-prohibited"
     assert abort_event.fingerprint == "esp32-firmware-panic-abort"
+
+
+@pytest.mark.parametrize(
+    ("line", "fingerprint"),
+    [
+        ("assert failed: x.cpp:42", "esp32-firmware-panic-assert"),
+        (
+            "Stack smashing protect failure!",
+            "esp32-firmware-panic-stack-smashing",
+        ),
+        ("Heap corruption detected", "esp32-firmware-panic-heap-corruption"),
+    ],
+)
+def test_other_primary_panic_lines_have_normalized_fingerprints(line, fingerprint):
+    monitor = ESPObservability(now=0)
+    monitor.observe_raw_line(line, 1)
+
+    event = monitor.check_timeouts(3.1)[0]
+
+    assert event.fingerprint == fingerprint
 
 
 def test_variable_unknown_panic_causes_share_bounded_fingerprint():

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -68,6 +68,18 @@ def test_update_recovery_failure_is_specific_and_bounded():
     assert events[0].context["timeout_seconds"] == 30.0
 
 
+def test_update_without_current_info_retains_last_known_firmware():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    monitor.begin_update("2.0.0", None, 1)
+    monitor.finish_flashing(2)
+    event = monitor.check_timeouts(32.1)[0]
+
+    assert monitor.previous_firmware == "1.2.3"
+    assert event.context["previous_firmware"] == "1.2.3"
+
+
 def test_flash_error_is_specific_bounded_and_restores_normal_state():
     monitor = ESPObservability(now=0)
     monitor.begin_update("new", "old", 1)

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -42,6 +42,19 @@ def test_update_requires_boot_and_exact_expected_esp_info_without_false_timeout(
     assert monitor.phase == ESPCommunicationPhase.NORMAL
 
 
+def test_update_without_expected_artifact_version_stays_in_recovery():
+    monitor = ESPObservability(now=0)
+    monitor.begin_update(None, "old", 1)
+    monitor.finish_flashing(2)
+
+    assert monitor.observe_raw_line(BOOT, 2.1) == []
+    assert monitor.observe_valid_message("ESPInfo", 2.2, "new") == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+    assert titles(monitor.check_timeouts(32.1)) == [
+        "ESP32 did not recover after firmware update"
+    ]
+
+
 def test_update_recovery_failure_is_specific_and_bounded():
     monitor = ESPObservability(now=0)
     monitor.begin_update("new", "old", 1)

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -1,6 +1,5 @@
 from esp_observability import ESPCommunicationPhase, ESPObservability
 
-
 BOOT = "rst:0xc (RTC_SW_CPU_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)"
 
 

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -214,6 +214,46 @@ def test_expected_reset_timeout_is_distinct():
     assert events[0].tags["operation"] == "expected_reset"
 
 
+def test_unexpected_boot_without_protocol_reaches_reset_recovery_timeout():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    assert monitor.observe_raw_line(BOOT, 1) == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+    assert monitor.check_timeouts(16) == []
+
+    events = monitor.check_timeouts(16.1)
+
+    assert titles(events) == ["ESP32 valid-message timeout"]
+    assert events[0].tags["operation"] == "unexpected_reset"
+    assert events[0].context["threshold_seconds"] == 15.0
+    assert monitor.check_timeouts(20) == []
+
+
+def test_unexpected_boot_protocol_message_clears_recovery_timeout():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line(BOOT, 1)
+
+    events = monitor.observe_boot_reason("SW", "3", 2)
+    assert monitor.observe_valid_message("ESPBoot", 2) == []
+
+    assert titles(events) == ["ESP32 unexpected reset detected"]
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+    assert monitor.check_timeouts(16.1) == []
+
+
+def test_unexpected_boot_loop_is_detected_without_protocol_follow_up():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    events = []
+    for timestamp in (1, 10, 20):
+        events += monitor.observe_raw_line(BOOT, timestamp)
+
+    assert titles(events) == ["ESP32 firmware boot loop detected"]
+
+
 def test_three_unexpected_boots_report_boot_loop_once():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -1,0 +1,249 @@
+from esp_observability import ESPCommunicationPhase, ESPObservability
+
+
+BOOT = "rst:0xc (RTC_SW_CPU_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)"
+
+
+def titles(events):
+    return [event.title for event in events]
+
+
+def capture_guru(monitor, reason="LoadProhibited", now=1):
+    monitor.observe_raw_line(
+        f"Guru Meditation Error: Core 1 panic'ed ({reason}).", now
+    )
+    monitor.observe_raw_line("Core 1 register dump:", now + 0.1)
+    monitor.observe_raw_line("Backtrace: 0x40381234:0x3fceabcd", now + 0.2)
+
+
+def test_stale_pre_update_info_does_not_finish_update():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", now=0.1, firmware_version="old")
+    monitor.begin_update("new", "old", now=1)
+    monitor.finish_flashing(now=10)
+
+    assert monitor.observe_valid_message("ESPInfo", 10.1, "old") == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_BOOT
+    assert monitor.check_timeouts(12.5) == []
+
+
+def test_update_requires_boot_and_exact_expected_esp_info_without_false_timeout():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "old")
+    monitor.begin_update("new", "old", 1)
+    monitor.finish_flashing(10)
+
+    assert monitor.observe_raw_line(BOOT, 10.2) == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+    assert monitor.check_timeouts(15) == []
+    assert monitor.observe_boot_reason("SW", "3", 12) == []
+    assert monitor.observe_valid_message("Data", 12.1) == []
+    assert monitor.observe_valid_message("ESPInfo", 12.15, "new-dirty") == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+    assert monitor.observe_valid_message("ESPInfo", 12.2, "new") == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+def test_update_recovery_failure_is_specific_and_bounded():
+    monitor = ESPObservability(now=0)
+    monitor.begin_update("new", "old", 1)
+    monitor.finish_flashing(2)
+
+    events = monitor.check_timeouts(32.1)
+
+    assert titles(events) == ["ESP32 did not recover after firmware update"]
+    assert events[0].tags["recovery_phase"] == "waiting_for_boot"
+    assert events[0].context["timeout_seconds"] == 30.0
+
+
+def test_flash_error_is_specific_bounded_and_restores_normal_state():
+    monitor = ESPObservability(now=0)
+    monitor.begin_update("new", "old", 1)
+
+    event = monitor.fail_flashing("x" * 2000, "flash", 2)
+
+    assert event.title == "ESP32 firmware update failed"
+    assert len(event.context["detail"]) == 1000
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+def test_expected_api_reset_emits_no_error():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "current")
+    monitor.begin_expected_reset(1)
+
+    assert monitor.observe_raw_line(BOOT, 1.2) == []
+    assert monitor.observe_boot_reason("SW", "3", 3) == []
+    assert monitor.observe_valid_message("ESPInfo", 3.1, "current") == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+def test_exact_debug_exception_is_structured_and_correlated_with_boot_reason():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line(
+        "Guru Meditation Error: Core 1 panic'ed (Unhandled debug exception).", 1
+    )
+    monitor.observe_raw_line(
+        "Debug exception reason: Stack canary watchpoint triggered (Read ADC)", 1.1
+    )
+    monitor.observe_raw_line("Backtrace: 0x40381234:0x3fceabcd", 1.2)
+
+    assert monitor.observe_raw_line(BOOT, 1.3) == []
+    events = monitor.observe_boot_reason("PANIC", "4", 3.5)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    event = events[0]
+    assert event.tags["reset_reason"] == "PANIC"
+    assert event.tags["reset_reason_code"] == "4"
+    assert event.context["core"] == "1"
+    assert event.context["panic_reason"] == "Unhandled debug exception"
+    assert event.context["exception_reason"] == "Stack canary watchpoint triggered"
+    assert event.context["panic_location"] == "Read ADC"
+    assert event.context["previous_firmware"] == "1.2.3"
+    assert event.context["backtrace"].startswith("Backtrace:")
+    assert event.fingerprint == "esp32-firmware-panic-stack-canary"
+
+
+def test_abort_waits_for_boot_reason_and_emits_once():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line("abort() was called at PC 0x420037e1 on core 1", 1)
+    monitor.observe_raw_line("Backtrace: 0x4037801a:0x3fcebce0", 1.1)
+
+    assert monitor.observe_raw_line(BOOT, 1.2) == []
+    events = monitor.observe_boot_reason("PANIC", "4", 3)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert events[0].context["panic_reason"] == "abort"
+    assert events[0].context["core"] == "1"
+    assert events[0].context["panic_output"].startswith("abort() was called")
+    assert events[0].fingerprint == "esp32-firmware-panic-abort"
+    assert monitor.observe_valid_message("ESPBoot", 3.1) == []
+
+
+def test_older_firmware_valid_message_provides_one_unknown_reset_fallback():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    capture_guru(monitor)
+
+    assert monitor.observe_raw_line(BOOT, 1.3) == []
+    events = monitor.observe_valid_message("Data", 3)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert events[0].tags["reset_reason"] == "UNKNOWN"
+    assert monitor.observe_valid_message("Sensors", 3.1) == []
+
+
+def test_watchdog_reset_is_unexpected_reset_without_raw_backtrace():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line(BOOT, 1)
+
+    events = monitor.observe_boot_reason("TASK_WDT", "6", 3)
+
+    assert titles(events) == ["ESP32 unexpected reset detected"]
+    assert events[0].tags["reset_reason"] == "TASK_WDT"
+
+
+def test_update_panic_is_deduplicated_across_recovery_boots():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "old")
+    monitor.begin_update("new", "old", 1)
+    monitor.finish_flashing(2)
+    capture_guru(monitor, now=2.05)
+
+    assert monitor.observe_raw_line(BOOT, 2.4) == []
+    assert monitor.observe_raw_line(BOOT, 4) == []
+    events = monitor.observe_boot_reason("PANIC", "4", 6)
+
+    assert titles(events) == ["ESP32 firmware panic detected"]
+    assert monitor.observe_valid_message("ESPBoot", 6.1) == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_PROTOCOL
+
+
+def test_normal_valid_message_timeout_is_deduplicated():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    assert monitor.check_timeouts(2) == []
+    assert titles(monitor.check_timeouts(2.2)) == ["ESP32 valid-message timeout"]
+    assert monitor.check_timeouts(5) == []
+
+
+def test_expected_reset_timeout_is_distinct():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.begin_expected_reset(1)
+
+    events = monitor.check_timeouts(16.1)
+
+    assert titles(events) == ["ESP32 valid-message timeout"]
+    assert events[0].tags["operation"] == "expected_reset"
+
+
+def test_three_unexpected_boots_report_boot_loop_once():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    events = []
+    for timestamp in (1, 10, 20, 30):
+        events += monitor.observe_raw_line(BOOT, timestamp)
+        monitor.observe_boot_reason("SW", "3", timestamp + 0.1)
+        monitor.observe_valid_message("ESPInfo", timestamp + 0.2, "1.2.3")
+
+    assert titles(events) == ["ESP32 firmware boot loop detected"]
+
+
+def test_panic_evidence_is_bounded_by_line_count():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line(
+        "Guru Meditation Error: Core 1 panic'ed (LoadProhibited).", 1
+    )
+    for index in range(100):
+        monitor.observe_raw_line(f"register {index}", 1.1 + index / 100)
+    monitor.observe_raw_line(BOOT, 3)
+
+    event = monitor.observe_boot_reason("PANIC", "4", 4)[0]
+
+    assert len(event.context["panic_output"].splitlines()) == 80
+    assert event.context["panic_output_truncated"] is True
+
+
+def test_panic_evidence_is_bounded_by_byte_count():
+    monitor = ESPObservability(now=0)
+    monitor.observe_raw_line("abort() was called at PC 0x1 on core 0", 1)
+    for index in range(20):
+        monitor.observe_raw_line(f"{index}:" + "x" * 1000, 1.1 + index / 100)
+    monitor.observe_raw_line(BOOT, 3)
+
+    event = monitor.observe_boot_reason("PANIC", "4", 4)[0]
+
+    assert len(event.context["panic_output"].encode()) <= 8192
+    assert event.context["panic_output_truncated"] is True
+
+
+def test_known_panic_causes_have_separate_fingerprints():
+    load = ESPObservability()
+    capture_guru(load, "LoadProhibited")
+    load.observe_raw_line(BOOT, 2)
+    load_event = load.observe_boot_reason("PANIC", "4", 3)[0]
+
+    abort = ESPObservability()
+    abort.observe_raw_line("abort() was called at PC 0x1 on core 0", 1)
+    abort.observe_raw_line(BOOT, 2)
+    abort_event = abort.observe_boot_reason("PANIC", "4", 3)[0]
+
+    assert load_event.fingerprint == "esp32-firmware-panic-load-prohibited"
+    assert abort_event.fingerprint == "esp32-firmware-panic-abort"
+
+
+def test_variable_unknown_panic_causes_share_bounded_fingerprint():
+    fingerprints = set()
+    for reason in ("Task foo at 0x1234", "Task bar at 0x9876"):
+        monitor = ESPObservability()
+        capture_guru(monitor, reason)
+        monitor.observe_raw_line(BOOT, 2)
+        fingerprints.add(monitor.observe_boot_reason("PANIC", "4", 3)[0].fingerprint)
+
+    assert fingerprints == {"esp32-firmware-panic-unknown"}

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -99,7 +99,8 @@ def test_any_valid_message_completes_non_update_expected_reset(message_type):
     assert monitor.observe_valid_message(message_type, 2) == []
     assert monitor.phase == ESPCommunicationPhase.NORMAL
     assert monitor.recovery_deadline is None
-    assert monitor.check_timeouts(16.1) == []
+    assert monitor.check_timeouts(3.9) == []
+    assert titles(monitor.check_timeouts(4.1)) == ["ESP32 valid-message timeout"]
 
 
 def test_exact_debug_exception_is_structured_and_correlated_with_boot_reason():
@@ -186,9 +187,7 @@ def test_normal_timeout_resumes_after_panic_recovery_traffic():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
     capture_guru(monitor, now=1)
-    assert titles(monitor.check_timeouts(3.3)) == [
-        "ESP32 firmware panic detected"
-    ]
+    assert titles(monitor.check_timeouts(3.3)) == ["ESP32 firmware panic detected"]
 
     assert monitor.observe_valid_message("Data", 4) == []
     assert titles(monitor.check_timeouts(6.1)) == ["ESP32 valid-message timeout"]

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -102,17 +102,29 @@ def test_expected_api_reset_emits_no_error():
     assert monitor.phase == ESPCommunicationPhase.NORMAL
 
 
-@pytest.mark.parametrize("message_type", ["Data", "Sensors"])
-def test_any_valid_message_completes_non_update_expected_reset(message_type):
+def test_startup_attachment_accepts_valid_protocol_without_boot_banner():
+    monitor = ESPObservability(now=0)
+
+    assert monitor.phase == ESPCommunicationPhase.EXPECTED_RESET
+    assert monitor.observe_valid_message("Data", 0.1) == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
+@pytest.mark.parametrize("message_type", ["Data", "Sensors", "Log", "ESPInfo", "ESPBoot"])
+def test_stale_valid_message_cannot_complete_explicit_reset_before_boot(message_type):
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "current")
     monitor.begin_expected_reset(1)
 
-    assert monitor.observe_valid_message(message_type, 2) == []
+    firmware_version = "current" if message_type == "ESPInfo" else None
+    assert monitor.observe_valid_message(message_type, 2, firmware_version) == []
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_BOOT
+    assert monitor.recovery_deadline == 16
+
+    assert monitor.observe_raw_line(BOOT, 2.1) == []
+    assert monitor.observe_boot_reason("SW", "3", 2.2) == []
+    assert monitor.observe_valid_message("ESPInfo", 2.3, "current") == []
     assert monitor.phase == ESPCommunicationPhase.NORMAL
-    assert monitor.recovery_deadline is None
-    assert monitor.check_timeouts(3.9) == []
-    assert titles(monitor.check_timeouts(4.1)) == ["ESP32 valid-message timeout"]
 
 
 def test_exact_debug_exception_is_structured_and_correlated_with_boot_reason():
@@ -338,6 +350,7 @@ def test_expected_reset_timeout_is_distinct():
 
     assert titles(events) == ["ESP32 valid-message timeout"]
     assert events[0].tags["operation"] == "expected_reset"
+    assert events[0].context["recovery_phase"] == "waiting_for_boot"
 
 
 def test_unexpected_boot_without_protocol_reaches_reset_recovery_timeout():

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -9,9 +9,7 @@ def titles(events):
 
 
 def capture_guru(monitor, reason="LoadProhibited", now=1):
-    monitor.observe_raw_line(
-        f"Guru Meditation Error: Core 1 panic'ed ({reason}).", now
-    )
+    monitor.observe_raw_line(f"Guru Meditation Error: Core 1 panic'ed ({reason}).", now)
     monitor.observe_raw_line("Core 1 register dump:", now + 0.1)
     monitor.observe_raw_line("Backtrace: 0x40381234:0x3fceabcd", now + 0.2)
 
@@ -197,9 +195,7 @@ def test_three_unexpected_boots_report_boot_loop_once():
 def test_panic_evidence_is_bounded_by_line_count():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
-    monitor.observe_raw_line(
-        "Guru Meditation Error: Core 1 panic'ed (LoadProhibited).", 1
-    )
+    monitor.observe_raw_line("Guru Meditation Error: Core 1 panic'ed (LoadProhibited).", 1)
     for index in range(100):
         monitor.observe_raw_line(f"register {index}", 1.1 + index / 100)
     monitor.observe_raw_line(BOOT, 3)

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -132,6 +132,28 @@ def test_abort_waits_for_boot_reason_and_emits_once():
     assert monitor.observe_valid_message("ESPBoot", 3.1) == []
 
 
+def test_independent_panics_are_reported_after_esp_info_recovery():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    capture_guru(monitor, reason="LoadProhibited", now=1)
+    monitor.observe_raw_line(BOOT, 1.3)
+    first_events = monitor.observe_boot_reason("PANIC", "4", 2)
+    assert monitor.observe_boot_reason("PANIC", "4", 2.1) == []
+    assert monitor.observe_valid_message("ESPInfo", 2.2, "1.2.3") == []
+
+    capture_guru(monitor, reason="StoreProhibited", now=3)
+    monitor.observe_raw_line(BOOT, 3.3)
+    second_events = monitor.observe_boot_reason("PANIC", "4", 4)
+
+    assert titles(first_events) == ["ESP32 firmware panic detected"]
+    assert titles(second_events) == ["ESP32 firmware panic detected"]
+    assert [event.fingerprint for event in first_events + second_events] == [
+        "esp32-firmware-panic-load-prohibited",
+        "esp32-firmware-panic-store-prohibited",
+    ]
+
+
 def test_older_firmware_valid_message_provides_one_unknown_reset_fallback():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -132,6 +132,16 @@ def test_abort_waits_for_boot_reason_and_emits_once():
     assert monitor.observe_valid_message("ESPBoot", 3.1) == []
 
 
+def test_active_panic_collection_suppresses_normal_timeout():
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    monitor.observe_raw_line("abort() was called at PC 0x420037e1 on core 1", 3)
+
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+    assert monitor.check_timeouts(3.1) == []
+
+
 def test_independent_panics_are_reported_after_esp_info_recovery():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
@@ -240,7 +250,9 @@ def test_unexpected_boot_protocol_message_clears_recovery_timeout():
 
     assert titles(events) == ["ESP32 unexpected reset detected"]
     assert monitor.phase == ESPCommunicationPhase.NORMAL
-    assert monitor.check_timeouts(16.1) == []
+    assert monitor.recovery_deadline is None
+    assert monitor.check_timeouts(4) == []
+    assert titles(monitor.check_timeouts(4.1)) == ["ESP32 valid-message timeout"]
 
 
 def test_unexpected_boot_loop_is_detected_without_protocol_follow_up():

--- a/tests/test_esp_observability.py
+++ b/tests/test_esp_observability.py
@@ -1,3 +1,5 @@
+import pytest
+
 from esp_observability import ESPCommunicationPhase, ESPObservability
 
 BOOT = "rst:0xc (RTC_SW_CPU_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)"
@@ -238,6 +240,70 @@ def test_unexpected_boot_without_protocol_reaches_reset_recovery_timeout():
     assert events[0].tags["operation"] == "unexpected_reset"
     assert events[0].context["threshold_seconds"] == 15.0
     assert monitor.check_timeouts(20) == []
+
+
+@pytest.mark.parametrize("update_recovery", [False, True], ids=["reset", "update"])
+@pytest.mark.parametrize(
+    ("panic_lines", "core", "fingerprint"),
+    [
+        (
+            [
+                "Guru Meditation Error: Core 1 panic'ed (LoadProhibited).",
+                "Core 1 register dump:",
+                "Backtrace: 0x40381234:0x3fceabcd",
+            ],
+            "1",
+            "esp32-firmware-panic-load-prohibited",
+        ),
+        (
+            [
+                "abort() was called at PC 0x420037e1 on core 0",
+                "Register dump:",
+                "Backtrace: 0x4037801a:0x3fcebce0",
+            ],
+            "0",
+            "esp32-firmware-panic-abort",
+        ),
+    ],
+    ids=["guru", "abort"],
+)
+def test_recovery_timeout_reports_retained_panic_once(
+    update_recovery, panic_lines, core, fingerprint
+):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    if update_recovery:
+        monitor.begin_update("2.0.0", "1.2.3", 1)
+        monitor.finish_flashing(2)
+
+    for index, line in enumerate(panic_lines):
+        monitor.observe_raw_line(line, 2.1 + index / 10)
+    assert monitor.observe_raw_line(BOOT, 3) == []
+
+    timeout = 32.1 if update_recovery else 18.1
+    events = monitor.check_timeouts(timeout)
+    assert monitor.check_timeouts(timeout + 0.1) == []
+    assert monitor.observe_valid_message("ESPBoot", timeout + 0.2) == []
+
+    panic_events = [
+        event for event in events if event.title == "ESP32 firmware panic detected"
+    ]
+    assert len(panic_events) == 1
+    panic = panic_events[0]
+    assert panic.tags["reset_reason"] == "UNKNOWN"
+    assert panic.context["reset_reason"] == "UNKNOWN"
+    assert panic.context["core"] == core
+    assert panic.context["previous_firmware"] == "1.2.3"
+    assert panic.context["backtrace"].startswith("Backtrace:")
+    assert len(panic.context["panic_output"].splitlines()) <= monitor.MAX_PANIC_LINES
+    assert len(panic.context["panic_output"].encode()) <= monitor.MAX_PANIC_BYTES
+    assert panic.fingerprint == fingerprint
+    expected_recovery_title = (
+        "ESP32 did not recover after firmware update"
+        if update_recovery
+        else "ESP32 valid-message timeout"
+    )
+    assert titles(events).count(expected_recovery_title) == 1
 
 
 def test_unexpected_boot_protocol_message_clears_recovery_timeout():

--- a/tests/test_machine_esp_observability.py
+++ b/tests/test_machine_esp_observability.py
@@ -188,6 +188,40 @@ def test_machine_routes_one_bounded_panic_with_firmware_context(run_machine_uart
     assert len(context["panic_output"].encode()) <= monitor.MAX_PANIC_BYTES
 
 
+def test_machine_routes_one_bounded_abort_with_firmware_context(run_machine_uart):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    sentry_events, update_calls = run_machine_uart(
+        [
+            "abort() was called at PC 0x42000000 on core 0\n",
+            "Register dump:\n",
+            "Backtrace: 0x42000000:0x3fc00000\n",
+            "rst:0x3 (SW_RESET),boot:0x8 (SPI_FAST_FLASH_BOOT)\n",
+            "ESPBoot,PANIC,4\n",
+        ],
+        monitor,
+        available_firmware="1.2.3",
+    )
+
+    assert update_calls == []
+    assert len(sentry_events) == 1
+    captured = sentry_events[0]
+    event = captured["event"]
+    context = captured["contexts"]["esp-diagnostic"]
+    assert event["message"] == "ESP32 firmware panic detected"
+    assert event["release"] == "espresso-firmware@1.2.3"
+    assert event["fingerprint"] == ["esp32-firmware-panic-abort"]
+    assert captured["tags"]["firmware-version"] == "1.2.3"
+    assert context["previous_firmware"] == "1.2.3"
+    assert context["reset_reason"] == "PANIC"
+    assert context["core"] == "0"
+    assert context["panic_reason"] == "abort"
+    assert context["backtrace"] == "Backtrace: 0x42000000:0x3fc00000"
+    assert context["panic_output"].startswith("abort() was called")
+    assert len(context["panic_output"].encode()) <= monitor.MAX_PANIC_BYTES
+
+
 def test_machine_missing_expected_version_cannot_complete_or_reflash(run_machine_uart):
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.0.0")

--- a/tests/test_machine_esp_observability.py
+++ b/tests/test_machine_esp_observability.py
@@ -1,0 +1,61 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from config import CONFIG_USER, DISALLOW_FIRMWARE_FLASHING, MeticulousConfig
+from esp_observability import ESPCommunicationPhase, ESPObservability
+from machine import AlarmManager, Machine
+
+
+class StopReadLoop(Exception):
+    pass
+
+
+class OneLineUART:
+    def __init__(self, _port):
+        self.lines = [b"ESPInfo,1.0.0,1,24.0\n"]
+
+    def readline(self, timeout=None):
+        if self.lines:
+            return self.lines.pop(0)
+        raise StopReadLoop
+
+
+def test_stale_esp_info_during_update_recovery_does_not_start_another_update(
+    monkeypatch,
+):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.0.0")
+    monitor.begin_update("2.0.0", "1.0.0", 1)
+    monitor.finish_flashing(2)
+    update_calls = []
+
+    port = SimpleNamespace(reset_input_buffer=lambda: None, write=lambda _data: None)
+    monkeypatch.setattr(Machine, "_connection", SimpleNamespace(port=port))
+    monkeypatch.setattr(Machine, "ReadLine", OneLineUART)
+    monkeypatch.setattr(Machine, "esp_observability", monitor)
+    monkeypatch.setattr(Machine, "firmware_available_string", "2.0.0")
+    monkeypatch.setattr(Machine, "firmware_available", Machine._parseVersionString("2.0.0"))
+    monkeypatch.setattr(Machine, "esp_info", None)
+    monkeypatch.setattr(Machine, "firmware_running", None)
+    monkeypatch.setattr(Machine, "infoReady", False)
+    monkeypatch.setattr(Machine, "_stopESPcomm", False)
+    monkeypatch.setattr(Machine, "shot_start_time", 0)
+    monkeypatch.setattr(Machine, "startTime", None)
+    monkeypatch.setattr(Machine, "esp_restart_request", False)
+    monkeypatch.setattr(Machine, "reset_count", 0)
+    monkeypatch.setattr(Machine, "startUpdate", lambda: update_calls.append(True))
+    monkeypatch.setattr(Machine, "setPartialRetraction", lambda _value: None)
+    monkeypatch.setattr(Machine, "setAutoPurgeAfterShot", lambda _value: None)
+    monkeypatch.setattr(Machine, "toggle_manufacturing_mode", lambda enabled: None)
+    monkeypatch.setattr(AlarmManager, "clear_alarm", lambda _alarm: None)
+    monkeypatch.setitem(MeticulousConfig[CONFIG_USER], DISALLOW_FIRMWARE_FLASHING, False)
+
+    with pytest.raises(StopReadLoop):
+        asyncio.run(Machine._read_data())
+
+    assert update_calls == []
+    assert Machine.firmware_running == Machine._parseVersionString("1.0.0")
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_BOOT
+    assert monitor.expected_firmware == "2.0.0"

--- a/tests/test_machine_esp_observability.py
+++ b/tests/test_machine_esp_observability.py
@@ -1,61 +1,58 @@
-import asyncio
-from types import SimpleNamespace
-
 import pytest
 
-from config import CONFIG_USER, DISALLOW_FIRMWARE_FLASHING, MeticulousConfig
-from esp_observability import ESPCommunicationPhase, ESPObservability
-from machine import AlarmManager, Machine
+from esp_observability import (
+    ESPCommunicationPhase,
+    ESPObservability,
+    should_start_firmware_update,
+)
 
 
-class StopReadLoop(Exception):
-    pass
-
-
-class OneLineUART:
-    def __init__(self, _port):
-        self.lines = [b"ESPInfo,1.0.0,1,24.0\n"]
-
-    def readline(self, timeout=None):
-        if self.lines:
-            return self.lines.pop(0)
-        raise StopReadLoop
-
-
-def test_stale_esp_info_during_update_recovery_does_not_start_another_update(
-    monkeypatch,
-):
+def test_stale_esp_info_during_update_recovery_does_not_start_another_update():
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.0.0")
     monitor.begin_update("2.0.0", "1.0.0", 1)
     monitor.finish_flashing(2)
-    update_calls = []
 
-    port = SimpleNamespace(reset_input_buffer=lambda: None, write=lambda _data: None)
-    monkeypatch.setattr(Machine, "_connection", SimpleNamespace(port=port))
-    monkeypatch.setattr(Machine, "ReadLine", OneLineUART)
-    monkeypatch.setattr(Machine, "esp_observability", monitor)
-    monkeypatch.setattr(Machine, "firmware_available_string", "2.0.0")
-    monkeypatch.setattr(Machine, "firmware_available", Machine._parseVersionString("2.0.0"))
-    monkeypatch.setattr(Machine, "esp_info", None)
-    monkeypatch.setattr(Machine, "firmware_running", None)
-    monkeypatch.setattr(Machine, "infoReady", False)
-    monkeypatch.setattr(Machine, "_stopESPcomm", False)
-    monkeypatch.setattr(Machine, "shot_start_time", 0)
-    monkeypatch.setattr(Machine, "startTime", None)
-    monkeypatch.setattr(Machine, "esp_restart_request", False)
-    monkeypatch.setattr(Machine, "reset_count", 0)
-    monkeypatch.setattr(Machine, "startUpdate", lambda: update_calls.append(True))
-    monkeypatch.setattr(Machine, "setPartialRetraction", lambda _value: None)
-    monkeypatch.setattr(Machine, "setAutoPurgeAfterShot", lambda _value: None)
-    monkeypatch.setattr(Machine, "toggle_manufacturing_mode", lambda enabled: None)
-    monkeypatch.setattr(AlarmManager, "clear_alarm", lambda _alarm: None)
-    monkeypatch.setitem(MeticulousConfig[CONFIG_USER], DISALLOW_FIRMWARE_FLASHING, False)
-
-    with pytest.raises(StopReadLoop):
-        asyncio.run(Machine._read_data())
-
-    assert update_calls == []
-    assert Machine.firmware_running == Machine._parseVersionString("1.0.0")
+    assert monitor.observe_valid_message("ESPInfo", 3, "1.0.0") == []
     assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_BOOT
     assert monitor.expected_firmware == "2.0.0"
+    assert not should_start_firmware_update(
+        available_firmware="2.0.0",
+        running_firmware="1.0.0",
+        update_in_progress=monitor.update_in_progress,
+        flashing_disallowed=False,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "available_firmware",
+        "running_firmware",
+        "update_in_progress",
+        "flashing_disallowed",
+        "expected",
+    ),
+    [
+        ("2.0.0", "1.0.0", False, False, True),
+        ("2.0.0", "1.0.0", True, False, False),
+        ("2.0.0", "2.0.0", False, False, False),
+        ("2.0.0", "1.0.0", False, True, False),
+        (None, "1.0.0", False, False, False),
+    ],
+)
+def test_should_start_firmware_update(
+    available_firmware,
+    running_firmware,
+    update_in_progress,
+    flashing_disallowed,
+    expected,
+):
+    assert (
+        should_start_firmware_update(
+            available_firmware,
+            running_firmware,
+            update_in_progress,
+            flashing_disallowed,
+        )
+        is expected
+    )

--- a/tests/test_machine_esp_observability.py
+++ b/tests/test_machine_esp_observability.py
@@ -60,6 +60,7 @@ class CapturedSentryScope:
 def run_machine_uart(monkeypatch):
     sentry_events = []
     update_calls = []
+    alarm_calls = []
     port = SimpleNamespace(reset_input_buffer=lambda: None, write=lambda _data: None)
 
     monkeypatch.setattr(Machine, "_connection", SimpleNamespace(port=port))
@@ -82,7 +83,11 @@ def run_machine_uart(monkeypatch):
         lambda: CapturedSentryScope(sentry_events),
     )
     monkeypatch.setattr(AlarmManager, "is_alarm_set", lambda _alarm: None)
-    monkeypatch.setattr(AlarmManager, "set_alarm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        AlarmManager,
+        "set_alarm",
+        lambda alarm, *_args, **_kwargs: alarm_calls.append(alarm),
+    )
     monkeypatch.setattr(AlarmManager, "clear_alarm", lambda _alarm: None)
     monkeypatch.setitem(MeticulousConfig[CONFIG_USER], DISALLOW_FIRMWARE_FLASHING, False)
 
@@ -107,6 +112,7 @@ def run_machine_uart(monkeypatch):
             asyncio.run(Machine._read_data())
         return sentry_events, update_calls
 
+    run.alarm_calls = alarm_calls
     return run
 
 
@@ -220,6 +226,52 @@ def test_machine_routes_one_bounded_abort_with_firmware_context(run_machine_uart
     assert context["backtrace"] == "Backtrace: 0x42000000:0x3fc00000"
     assert context["panic_output"].startswith("abort() was called")
     assert len(context["panic_output"].encode()) <= monitor.MAX_PANIC_BYTES
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "assert failed in old diagnostic text",
+        "Backtrace: is a troubleshooting label",
+        "heap corruption is not what this log reports",
+    ],
+)
+def test_valid_log_marker_text_does_not_start_raw_panic(run_machine_uart, message):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    sentry_events, update_calls = run_machine_uart(
+        [f"Log,info,{message}\n"],
+        monitor,
+        available_firmware="1.2.3",
+    )
+
+    assert sentry_events == []
+    assert update_calls == []
+    assert run_machine_uart.alarm_calls == []
+
+
+def test_start_update_reports_pending_panic_before_automatic_reflash_cleanup(
+    monkeypatch,
+):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.observe_raw_line(
+        "Guru Meditation Error: Core 1 panic'ed (LoadProhibited).", 1
+    )
+    captured = []
+
+    monkeypatch.setattr(Machine, "esp_observability", monitor)
+    monkeypatch.setattr(Machine, "esp_info", SimpleNamespace(firmwareV="1.2.3"))
+    monkeypatch.setattr(Machine, "firmware_available_string", "2.0.0")
+    monkeypatch.setattr(Machine, "_connection", SimpleNamespace(sendUpdate=lambda: None))
+    monkeypatch.setattr(Machine, "_report_esp_diagnostics", captured.extend)
+    monkeypatch.setattr("machine.time.monotonic", lambda: 2)
+
+    Machine.startUpdate()
+
+    assert [event.title for event in captured] == ["ESP32 firmware panic detected"]
+    assert monitor.phase == ESPCommunicationPhase.WAITING_FOR_BOOT
 
 
 def test_machine_missing_expected_version_cannot_complete_or_reflash(run_machine_uart):

--- a/tests/test_machine_esp_observability.py
+++ b/tests/test_machine_esp_observability.py
@@ -1,10 +1,113 @@
+import asyncio
+import itertools
+import time as system_time
+from types import SimpleNamespace
+
 import pytest
 
+from config import CONFIG_USER, DISALLOW_FIRMWARE_FLASHING, MeticulousConfig
 from esp_observability import (
     ESPCommunicationPhase,
     ESPObservability,
     should_start_firmware_update,
 )
+from machine import AlarmManager, Machine
+
+
+class StopReadLoop(Exception):
+    pass
+
+
+class ScriptedUART:
+    lines = []
+
+    def __init__(self, _port):
+        self._lines = iter(self.lines)
+
+    def readline(self, timeout=None):
+        try:
+            return next(self._lines)
+        except StopIteration as error:
+            raise StopReadLoop from error
+
+
+class CapturedSentryScope:
+    def __init__(self, captured):
+        self._captured = captured
+        self.tags = {}
+        self.contexts = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def set_client(self, _client):
+        pass
+
+    def set_tag(self, key, value):
+        self.tags[key] = value
+
+    def set_context(self, key, value):
+        self.contexts[key] = value
+
+    def capture_event(self, event):
+        self._captured.append({"event": event, "tags": self.tags, "contexts": self.contexts})
+
+
+@pytest.fixture
+def run_machine_uart(monkeypatch):
+    sentry_events = []
+    update_calls = []
+    port = SimpleNamespace(reset_input_buffer=lambda: None, write=lambda _data: None)
+
+    monkeypatch.setattr(Machine, "_connection", SimpleNamespace(port=port))
+    monkeypatch.setattr(Machine, "ReadLine", ScriptedUART)
+    monkeypatch.setattr(Machine, "esp_info", None)
+    monkeypatch.setattr(Machine, "firmware_running", None)
+    monkeypatch.setattr(Machine, "infoReady", False)
+    monkeypatch.setattr(Machine, "profileReady", False)
+    monkeypatch.setattr(Machine, "_stopESPcomm", False)
+    monkeypatch.setattr(Machine, "shot_start_time", 0)
+    monkeypatch.setattr(Machine, "startTime", None)
+    monkeypatch.setattr(Machine, "esp_restart_request", False)
+    monkeypatch.setattr(Machine, "reset_count", 0)
+    monkeypatch.setattr(Machine, "startUpdate", lambda: update_calls.append(True))
+    monkeypatch.setattr(Machine, "setPartialRetraction", lambda _value: None)
+    monkeypatch.setattr(Machine, "setAutoPurgeAfterShot", lambda _value: None)
+    monkeypatch.setattr(Machine, "toggle_manufacturing_mode", lambda enabled: None)
+    monkeypatch.setattr(
+        "machine.sentry_sdk.new_scope",
+        lambda: CapturedSentryScope(sentry_events),
+    )
+    monkeypatch.setattr(AlarmManager, "is_alarm_set", lambda _alarm: None)
+    monkeypatch.setattr(AlarmManager, "set_alarm", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(AlarmManager, "clear_alarm", lambda _alarm: None)
+    monkeypatch.setitem(MeticulousConfig[CONFIG_USER], DISALLOW_FIRMWARE_FLASHING, False)
+
+    def run(lines, monitor, available_firmware, monotonic_times=None):
+        clock_values = iter(monotonic_times or itertools.count(3, 0.1))
+        ScriptedUART.lines = [line.encode() for line in lines]
+        monkeypatch.setattr(
+            "machine.time",
+            SimpleNamespace(
+                monotonic=lambda: next(clock_values),
+                time=system_time.time,
+            ),
+        )
+        monkeypatch.setattr(Machine, "esp_observability", monitor)
+        monkeypatch.setattr(Machine, "firmware_available_string", available_firmware)
+        monkeypatch.setattr(
+            Machine,
+            "firmware_available",
+            Machine._parseVersionString(available_firmware),
+        )
+        with pytest.raises(StopReadLoop):
+            asyncio.run(Machine._read_data())
+        return sentry_events, update_calls
+
+    return run
 
 
 def test_stale_esp_info_during_update_recovery_does_not_start_another_update():
@@ -22,6 +125,93 @@ def test_stale_esp_info_during_update_recovery_does_not_start_another_update():
         update_in_progress=monitor.update_in_progress,
         flashing_disallowed=False,
     )
+
+
+def test_machine_update_recovery_requires_boot_and_exact_version(run_machine_uart):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.0.0")
+    monitor.begin_update("2.0.0", "1.0.0", 1)
+    monitor.finish_flashing(2)
+
+    sentry_events, update_calls = run_machine_uart(
+        [
+            "ESPInfo,1.0.0,1,24.0\n",
+            "rst:0x1 (POWERON_RESET),boot:0x8 (SPI_FAST_FLASH_BOOT)\n",
+            "ESPInfo,2.0.0-dirty,1,24.0\n",
+            "ESPInfo,2.0.0,1,24.0\n",
+        ],
+        monitor,
+        available_firmware="2.0.0",
+    )
+
+    assert sentry_events == []
+    assert update_calls == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+    assert monitor.expected_firmware is None
+    assert monitor.previous_firmware == "2.0.0"
+    assert Machine.firmware_running == Machine._parseVersionString("2.0.0")
+
+
+def test_machine_routes_one_bounded_panic_with_firmware_context(run_machine_uart):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+
+    sentry_events, update_calls = run_machine_uart(
+        [
+            "Guru Meditation Error: Core 1 panic'ed (Unhandled debug exception).\n",
+            "Debug exception reason: Stack canary watchpoint triggered (Read ADC)\n",
+            "Register dump:\n",
+            "Backtrace: 0x42000000:0x3fc00000\n",
+            "rst:0x3 (SW_RESET),boot:0x8 (SPI_FAST_FLASH_BOOT)\n",
+            "ESPBoot,PANIC,4\n",
+        ],
+        monitor,
+        available_firmware="1.2.3",
+    )
+
+    assert update_calls == []
+    assert len(sentry_events) == 1
+    captured = sentry_events[0]
+    event = captured["event"]
+    context = captured["contexts"]["esp-diagnostic"]
+    assert event["message"] == "ESP32 firmware panic detected"
+    assert event["release"] == "espresso-firmware@1.2.3"
+    assert event["fingerprint"] == ["esp32-firmware-panic-stack-canary"]
+    assert captured["tags"]["firmware-version"] == "1.2.3"
+    assert context["previous_firmware"] == "1.2.3"
+    assert context["reset_reason"] == "PANIC"
+    assert context["core"] == "1"
+    assert context["panic_reason"] == "Unhandled debug exception"
+    assert context["exception_reason"] == "Stack canary watchpoint triggered"
+    assert context["panic_location"] == "Read ADC"
+    assert context["backtrace"] == "Backtrace: 0x42000000:0x3fc00000"
+    assert len(context["panic_output"].encode()) <= monitor.MAX_PANIC_BYTES
+
+
+def test_machine_missing_expected_version_cannot_complete_or_reflash(run_machine_uart):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.0.0")
+    monitor.begin_update(None, "1.0.0", 1)
+    monitor.finish_flashing(2)
+
+    sentry_events, update_calls = run_machine_uart(
+        [
+            "rst:0x1 (POWERON_RESET),boot:0x8 (SPI_FAST_FLASH_BOOT)\n",
+            "ESPInfo,2.0.0,1,24.0\n",
+            "waiting for expected artifact version\n",
+        ],
+        monitor,
+        available_firmware=None,
+        monotonic_times=[3, 3, 4, 4, 123, 123],
+    )
+
+    assert update_calls == []
+    assert len(sentry_events) == 1
+    captured = sentry_events[0]
+    assert captured["event"]["message"] == "ESP32 did not recover after firmware update"
+    assert captured["event"]["fingerprint"] == ["esp32-firmware-update-recovery-failed"]
+    assert captured["contexts"]["esp-diagnostic"]["expected_firmware"] is None
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
 
 
 @pytest.mark.parametrize(

--- a/tests/test_machine_esp_observability.py
+++ b/tests/test_machine_esp_observability.py
@@ -256,9 +256,7 @@ def test_start_update_reports_pending_panic_before_automatic_reflash_cleanup(
 ):
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
-    monitor.observe_raw_line(
-        "Guru Meditation Error: Core 1 panic'ed (LoadProhibited).", 1
-    )
+    monitor.observe_raw_line("Guru Meditation Error: Core 1 panic'ed (LoadProhibited).", 1)
     captured = []
 
     monkeypatch.setattr(Machine, "esp_observability", monitor)

--- a/tests/test_machine_esp_observability.py
+++ b/tests/test_machine_esp_observability.py
@@ -158,6 +158,29 @@ def test_machine_update_recovery_requires_boot_and_exact_version(run_machine_uar
     assert Machine.firmware_running == Machine._parseVersionString("2.0.0")
 
 
+def test_machine_explicit_reset_ignores_stale_protocol_until_boot(run_machine_uart):
+    monitor = ESPObservability(now=0)
+    monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")
+    monitor.begin_expected_reset(1)
+
+    sentry_events, update_calls = run_machine_uart(
+        [
+            "Log,info,stale pre-reset message\n",
+            "ESPInfo,1.2.3,1,24.0\n",
+            "rst:0x3 (SW_RESET),boot:0x8 (SPI_FAST_FLASH_BOOT)\n",
+            "ESPBoot,SW,3\n",
+            "ESPInfo,1.2.3,1,24.0\n",
+        ],
+        monitor,
+        available_firmware="1.2.3",
+    )
+
+    assert sentry_events == []
+    assert update_calls == []
+    assert run_machine_uart.alarm_calls == []
+    assert monitor.phase == ESPCommunicationPhase.NORMAL
+
+
 def test_machine_routes_one_bounded_panic_with_firmware_context(run_machine_uart):
     monitor = ESPObservability(now=0)
     monitor.observe_valid_message("ESPInfo", 0.1, "1.2.3")


### PR DESCRIPTION
Implemented the complete backend SW-112 scope on current nightly without committing or pushing. Added update-aware communication diagnostics, structured panic parsing, bounded cause-based grouping, ESPBoot reset correlation, deduplication, and focused tests.



Linear: https://linear.app/meticulous-home/issue/SW-112/improve-esp32-crash-and-firmware-update-diagnostics-in-sentry

> Draft created by the local agent orchestrator. Human approval and merge are required.

<!-- linear-agent-orchestrator:pr-description:start -->
## Summary
- Explicit ESP32 resets now require a boot banner before buffered UART traffic can complete recovery. Added state-machine and machine-level regressions covering stale Data, Sensors, Log, ESPInfo, and ESPBoot traffic, expected boot classification, startup attachment, timeout behavior, and absence of Sentry events or ESP_RESTART alarms.
- Root cause: Explicit API resets reused the startup-compatible EXPECTED_RESET phase, allowing stale buffered protocol messages to return the monitor to NORMAL before the physical reset banner arrived. The subsequent expected boot was therefore classified as unexpected.

## Validation
- `git diff --check`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-112-attempt-2-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run flake8 --exclude=.venv-wsl .`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-112-attempt-2-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run black --check --diff .`
- `wsl.exe -d Ubuntu-24.04 -- bash -lc cd '/mnt/c/Users/alufi/Documents/Codex/2026-08-05/oye-2/outputs/local-agent-orchestrator/workspaces/SW-112-attempt-2-meticulous-backend' && UV_PROJECT_ENVIRONMENT=.venv-wsl $HOME/.local/bin/uv run pytest -q`

Linear: [SW-112](https://linear.app/meticulous-home/issue/SW-112/improve-esp32-crash-and-firmware-update-diagnostics-in-sentry)

> Draft maintained by the local agent orchestrator. Human approval and merge are required.
<!-- linear-agent-orchestrator:pr-description:end -->