### PR TITLE
Advertise the public machine URL in Improv results

### DIFF
--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import sys
 import time
 from threading import Thread
@@ -87,10 +86,6 @@ async def register_pairing_agent():
         return bus  # keep reference alive
     except Exception as e:
         logger.warning(f"[BLE Agent] Failed to register pairing agent: {type(e).__name__}")
-
-
-# FIXME Remove once the tornado server logic is in its own class
-PORT = int(os.getenv("PORT", "8080"))
 
 
 class GATTServer:
@@ -540,9 +535,9 @@ class GATTServer:
                 localServer = []
                 for localIP in networkConfig.ips:
                     if localIP.ip.version == 6:
-                        localServer.append(f"http://[{str(localIP.ip)}]:{PORT}")
+                        localServer.append(f"http://[{str(localIP.ip)}]")
                     else:
-                        localServer.append(f"http://{str(localIP.ip)}:{PORT}")
+                        localServer.append(f"http://{str(localIP.ip)}")
 
                 logger.debug(f"Backend redirect IP/URL: {localServer}")
                 return localServer

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -157,8 +157,7 @@ def mock_wifi_manager():
 class TestWifiConnectUTF8:
     def test_ascii_ssid_and_password(self, mock_wifi_manager):
         result = GATTServer.wifi_connect(bytearray(b"MyNetwork"), bytearray(b"password"))
-        assert result is not None
-        assert any("192.168.1.100" in url for url in result)
+        assert result == ["http://192.168.1.100"]
         call_args = mock_wifi_manager.connectToWifi.call_args[0][0]
         assert call_args.ssid == "MyNetwork"
         assert call_args.password == "password"
@@ -291,9 +290,7 @@ class TestWifiConnectEdgeCases:
         )
         mock_wifi_manager.getCurrentConfig.return_value = config
         result = GATTServer.wifi_connect(bytearray(b"Net"), bytearray(b"pass"))
-        assert result is not None
-        assert any("192.168.1.100" in url for url in result)
-        assert any("fe80::1" in url for url in result)
+        assert result == ["http://192.168.1.100", "http://[fe80::1]"]
 
     def test_ssid_with_spaces(self, mock_wifi_manager):
         ssid = b"My Home Network"


### PR DESCRIPTION
## Summary

Return the machine's public HTTP origin from the Improv Wi-Fi provisioning result instead of the loopback-only Tornado backend port.

## Root cause

The Improv BLE handler constructed `http://<machine-ip>:8080` using its internal `PORT` setting. The Tornado backend listens on `127.0.0.1:8080`, so a phone on the LAN cannot reach that advertised origin. The machine's public reverse-proxy origin is port 80.

This caused Companion to time out even after Wi-Fi association and DHCP had succeeded.

## What changed

- Return `http://<IPv4>` for IPv4 addresses.
- Return `http://[<IPv6>]` for IPv6 addresses.
- Remove the unused internal `PORT` lookup from the BLE module.
- Assert exact public IPv4 and IPv6 result URLs in the existing BLE Wi-Fi tests.

## Customer impact

Clients that follow the Improv result literally receive a LAN-reachable address. This prevents false provisioning timeouts at the source.

## Validation

- `tests/test_ble_gatt_wifi.py`: 25 tests passed
- Black, Flake8, and diff checks passed
- Full backend run: 224 tests and 26 subtests passed
- One unrelated macOS-only memory-budget test fails because `ru_maxrss` is returned in bytes on macOS but compared as KiB