### PR TITLE
Persist automatic timezone detection

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -72,7 +72,7 @@ class SettingsHandler(BaseHandler):
         if setting_target == PROFILE_PARTIAL_RETRACTION:
             validate_partial_retraction(value)
 
-    async def update_timezone_sync(self, value) -> str:
+    async def update_timezone_sync(self, value) -> str | None:
         if value == AUTOMATIC_TIMEZONE_SYNC:
             try:
                 new_tz = await TimezoneManager.request_and_sync_tz()

--- a/tests/test_timezone_manager.py
+++ b/tests/test_timezone_manager.py
@@ -1,0 +1,101 @@
+import asyncio
+
+import pytest
+
+from config import CONFIG_USER, TIME_ZONE, TIMEZONE_SYNC, MeticulousConfig
+from timezone_manager import TimezoneManager
+
+
+class FakeEventLoop:
+    def __init__(self, timezone, before_return=None):
+        self.timezone = timezone
+        self.before_return = before_return
+
+    def run_until_complete(self, request):
+        assert request is REQUEST_SENTINEL
+        if self.before_return:
+            self.before_return()
+        TimezoneManager._TimezoneManager__system_synced = True
+        return self.timezone
+
+
+REQUEST_SENTINEL = object()
+
+
+@pytest.fixture(autouse=True)
+def restore_timezone_state():
+    original_timezone = MeticulousConfig[CONFIG_USER][TIME_ZONE]
+    original_sync_mode = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
+    original_synced = TimezoneManager._TimezoneManager__system_synced
+    original_attempts = TimezoneManager._TimezoneManager__timezone_fetch_attempts
+
+    yield
+
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = original_timezone
+    MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] = original_sync_mode
+    TimezoneManager._TimezoneManager__system_synced = original_synced
+    TimezoneManager._TimezoneManager__timezone_fetch_attempts = original_attempts
+
+
+def configure_background_sync(monkeypatch, timezone, before_return=None):
+    MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] = "automatic"
+    TimezoneManager._TimezoneManager__system_synced = False
+    TimezoneManager._TimezoneManager__timezone_fetch_attempts = 0
+    monkeypatch.setattr(TimezoneManager, "request_and_sync_tz", lambda: REQUEST_SENTINEL)
+    monkeypatch.setattr(
+        asyncio,
+        "get_event_loop",
+        lambda: FakeEventLoop(timezone, before_return),
+    )
+
+
+def test_background_sync_persists_detected_timezone(monkeypatch):
+    save_calls = []
+    configure_background_sync(monkeypatch, "Europe/Zurich")
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Etc/UTC"
+    monkeypatch.setattr(MeticulousConfig, "save", lambda: save_calls.append(True))
+
+    TimezoneManager.tz_background_update()
+
+    assert MeticulousConfig[CONFIG_USER][TIME_ZONE] == "Europe/Zurich"
+    assert save_calls == [True]
+    assert TimezoneManager._TimezoneManager__system_synced is True
+    assert TimezoneManager._TimezoneManager__timezone_fetch_attempts == 0
+
+
+def test_background_sync_retries_when_persistence_fails(monkeypatch):
+    configure_background_sync(monkeypatch, "Europe/Zurich")
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Etc/UTC"
+
+    def fail_save():
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(MeticulousConfig, "save", fail_save)
+
+    TimezoneManager.tz_background_update()
+
+    assert MeticulousConfig[CONFIG_USER][TIME_ZONE] == "Etc/UTC"
+    assert TimezoneManager._TimezoneManager__system_synced is False
+    assert TimezoneManager._TimezoneManager__timezone_fetch_attempts == 1
+
+
+def test_background_sync_does_not_overwrite_manual_change(monkeypatch):
+    restored_timezones = []
+
+    def switch_to_manual():
+        MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] = "manual"
+        MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Europe/London"
+
+    configure_background_sync(monkeypatch, "Europe/Zurich", switch_to_manual)
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Etc/UTC"
+    monkeypatch.setattr(
+        TimezoneManager,
+        "set_system_timezone",
+        lambda timezone: restored_timezones.append(timezone),
+    )
+
+    TimezoneManager.tz_background_update()
+
+    assert MeticulousConfig[CONFIG_USER][TIME_ZONE] == "Europe/London"
+    assert restored_timezones == ["Europe/London"]
+    assert TimezoneManager._TimezoneManager__system_synced is False

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -90,7 +90,7 @@ class TimezoneManager:
                 MeticulousConfig.save()
 
     @staticmethod
-    def update_timezone(new_timezone: str) -> None:
+    def update_timezone(new_timezone: str) -> str:
         stripped_new_tz = new_timezone.rstrip('"').lstrip('"')
         if MeticulousConfig[CONFIG_USER][TIME_ZONE] != stripped_new_tz:
             try:
@@ -99,6 +99,22 @@ class TimezoneManager:
             except TimezoneManagerError as e:
                 logger.error(f"Error updating timezone: {e}")
                 raise TimezoneManagerError(f"Error updating timezone: {e}")
+        return stripped_new_tz
+
+    @staticmethod
+    def persist_timezone(timezone: str) -> None:
+        previous_timezone = MeticulousConfig[CONFIG_USER][TIME_ZONE]
+        if previous_timezone == timezone:
+            return
+
+        MeticulousConfig[CONFIG_USER][TIME_ZONE] = timezone
+        try:
+            MeticulousConfig.save()
+        except Exception:
+            # Keep the in-memory value aligned with what was last known to be
+            # persisted so the next background attempt retries the save.
+            MeticulousConfig[CONFIG_USER][TIME_ZONE] = previous_timezone
+            raise
 
     @staticmethod
     def set_system_timezone(new_timezone: str) -> str:
@@ -295,17 +311,29 @@ class TimezoneManager:
             try:
                 logger.info("Timezone is set to automatic, fetching timezone in the background")
                 loop = asyncio.get_event_loop()
-                loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+                new_timezone = loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+                if new_timezone is not None:
+                    if MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] == "automatic":
+                        TimezoneManager.persist_timezone(new_timezone)
+                    else:
+                        # Automatic sync may finish after the user switches to
+                        # manual mode. Restore the saved manual timezone instead
+                        # of letting the stale request overwrite that choice.
+                        configured_timezone = MeticulousConfig[CONFIG_USER][TIME_ZONE]
+                        if configured_timezone and configured_timezone != new_timezone:
+                            TimezoneManager.set_system_timezone(configured_timezone)
+                        TimezoneManager.__system_synced = False
                 # Clear the attempt counter on a successful request so that, if
                 # __system_synced is ever reset, an unstable network gets a fresh
                 # batch of attempts instead of inheriting an exhausted counter.
                 TimezoneManager.__timezone_fetch_attempts = 0
             except Exception as e:
+                TimezoneManager.__system_synced = False
                 logger.error(f"Error while fetching timezone in the background: {e}")
 
     @staticmethod
-    async def request_and_sync_tz() -> str:
-        async def request_tz_task() -> str:
+    async def request_and_sync_tz() -> str | None:
+        async def request_tz_task() -> str | None:
             # nonlocal error
             import aiohttp
 
@@ -319,7 +347,7 @@ class TimezoneManager:
                             str_content = await response.text()
                             tz = json.loads(str_content).get("tz")
                             if tz is not None:
-                                TimezoneManager.update_timezone(
+                                tz = TimezoneManager.update_timezone(
                                     tz
                                 )  # raises TimezoneManagerError if fails
                                 TimezoneManager.__system_synced = True


### PR DESCRIPTION
## Summary

- persist a timezone returned by the background automatic lookup
- normalize the detected timezone before applying and saving it
- retry when configuration persistence fails
- restore a newly selected manual timezone if an older automatic request finishes late
- add regression coverage for persistence, save failure, and the automatic/manual race

## Root cause

The automatic Wi-Fi path applied the server-provided timezone with `timedatectl` but never copied it into the saved machine configuration. A later backend restart could therefore restore `Etc/UTC` and wait for Wi-Fi to discover the local timezone again.

## Impact

Once automatic detection succeeds, the machine keeps the detected IANA timezone across restarts and can start with the correct local timezone even before Wi-Fi is available.

Companion dial refresh fix: [MeticulousHome/meticulous-dial#579](https://github.com/MeticulousHome/meticulous-dial/pull/579)

## Validation

- `pytest -q -k 'not ten_megabyte_runtime_and_memory_budget'` — 227 passed; one pre-existing macOS RSS-unit assertion deselected
- `black --check api/settings.py timezone_manager.py tests/test_timezone_manager.py`
- `flake8 api/settings.py timezone_manager.py tests/test_timezone_manager.py`
- adversarial review covering save failures and automatic/manual synchronization races