### PR TITLE
Stabilize Wi-Fi health results during background refresh

### DIFF
--- a/tests/test_wifi_repair.py
+++ b/tests/test_wifi_repair.py
@@ -7,7 +7,7 @@ under an isolated module name with small system dependency stubs.
 import importlib.util
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -85,6 +85,90 @@ def _wifi_config(module, *, connected, connection_name):
         hostname="meticulous",
         domains=[],
     )
+
+
+def _connected_ipv4_config(module, *, connection_name="Home", address="192.0.2.10"):
+    config = _wifi_config(module, connected=True, connection_name=connection_name)
+    config.ips = [
+        SimpleNamespace(
+            ip=SimpleNamespace(version=4),
+            __str__=lambda: address,
+        )
+    ]
+    config.gateway = "192.0.2.1"
+    return config
+
+
+def _health(module, *, degraded=False, dns_resolves=True):
+    return module.WifiHealthStatus(
+        "client",
+        True,
+        True,
+        True,
+        dns_resolves,
+        True,
+        False,
+        degraded,
+        "dns_unreachable" if degraded else "",
+        "",
+        "",
+    )
+
+
+def test_initial_shallow_health_does_not_cache_unchecked_probe_failures(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    current = _connected_ipv4_config(module)
+
+    manager.invalidateHealthCache()
+    with patch.object(manager, "refreshHealthInBackground") as refresh:
+        result = manager.getHealthStatus(current, deep=False)
+
+    assert result.link_connected is True
+    assert result.has_ipv4 is True
+    assert result.gateway_reachable is False
+    assert result.dns_resolves is False
+    assert result.internet_reachable is False
+    assert result.degraded is False
+    assert manager._cached_health is None
+    refresh.assert_called_once_with(current)
+
+
+def test_expired_matching_health_stays_visible_during_background_refresh(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    current = _connected_ipv4_config(module)
+    previous = _health(module)
+
+    manager._cached_health = previous
+    manager._health_cache_signature = manager.getHealthCacheSignature(current)
+    manager._health_cache_time = 0
+
+    with patch.object(manager, "refreshHealthInBackground") as refresh:
+        result = manager.getHealthStatus(current, deep=False)
+
+    assert result is previous
+    assert result.dns_resolves is True
+    refresh.assert_called_once_with(current)
+
+
+def test_changed_connection_does_not_reuse_previous_network_health(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    old_config = _connected_ipv4_config(module, connection_name="Old network")
+    current = _connected_ipv4_config(module, connection_name="New network")
+
+    manager._cached_health = _health(module)
+    manager._health_cache_signature = manager.getHealthCacheSignature(old_config)
+    manager._health_cache_time = 0
+
+    with patch.object(manager, "refreshHealthInBackground") as refresh:
+        result = manager.getHealthStatus(current, deep=False)
+
+    assert result is not manager._cached_health
+    assert result.degraded is False
+    assert result.dns_resolves is False
+    refresh.assert_called_once_with(current)
 
 
 def test_repair_without_saved_client_connection_never_resets_hardware(monkeypatch):

--- a/wifi.py
+++ b/wifi.py
@@ -369,10 +369,16 @@ class WifiManager:
         )
 
     def healthCacheIsValid(config: WifiSystemConfig = None):
-        if (
-            WifiManager._cached_health is None
-            or time.time() - WifiManager._health_cache_time >= WifiManager._health_cache_ttl
-        ):
+        if not WifiManager.healthCacheMatches(config):
+            return False
+
+        if time.time() - WifiManager._health_cache_time >= WifiManager._health_cache_ttl:
+            return False
+
+        return True
+
+    def healthCacheMatches(config: WifiSystemConfig = None):
+        if WifiManager._cached_health is None:
             return False
 
         signature = WifiManager.getHealthCacheSignature(config)
@@ -842,11 +848,21 @@ class WifiManager:
     def getHealthStatus(
         config: WifiSystemConfig = None, force: bool = False, deep: bool = True
     ) -> WifiHealthStatus:
+        if config is None:
+            config = WifiManager.getCurrentConfig()
+
         if not force and WifiManager.healthCacheIsValid(config):
             return WifiManager._cached_health
 
         if not deep:
-            health = WifiManager.buildHealthStatus(config, deep=False)
+            # Keep displaying the last conclusive result while its replacement is
+            # calculated. A shallow result has not run any probes, so caching its
+            # default False values would make the UI report a false failure on
+            # every cache refresh.
+            if WifiManager.healthCacheMatches(config):
+                health = WifiManager._cached_health
+            else:
+                health = WifiManager.buildHealthStatus(config, deep=False)
             WifiManager.refreshHealthInBackground(config)
             return health
 
@@ -912,7 +928,10 @@ class WifiManager:
             return health
 
         if config.connected and has_ipv4 and not deep:
-            health = WifiHealthStatus(
+            # False means "not checked yet" in this shallow response. Do not cache
+            # it as a completed health check; the background deep check below will
+            # replace it with conclusive probe results.
+            return WifiHealthStatus(
                 mode,
                 config.connected,
                 has_ipv4,
@@ -925,10 +944,6 @@ class WifiManager:
                 WifiManager._last_recovery_action,
                 WifiManager._last_recovery_result,
             )
-            WifiManager._cached_health = health
-            WifiManager._health_cache_time = time.time()
-            WifiManager._health_cache_signature = signature
-            return health
 
         if config.connected and has_ipv4:
             gateway_reachable = WifiManager.gatewayReachable(config.gateway)


### PR DESCRIPTION
## Summary

Stop publishing and caching untested Wi-Fi probe defaults as conclusive failures while a deep health refresh is running.

## Root cause

The fast Wi-Fi status endpoint called `getHealthStatus(..., deep=False)`. For a connected machine with IPv4, that shallow path initialized gateway, DNS, and internet to `false`, cached the placeholder for ten seconds, and then started the real checks in the background.

The Dial polls every five seconds, so it repeatedly observed:

`FAILED/FAILED/FAILED -> OK/OK/OK -> cache expiry -> FAILED/FAILED/FAILED`

The recording showed all three rows switching together while IP, `HEALTH: CONNECTED`, and `LAST ERROR: HEALTHY` remained stable, matching this sequence.

## What changed

- Keep the last conclusive health result visible while refreshing the same connection signature.
- Do not cache the initial shallow, untested probe values.
- Never reuse health from a different SSID/address/gateway signature.
- Preserve genuine deep failure results and recovery behavior.

## Customer impact

Healthy machines no longer flash recurring gateway, DNS, and internet failures solely because the cache expired. Real DNS/internet failures remain reportable.

## Validation

- `tests/test_wifi_repair.py`: 6 tests passed, including three new cache-state regressions
- Black, Flake8, and diff checks passed
- Full backend run: 227 tests and 26 subtests passed
- The only failure is the unrelated macOS `ru_maxrss` unit assertion