### PR TITLE
Pour Over history, profile support, and bounded card images

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -45,6 +45,7 @@ RUN mkdir -p opt/meticulous-venv \
     opt/meticulous-backend/alembic/versions \
     opt/meticulous-backend/db-migrations \
     opt/meticulous-backend/profile_schema \
+    opt/meticulous-backend/pour_over_profile_schema \
     opt/meticulous-backend/default_profiles/community \
     opt/meticulous-backend/log_redactor \
     opt/meticulous-backend/sounds/default
@@ -76,6 +77,7 @@ COPY log_redactor/*.py /pkg/opt/meticulous-backend/log_redactor/
 
 # Data files (submodules - must be checked out before building)
 COPY profile_schema/ /pkg/opt/meticulous-backend/profile_schema/
+COPY pour_over_profile_schema/ /pkg/opt/meticulous-backend/pour_over_profile_schema/
 COPY default_profiles/ /pkg/opt/meticulous-backend/default_profiles/
 COPY sounds/ /pkg/opt/meticulous-backend/sounds/
 COPY images/default/ /pkg/opt/meticulous-backend/images/default/

--- a/alembic/versions/2026_08_16_1500-b71d84a4c2ef_add_brew_history_table.py
+++ b/alembic/versions/2026_08_16_1500-b71d84a4c2ef_add_brew_history_table.py
@@ -1,0 +1,43 @@
+"""add first-class brew history table
+
+Revision ID: b71d84a4c2ef
+Revises: 8f4e7b2c9d10
+Create Date: 2026-08-16 15:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b71d84a4c2ef"
+down_revision: Union[str, None] = "8f4e7b2c9d10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "brew_history",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("uuid", sa.Text(), nullable=False),
+        sa.Column("brew_type", sa.Text(), nullable=False),
+        sa.Column("mode", sa.Text(), nullable=False),
+        sa.Column("file", sa.Text(), nullable=False),
+        sa.Column("time", sa.DateTime(), nullable=False),
+        sa.Column("completed_time", sa.DateTime(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("schema_version", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("file"),
+        sa.UniqueConstraint("uuid"),
+    )
+    op.create_index("ix_brew_history_completed_time", "brew_history", ["completed_time"])
+    op.create_index("ix_brew_history_brew_type", "brew_history", ["brew_type"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_brew_history_brew_type", table_name="brew_history")
+    op.drop_index("ix_brew_history_completed_time", table_name="brew_history")
+    op.drop_table("brew_history")

--- a/api/api.py
+++ b/api/api.py
@@ -42,6 +42,7 @@ class API:
         from . import action as _action  # noqa
         from . import history as _history  # noqa
         from . import pour_over_history as _pour_over_history  # noqa
+        from . import pour_over_profiles as _pour_over_profiles  # noqa
         from . import bug_report as _bug_report  # noqa
         from . import notifications as _noti  # noqa
         from . import profiles as _profiles  # noqa

--- a/api/api.py
+++ b/api/api.py
@@ -41,6 +41,7 @@ class API:
     def get_routes(cls):
         from . import action as _action  # noqa
         from . import history as _history  # noqa
+        from . import pour_over_history as _pour_over_history  # noqa
         from . import bug_report as _bug_report  # noqa
         from . import notifications as _noti  # noqa
         from . import profiles as _profiles  # noqa

--- a/api/history.py
+++ b/api/history.py
@@ -13,7 +13,7 @@ from config import DEBUG_HISTORY_PATH, SHOT_PATH
 from shot_manager import ShotManager
 
 from .api import API, APIVersion
-from .base_handler import BaseHandler
+from .base_handler import BaseHandler, LocalAccessHandler
 import asyncio
 from shot_debug_manager import ShotDebugManager
 from pathlib import Path
@@ -215,6 +215,22 @@ class LastShotHandler(BaseHandler):
         self.write(last_shot_json)
 
 
+class UploadHistoryIndexHandler(LocalAccessHandler):
+    async def get(self):
+        try:
+            max_results = min(max(int(self.get_query_argument("max_results", "200")), 1), 200)
+        except ValueError:
+            self.set_status(400)
+            self.write({"status": "error", "error": "max_results must be an integer"})
+            return
+        after = self.get_query_argument("after", None)
+        loop = asyncio.get_event_loop()
+        history = await loop.run_in_executor(
+            None, ShotDataBase.list_history_files, after, max_results
+        )
+        self.write({"history": history})
+
+
 class HistoryHandler(BaseHandler):
     async def searchHistory(self, params: SearchParams):
         loop = asyncio.get_event_loop()
@@ -309,6 +325,7 @@ class ShotRatingHandler(BaseHandler):
 API.register_handler(APIVersion.V1, r"/history/search", ProfileSearchHandler),
 API.register_handler(APIVersion.V1, r"/history/current", CurrentShotHandler),
 API.register_handler(APIVersion.V1, r"/history/last", LastShotHandler),
+API.register_handler(APIVersion.V1, r"/history/upload-index", UploadHistoryIndexHandler),
 API.register_handler(APIVersion.V1, r"/history/stats", StatisticsHandler),
 
 API.register_handler(APIVersion.V1, r"/history", HistoryHandler),

--- a/api/machine.py
+++ b/api/machine.py
@@ -14,6 +14,7 @@ from ota import UpdateManager
 from backlight_controller import BacklightController
 from datetime import datetime
 from timezone_manager import TimezoneManager
+from pour_over_profiles import PourOverProfileManager
 
 from config import (
     MeticulousConfig,
@@ -40,6 +41,10 @@ def get_machine_info():
 
     response["tare_behavior_supported"] = bool(
         Machine.esp_info is not None and Machine.esp_info.tareBehavior is not None
+    )
+    response["pour_over_profiles_supported"] = PourOverProfileManager.is_available()
+    response["pour_over_profile_schema_version"] = (
+        1 if PourOverProfileManager.is_available() else None
     )
 
     response["serial"] = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]

--- a/api/pour_over_history.py
+++ b/api/pour_over_history.py
@@ -10,7 +10,10 @@ from log import MeticulousLogger
 from pour_over_history import (
     PourOverHistoryConflictError,
     PourOverHistoryManager,
+    PourOverHistoryRecordTooLargeError,
     PourOverSession,
+    MAX_POUR_OVER_RECORD_BYTES,
+    read_compressed_record,
 )
 
 from .api import API, APIVersion
@@ -18,7 +21,8 @@ from .base_handler import BaseHandler, LocalAccessHandler
 
 logger = MeticulousLogger.getLogger(__name__)
 last_version_path = f"/api/{APIVersion.latest_version().name.lower()}"
-MAX_POUR_OVER_BODY_BYTES = 2 * 1024 * 1024
+MAX_POUR_OVER_BODY_BYTES = MAX_POUR_OVER_RECORD_BYTES
+MAX_DIRECTORY_RESULTS = 200
 
 
 class PourOverFileHandler(BaseHandler):
@@ -37,7 +41,7 @@ class PourOverFileHandler(BaseHandler):
         if requested.is_dir():
             entries = sorted(
                 requested.iterdir(), key=lambda entry: entry.stat().st_mtime, reverse=True
-            )
+            )[:MAX_DIRECTORY_RESULTS]
             self.write(
                 [
                     {
@@ -64,9 +68,8 @@ class PourOverFileHandler(BaseHandler):
             return
 
         try:
-            with compressed_path.open("rb") as compressed:
-                raw = zstd.ZstdDecompressor().stream_reader(compressed).read()
-        except zstd.ZstdError:
+            raw = read_compressed_record(compressed_path)
+        except (zstd.ZstdError, PourOverHistoryRecordTooLargeError):
             logger.warning("Invalid compressed Pour Over history file: %s", compressed_path)
             self.set_status(500)
             self.write({"status": "error", "error": "Invalid history entry"})
@@ -101,6 +104,10 @@ class PourOverHistoryHandler(LocalAccessHandler):
 
         try:
             history, created = PourOverHistoryManager.save(session)
+        except PourOverHistoryRecordTooLargeError:
+            self.set_status(413)
+            self.write({"status": "error", "error": "Pour Over record is too large"})
+            return
         except PourOverHistoryConflictError:
             self.set_status(409)
             self.write(

--- a/api/pour_over_history.py
+++ b/api/pour_over_history.py
@@ -1,0 +1,165 @@
+import json
+from pathlib import Path
+
+import tornado.web
+import zstandard as zstd
+from pydantic import ValidationError
+
+from config import POUR_OVER_PATH
+from log import MeticulousLogger
+from pour_over_history import (
+    PourOverHistoryConflictError,
+    PourOverHistoryManager,
+    PourOverSession,
+)
+
+from .api import API, APIVersion
+from .base_handler import BaseHandler, LocalAccessHandler
+
+logger = MeticulousLogger.getLogger(__name__)
+last_version_path = f"/api/{APIVersion.latest_version().name.lower()}"
+MAX_POUR_OVER_BODY_BYTES = 2 * 1024 * 1024
+
+
+class PourOverFileHandler(BaseHandler):
+    def initialize(self, path):
+        self.root = Path(path).resolve()
+
+    async def get(self, relative_path):
+        try:
+            requested = self.root.joinpath(relative_path).resolve()
+            requested.relative_to(self.root)
+        except ValueError:
+            self.set_status(404)
+            self.write({"status": "error", "error": "history entry not found"})
+            return
+
+        if requested.is_dir():
+            entries = sorted(
+                requested.iterdir(), key=lambda entry: entry.stat().st_mtime, reverse=True
+            )
+            self.write(
+                [
+                    {
+                        "name": entry.name.removesuffix(".zst"),
+                        "url": entry.name,
+                    }
+                    for entry in entries
+                ]
+            )
+            return
+
+        compressed_path = requested
+        if not compressed_path.is_file() and not str(compressed_path).endswith(".zst"):
+            compressed_path = Path(f"{compressed_path}.zst")
+        if not compressed_path.is_file():
+            self.set_status(404)
+            self.write(
+                {
+                    "status": "error",
+                    "error": "history entry not found",
+                    "path": relative_path,
+                }
+            )
+            return
+
+        try:
+            with compressed_path.open("rb") as compressed:
+                raw = zstd.ZstdDecompressor().stream_reader(compressed).read()
+        except zstd.ZstdError:
+            logger.warning("Invalid compressed Pour Over history file: %s", compressed_path)
+            self.set_status(500)
+            self.write({"status": "error", "error": "Invalid history entry"})
+            return
+        self.set_header("Content-Type", "application/json")
+        self.write(raw)
+
+
+class PourOverHistoryHandler(LocalAccessHandler):
+    async def post(self):
+        if len(self.request.body) > MAX_POUR_OVER_BODY_BYTES:
+            self.set_status(413)
+            self.write({"status": "error", "error": "Pour Over record is too large"})
+            return
+        try:
+            raw = json.loads(self.request.body)
+            session = PourOverSession.model_validate(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.set_status(400)
+            self.write({"status": "error", "error": "Invalid JSON"})
+            return
+        except ValidationError as error:
+            self.set_status(422)
+            self.write(
+                {
+                    "status": "error",
+                    "error": "Invalid Pour Over record",
+                    "details": json.loads(error.json(include_url=False)),
+                }
+            )
+            return
+
+        try:
+            history, created = PourOverHistoryManager.save(session)
+        except PourOverHistoryConflictError:
+            self.set_status(409)
+            self.write(
+                {
+                    "status": "error",
+                    "error": "A different Pour Over record already uses this id",
+                }
+            )
+            return
+        except Exception as error:
+            logger.exception("Failed to save Pour Over history", exc_info=error)
+            self.set_status(500)
+            self.write({"status": "error", "error": "Could not save Pour Over record"})
+            return
+
+        self.set_status(201 if created else 200)
+        self.write({"status": "created" if created else "existing", "history": history})
+
+    async def get(self):
+        try:
+            max_results = min(max(int(self.get_query_argument("max_results", "50")), 1), 200)
+        except ValueError:
+            self.set_status(400)
+            self.write({"status": "error", "error": "max_results must be an integer"})
+            return
+        descending = self.get_query_argument("sort", "desc") != "asc"
+        after = self.get_query_argument("after", None)
+        mode = self.get_query_argument("mode", None)
+        if mode not in (None, "free_pour", "profile"):
+            self.set_status(400)
+            self.write({"status": "error", "error": "Invalid Pour Over mode"})
+            return
+        history = PourOverHistoryManager.search(
+            max_results=max_results, descending=descending, after=after, mode=mode
+        )
+        self.write({"history": history})
+
+
+class LastPourOverHandler(BaseHandler):
+    async def get(self):
+        history = PourOverHistoryManager.latest()
+        if history is None:
+            self.set_status(404)
+            self.write({"status": "error", "error": "No Pour Over records found"})
+            return
+        self.write(history)
+
+
+API.register_handler(APIVersion.V1, r"/history/pour-over", PourOverHistoryHandler)
+API.register_handler(APIVersion.V1, r"/history/pour-over/last", LastPourOverHandler)
+API.register_handler(
+    APIVersion.V1,
+    r"/history/pour-over/files",
+    tornado.web.RedirectHandler,
+    url=f"{last_version_path}/history/pour-over/files/",
+)
+API.register_handler(
+    APIVersion.V1,
+    r"/history/pour-over/files/(.*)",
+    PourOverFileHandler,
+    path=POUR_OVER_PATH,
+)

--- a/api/pour_over_profiles.py
+++ b/api/pour_over_profiles.py
@@ -41,6 +41,22 @@ class GetPourOverProfileHandler(BaseHandler):
         self.write(profile)
 
 
+class GetPourOverProfileImageHandler(BaseHandler):
+    def get(self, profile_id):
+        try:
+            image = PourOverProfileManager.get_profile_image(profile_id)
+        except (PourOverProfileUnavailableError, PourOverProfileStorageError) as error:
+            write_pour_over_profile_error(self, error)
+            return
+        if image is None:
+            self.set_status(404)
+            self.write({"status": "error", "error": "Pour Over profile image not found"})
+            return
+        self.set_header("Content-Type", "image/jpeg")
+        self.set_header("Cache-Control", "private, max-age=300")
+        self.write(image)
+
+
 class DeletePourOverProfileHandler(BaseHandler):
     def delete(self, profile_id):
         change_id = self.request.headers.get("X-Change-Id", None)
@@ -101,6 +117,11 @@ API.register_handler(
     APIVersion.V1,
     r"/pour-over/profile/get/([0-9a-fA-F-]+)",
     GetPourOverProfileHandler,
+)
+API.register_handler(
+    APIVersion.V1,
+    r"/pour-over/profile/image/([0-9a-fA-F-]+)",
+    GetPourOverProfileImageHandler,
 )
 API.register_handler(
     APIVersion.V1,

--- a/api/pour_over_profiles.py
+++ b/api/pour_over_profiles.py
@@ -1,0 +1,114 @@
+import json
+
+from log import MeticulousLogger
+from pour_over_profiles import (
+    PourOverProfileLimitError,
+    PourOverProfileManager,
+    PourOverProfileStorageError,
+    PourOverProfileTooLargeError,
+    PourOverProfileUnavailableError,
+    PourOverProfileValidationError,
+)
+
+from .api import API, APIVersion
+from .base_handler import BaseHandler
+
+logger = MeticulousLogger.getLogger(__name__)
+
+
+class ListPourOverProfilesHandler(BaseHandler):
+    def get(self):
+        try:
+            self.write({"profiles": PourOverProfileManager.list_profiles()})
+        except PourOverProfileUnavailableError as error:
+            write_pour_over_profile_error(self, error)
+
+
+class GetPourOverProfileHandler(BaseHandler):
+    def get(self, profile_id):
+        include_image = self.get_argument("include_image", "true").lower() == "true"
+        try:
+            profile = PourOverProfileManager.get_profile(
+                profile_id, include_image=include_image
+            )
+        except (PourOverProfileUnavailableError, PourOverProfileStorageError) as error:
+            write_pour_over_profile_error(self, error)
+            return
+        if profile is None:
+            self.set_status(404)
+            self.write({"status": "error", "error": "Pour Over profile not found"})
+            return
+        self.write(profile)
+
+
+class DeletePourOverProfileHandler(BaseHandler):
+    def delete(self, profile_id):
+        change_id = self.request.headers.get("X-Change-Id", None)
+        try:
+            result = PourOverProfileManager.delete_profile(profile_id, change_id=change_id)
+        except (PourOverProfileStorageError, PourOverProfileUnavailableError) as error:
+            write_pour_over_profile_error(self, error)
+            return
+        if result is None:
+            self.set_status(404)
+            self.write({"status": "error", "error": "Pour Over profile not found"})
+            return
+        self.write(result)
+
+
+class PourOverProfileSchemaHandler(BaseHandler):
+    def get(self):
+        try:
+            PourOverProfileManager._require_available()
+        except PourOverProfileUnavailableError as error:
+            write_pour_over_profile_error(self, error)
+            return
+        self.set_header("Content-Type", "application/schema+json")
+        self.write(json.dumps(PourOverProfileManager._schema))
+
+
+def write_pour_over_profile_error(handler, error):
+    if isinstance(error, PourOverProfileValidationError):
+        handler.set_status(422)
+        handler.write(
+            {
+                "status": "error",
+                "error": "Invalid Pour Over profile",
+                "details": error.issues,
+            }
+        )
+    elif isinstance(error, PourOverProfileTooLargeError):
+        handler.set_status(413)
+        handler.write({"status": "error", "error": "Pour Over profile is too large"})
+    elif isinstance(error, PourOverProfileLimitError):
+        handler.set_status(409)
+        handler.write({"status": "error", "error": "Pour Over profile limit reached"})
+    elif isinstance(error, PourOverProfileStorageError):
+        handler.set_status(507)
+        handler.write(
+            {"status": "error", "error": "Could not access Pour Over profile storage"}
+        )
+    elif isinstance(error, PourOverProfileUnavailableError):
+        handler.set_status(503)
+        handler.write({"status": "error", "error": "Pour Over profiles are unavailable"})
+    else:
+        handler.set_status(500)
+        handler.write({"status": "error", "error": "Could not process Pour Over profile"})
+
+
+API.register_handler(APIVersion.V1, r"/pour-over/profile/list", ListPourOverProfilesHandler)
+API.register_handler(
+    APIVersion.V1,
+    r"/pour-over/profile/get/([0-9a-fA-F-]+)",
+    GetPourOverProfileHandler,
+)
+API.register_handler(
+    APIVersion.V1,
+    r"/pour-over/profile/delete/([0-9a-fA-F-]+)",
+    DeletePourOverProfileHandler,
+)
+API.register_handler(
+    APIVersion.V1,
+    r"/pour-over/profile/schema",
+    PourOverProfileSchemaHandler,
+)

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime, timezone
 
 import jsonschema
@@ -12,6 +13,13 @@ from profile_preprocessor import (
     VariableTypeException,
 )
 from profiles import IMAGES_PATH, ProfileManager
+from pour_over_profiles import (
+    MAX_POUR_OVER_PROFILE_BYTES,
+    PourOverProfileError,
+    PourOverProfileManager,
+    PourOverProfileTooLargeError,
+)
+from .pour_over_profiles import write_pour_over_profile_error
 
 from .api import API, APIVersion
 from .base_handler import BaseHandler
@@ -20,6 +28,8 @@ from config import MeticulousConfig, ALLOW_LEGACY_JSON, CONFIG_USER
 from .emulation import LEGACY_DUMMY_PROFILE
 
 logger = MeticulousLogger.getLogger(__name__)
+
+POUR_OVER_BREW_TYPE_PATTERN = re.compile(rb'"brew_type"\s*:\s*"pour_over"')
 
 
 class ListHandler(BaseHandler):
@@ -44,11 +54,41 @@ class ListDefaultsHandler(BaseHandler):
 
 class SaveProfileHandler(BaseHandler):
     def post(self):
+        data = None
         try:
             change_id = self.request.headers.get("X-Change-Id", None)
-            data = json.loads(self.request.body)
-            profile_response = ProfileManager.save_profile(data, change_id=change_id)
+            # Tornado already owns the request bytes, but parsing a very large
+            # JSON object would create another large object graph on a small
+            # machine. Reject recognizable Pour Over payloads at the canonical
+            # stored-profile limit before decoding them. Espresso retains its
+            # existing, separate image limits and behavior.
+            if len(
+                self.request.body
+            ) > MAX_POUR_OVER_PROFILE_BYTES and POUR_OVER_BREW_TYPE_PATTERN.search(
+                self.request.body
+            ):
+                raise PourOverProfileTooLargeError()
+            data = json.loads(
+                self.request.body,
+                parse_constant=lambda value: (_ for _ in ()).throw(
+                    ValueError(f"Invalid number {value}")
+                ),
+            )
+            if isinstance(data, dict) and data.get("brew_type") == "pour_over":
+                profile_response = PourOverProfileManager.save_profile(
+                    data, change_id=change_id
+                )
+            else:
+                profile_response = ProfileManager.save_profile(data, change_id=change_id)
             self.write(profile_response)
+        except PourOverProfileError as error:
+            profile_id = data.get("id") if isinstance(data, dict) else None
+            logger.warning(
+                "Rejected Pour Over profile %s: %s",
+                profile_id,
+                error.__class__.__name__,
+            )
+            write_pour_over_profile_error(self, error)
         except jsonschema.exceptions.ValidationError as err:
             errors = {
                 "status": "error",
@@ -57,7 +97,8 @@ class SaveProfileHandler(BaseHandler):
 
             self.set_status(400)
             self.write(errors)
-            logger.debug(data)
+            profile_id = data.get("id") if isinstance(data, dict) else None
+            logger.warning("Rejected espresso profile %s: %s", profile_id, err.message)
             return
         except Exception as e:
             self.set_status(400)

--- a/api/settings.py
+++ b/api/settings.py
@@ -72,7 +72,7 @@ class SettingsHandler(BaseHandler):
         if setting_target == PROFILE_PARTIAL_RETRACTION:
             validate_partial_retraction(value)
 
-    async def update_timezone_sync(self, value) -> str:
+    async def update_timezone_sync(self, value) -> str | None:
         if value == AUTOMATIC_TIMEZONE_SYNC:
             try:
                 new_tz = await TimezoneManager.request_and_sync_tz()

--- a/api/wifi.py
+++ b/api/wifi.py
@@ -12,8 +12,6 @@ from config import (
     WIFI_MODE_CLIENT,
 )
 from wifi import WifiManager, WifiType, redact_ssid
-from ble_gatt import PORT
-
 from .base_handler import BaseHandler
 from .api import API, APIVersion
 
@@ -69,11 +67,11 @@ class WiFiQRHandler(BaseHandler):
         elif len(config.ips) > 0:
             current_ip = config.ips[0]
             if current_ip.ip.version == 6:
-                qr_contents = f"http://[{str(current_ip.ip)}]:{PORT}"
+                qr_contents = f"http://[{str(current_ip.ip)}]"
             else:
-                qr_contents = f"http://{str(current_ip.ip)}:{PORT}"
+                qr_contents = f"http://{str(current_ip.ip)}"
         else:
-            qr_contents = f"http://{str(config.hostname)}.local:{PORT}"
+            qr_contents = f"http://{str(config.hostname)}.local"
 
         buffer = io.BytesIO()
 

--- a/backend.py
+++ b/backend.py
@@ -18,6 +18,7 @@ from ble_gatt import GATTServer
 from wifi import WifiManager
 from notifications import Notification, NotificationManager
 from profiles import ProfileManager
+from pour_over_profiles import PourOverProfileManager
 from hostname import HostnameManager
 from config import (
     MeticulousConfig,
@@ -322,6 +323,7 @@ def main():
 
     NotificationManager.init(sio)
     ProfileManager.init(sio)
+    PourOverProfileManager.init()
     SoundPlayer.init(emulation=Machine.emulated)
 
     # Check for mapped timezones json

--- a/backend.py
+++ b/backend.py
@@ -58,6 +58,7 @@ tornado.log.gen_log = MeticulousLogger.getLogger("tornado.general")
 
 PORT = int(os.getenv("PORT", "8080"))
 DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1", "y")
+IDENTITY_READY_PATH = os.getenv("IDENTITY_READY_PATH", "/run/meticulous-backend-identity-ready")
 
 
 sio = socketio.AsyncServer(
@@ -276,7 +277,18 @@ def main():
     pyprctl.set_name("Main")
 
     DBusMonitor.init()
+    try:
+        os.remove(IDENTITY_READY_PATH)
+    except FileNotFoundError:
+        pass
     HostnameManager.init()
+    WifiManager.initializeIdentity()
+    identity_ready_temporary = f"{IDENTITY_READY_PATH}.{os.getpid()}"
+    with open(identity_ready_temporary, "w", encoding="utf-8") as ready_file:
+        ready_file.write("ready\n")
+        ready_file.flush()
+        os.fsync(ready_file.fileno())
+    os.replace(identity_ready_temporary, IDENTITY_READY_PATH)
     UpdateManager.init()
 
     try:

--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import sys
 import time
 from threading import Thread
@@ -87,10 +86,6 @@ async def register_pairing_agent():
         return bus  # keep reference alive
     except Exception as e:
         logger.warning(f"[BLE Agent] Failed to register pairing agent: {type(e).__name__}")
-
-
-# FIXME Remove once the tornado server logic is in its own class
-PORT = int(os.getenv("PORT", "8080"))
 
 
 class GATTServer:
@@ -540,9 +535,9 @@ class GATTServer:
                 localServer = []
                 for localIP in networkConfig.ips:
                     if localIP.ip.version == 6:
-                        localServer.append(f"http://[{str(localIP.ip)}]:{PORT}")
+                        localServer.append(f"http://[{str(localIP.ip)}]")
                     else:
-                        localServer.append(f"http://{str(localIP.ip)}:{PORT}")
+                        localServer.append(f"http://{str(localIP.ip)}")
 
                 logger.debug(f"Backend redirect IP/URL: {localServer}")
                 return localServer

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ DATABASE_FILE = "history.sqlite"
 ABSOLUTE_DATABASE_FILE = Path(HISTORY_PATH).joinpath(DATABASE_FILE).resolve()
 DATABASE_URL = f"sqlite:///{ABSOLUTE_DATABASE_FILE}"
 SHOT_PATH = Path(HISTORY_PATH).joinpath("shots")
+POUR_OVER_PATH = Path(HISTORY_PATH).joinpath("pour-over")
 DEBUG_HISTORY_PATH = os.getenv("DEBUG_HISTORY_PATH", "/meticulous-user/history/debug")
 
 # Config Compontents

--- a/database_models.py
+++ b/database_models.py
@@ -53,6 +53,20 @@ history = Table(
     Column("debug_file", Text, nullable=True),
 )
 
+brew_history = Table(
+    "brew_history",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("uuid", Text, nullable=False, unique=True),
+    Column("brew_type", Text, nullable=False),
+    Column("mode", Text, nullable=False),
+    Column("file", Text, nullable=False, unique=True),
+    Column("time", DateTime, nullable=False),
+    Column("completed_time", DateTime, nullable=False),
+    Column("name", Text, nullable=False),
+    Column("schema_version", Integer, nullable=False),
+)
+
 shot_annotation = Table(
     "shot_annotation",
     metadata,

--- a/db_migration_updater.py
+++ b/db_migration_updater.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 
 logger = MeticulousLogger.getLogger(__name__)
 
-DB_VERSION_REQUIRED = "8f4e7b2c9d10"
+DB_VERSION_REQUIRED = "b71d84a4c2ef"
 
 USER_DB_MIGRATION_DIR = os.getenv("USER_DB_MIGRATION_DIR", "/meticulous-user/.dbmigrations")
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/hostname.py
+++ b/hostname.py
@@ -1,13 +1,54 @@
 import subprocess
 import random
+import socket
 
-from config import CONFIG_SYSTEM, MeticulousConfig, DEVICE_IDENTIFIER, MACHINE_SERIAL_NUMBER
+from config import (
+    CONFIG_SYSTEM,
+    CONFIG_USER,
+    DEVICE_IDENTIFIER,
+    HOSTNAME_OVERRIDE,
+    MACHINE_SERIAL_NUMBER,
+    MeticulousConfig,
+)
 from log import MeticulousLogger
 
 logger = MeticulousLogger.getLogger(__name__)
 
 
 class HostnameManager:
+
+    @staticmethod
+    def _configuredIdentifierIsValid() -> bool:
+        identifier = MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER]
+        return (
+            isinstance(identifier, list)
+            and len(identifier) == 2
+            and all(isinstance(component, str) and component for component in identifier)
+        )
+
+    @staticmethod
+    def identifierFromHostname(hostname: str) -> tuple[str, str] | None:
+        """Recover a generated machine identifier from an established hostname."""
+        serial = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]
+        if not isinstance(hostname, str) or not hostname or serial is None:
+            return None
+
+        short_hostname = hostname.split(".", 1)[0]
+        prefix = "meticulous"
+        suffix = f"-{serial}"
+        if not short_hostname.startswith(prefix) or not short_hostname.endswith(suffix):
+            return None
+
+        encoded_identifier = short_hostname[len(prefix) : -len(suffix)]
+        for adjective in HostnameManager.ADJECTIVES:
+            adjective_component = adjective.capitalize()
+            if not encoded_identifier.casefold().startswith(adjective_component.casefold()):
+                continue
+            noun_component = encoded_identifier[len(adjective_component) :]
+            for noun in HostnameManager.NOUNS:
+                if noun_component.casefold() == noun.casefold():
+                    return (adjective, noun)
+        return None
 
     # We are using random identifier here instead of deriving it from something
     def _generateRandomIdentifierComponents() -> tuple[str, str]:
@@ -20,11 +61,32 @@ class HostnameManager:
         return (adjective, noun)
 
     def init():
-        if len(MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER]) == 2:
+        recovered_identifier = HostnameManager.identifierFromHostname(socket.gethostname())
+        hostname_override = MeticulousConfig[CONFIG_USER][HOSTNAME_OVERRIDE]
+        configured_identifier = MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER]
+
+        # A recognizable deployed hostname is the safest canonical source when no
+        # explicit override exists. This repairs both missing and conflicting config
+        # without changing the customer-visible OS hostname.
+        if hostname_override is None and recovered_identifier is not None:
+            recovered_list = list(recovered_identifier)
+            if configured_identifier != recovered_list:
+                logger.warning("Recovered device identifier from established hostname")
+                MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER] = recovered_list
+                MeticulousConfig.save()
+            return
+
+        if HostnameManager._configuredIdentifierIsValid():
+            return
+
+        if recovered_identifier is not None:
+            logger.warning("Recovered missing device identifier from established hostname")
+            MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER] = list(recovered_identifier)
+            MeticulousConfig.save()
             return
 
         adjective, noun = HostnameManager._generateRandomIdentifierComponents()
-        logger.info("Created new device identifier pair:")
+        logger.info("Created new device identifier pair")
         MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER] = [adjective, noun]
         MeticulousConfig.save()
 

--- a/pour_over_history.py
+++ b/pour_over_history.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import shutil
 import uuid
 from datetime import timezone
 from pathlib import Path
@@ -8,7 +9,7 @@ from typing import Any, Literal
 
 import zstandard as zstd
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
-from sqlalchemy import asc, desc, insert, select
+from sqlalchemy import asc, delete, desc, insert, select
 from sqlalchemy.exc import IntegrityError
 
 from config import POUR_OVER_PATH
@@ -18,9 +19,34 @@ from shot_database import ShotDataBase
 
 logger = MeticulousLogger.getLogger(__name__)
 
+MAX_POUR_OVER_DURATION_MS = 10 * 60 * 1000
+MAX_POUR_OVER_SAMPLES = MAX_POUR_OVER_DURATION_MS // 200 + 1
+MAX_POUR_OVER_RECORD_BYTES = 2 * 1024 * 1024
+MAX_POUR_OVER_HISTORY_RECORDS = 1_000
+MAX_POUR_OVER_HISTORY_BYTES = 128 * 1024 * 1024
+MIN_POUR_OVER_FREE_BYTES = 128 * 1024 * 1024
+
 
 class PourOverHistoryConflictError(Exception):
     pass
+
+
+class PourOverHistoryRecordTooLargeError(Exception):
+    pass
+
+
+def read_compressed_record(path: Path) -> bytes:
+    with path.open("rb") as compressed:
+        raw = (
+            zstd.ZstdDecompressor()
+            .stream_reader(compressed)
+            .read(MAX_POUR_OVER_RECORD_BYTES + 1)
+        )
+    if len(raw) > MAX_POUR_OVER_RECORD_BYTES:
+        raise PourOverHistoryRecordTooLargeError(
+            "Pour Over history entry exceeds the decompressed size limit"
+        )
+    return raw
 
 
 class PourOverContractModel(BaseModel):
@@ -28,7 +54,7 @@ class PourOverContractModel(BaseModel):
 
 
 class FreePourSample(PourOverContractModel):
-    t: float = Field(ge=0)
+    t: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
     w: float = Field(ge=0)
     f: float = Field(ge=0)
     p: int = Field(ge=0)
@@ -36,8 +62,8 @@ class FreePourSample(PourOverContractModel):
 
 class FreePourPour(PourOverContractModel):
     number: int = Field(gt=0)
-    startTimeMs: float = Field(ge=0)
-    endTimeMs: float = Field(ge=0)
+    startTimeMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
+    endTimeMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
     startWeightG: float = Field(ge=0)
     endWeightG: float = Field(ge=0)
     waterG: float = Field(ge=0)
@@ -53,7 +79,7 @@ class FreePourPour(PourOverContractModel):
 
 class PourOverPourTarget(PourOverContractModel):
     number: int = Field(gt=0)
-    startTimeMs: float = Field(ge=0)
+    startTimeMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
     stopWeightG: float = Field(ge=0)
     flowGps: float | None = Field(default=None, ge=0)
     flowRangeGps: tuple[float, float] | None = None
@@ -73,7 +99,7 @@ class PourOverRecipe(PourOverContractModel):
     doseG: float = Field(gt=0)
     temperatureC: float | None = Field(default=None, gt=0)
     targetWaterG: float | None = Field(gt=0)
-    targetDurationMs: float | None = Field(default=None, gt=0)
+    targetDurationMs: float | None = Field(default=None, gt=0, le=MAX_POUR_OVER_DURATION_MS)
     pourTargets: list[PourOverPourTarget] = Field(max_length=128)
 
 
@@ -87,7 +113,7 @@ class PourOverMeasurements(PourOverContractModel):
     waterPouredG: float = Field(ge=0)
     beverageG: float | None = Field(ge=0)
     retainedG: float | None = Field(ge=0)
-    durationMs: float = Field(ge=0)
+    durationMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
     status: Literal["measured", "skipped"]
 
     @model_validator(mode="after")
@@ -115,7 +141,7 @@ class PourOverSession(PourOverContractModel):
     recipe: PourOverRecipe
     measurements: PourOverMeasurements
     pours: list[FreePourPour] = Field(max_length=128)
-    samples: list[FreePourSample] = Field(min_length=1, max_length=20_000)
+    samples: list[FreePourSample] = Field(min_length=1, max_length=MAX_POUR_OVER_SAMPLES)
     completion: Literal["brewer_removed", "dial_fallback"]
     sync: PourOverSync
 
@@ -171,7 +197,83 @@ class PourOverHistoryManager:
             ).fetchone()
 
     @staticmethod
-    def _write_record(relative_path: Path, payload: dict[str, Any]) -> None:
+    def _history_rows():
+        engine = PourOverHistoryManager._require_engine()
+        statement = (
+            select(brew_history)
+            .where(brew_history.c.brew_type == "pour_over")
+            .order_by(asc(brew_history.c.time), asc(brew_history.c.id))
+        )
+        with engine.connect() as connection:
+            return connection.execute(statement).fetchall()
+
+    @staticmethod
+    def _available_history_bytes() -> int:
+        path = POUR_OVER_PATH if POUR_OVER_PATH.exists() else POUR_OVER_PATH.parent
+        path.mkdir(parents=True, exist_ok=True)
+        return shutil.disk_usage(path).free
+
+    @staticmethod
+    def _remove_history_row(row) -> int:
+        engine = PourOverHistoryManager._require_engine()
+        record_path = POUR_OVER_PATH.joinpath(row.file)
+        try:
+            record_size = record_path.stat().st_size
+        except OSError:
+            record_size = 0
+        with engine.begin() as connection:
+            connection.execute(delete(brew_history).where(brew_history.c.id == row.id))
+        try:
+            record_path.unlink(missing_ok=True)
+        except OSError as error:
+            logger.warning(
+                "Could not remove pruned Pour Over history file %s: %s",
+                record_path,
+                type(error).__name__,
+            )
+        logger.info("Pruned Pour Over history entry %s", row.uuid)
+        return record_size
+
+    @staticmethod
+    def _ensure_storage_capacity(incoming_bytes: int, additional_records: int) -> None:
+        if incoming_bytes > MAX_POUR_OVER_HISTORY_BYTES:
+            raise OSError("Pour Over record exceeds the history storage quota")
+
+        rows = PourOverHistoryManager._history_rows()
+        sizes = []
+        for row in rows:
+            try:
+                sizes.append(POUR_OVER_PATH.joinpath(row.file).stat().st_size)
+            except OSError:
+                sizes.append(0)
+        total_bytes = sum(sizes)
+        free_bytes = PourOverHistoryManager._available_history_bytes()
+
+        while rows and (
+            len(rows) + additional_records > MAX_POUR_OVER_HISTORY_RECORDS
+            or total_bytes + incoming_bytes > MAX_POUR_OVER_HISTORY_BYTES
+            or free_bytes < MIN_POUR_OVER_FREE_BYTES + incoming_bytes
+        ):
+            row = rows.pop(0)
+            expected_size = sizes.pop(0)
+            removed_size = PourOverHistoryManager._remove_history_row(row)
+            total_bytes = max(0, total_bytes - max(expected_size, removed_size))
+            free_bytes = PourOverHistoryManager._available_history_bytes()
+
+        if (
+            len(rows) + additional_records > MAX_POUR_OVER_HISTORY_RECORDS
+            or total_bytes + incoming_bytes > MAX_POUR_OVER_HISTORY_BYTES
+            or free_bytes < MIN_POUR_OVER_FREE_BYTES + incoming_bytes
+        ):
+            raise OSError("Insufficient reserved space for Pour Over history")
+
+    @staticmethod
+    def _write_record(
+        relative_path: Path,
+        payload: dict[str, Any],
+        *,
+        additional_records: int,
+    ) -> None:
         destination = POUR_OVER_PATH.joinpath(relative_path)
         destination.parent.mkdir(parents=True, exist_ok=True)
         raw = json.dumps(
@@ -180,7 +282,12 @@ class PourOverHistoryManager:
             allow_nan=False,
             separators=(",", ":"),
         ).encode("utf-8")
+        if len(raw) > MAX_POUR_OVER_RECORD_BYTES:
+            raise PourOverHistoryRecordTooLargeError(
+                "Pour Over history entry exceeds the size limit"
+            )
         compressed = zstd.ZstdCompressor(level=10).compress(raw)
+        PourOverHistoryManager._ensure_storage_capacity(len(compressed), additional_records)
         temporary = destination.parent.joinpath(f".{destination.name}.{uuid.uuid4()}.tmp")
         try:
             with temporary.open("xb") as output:
@@ -194,15 +301,14 @@ class PourOverHistoryManager:
 
     @staticmethod
     def _read_record(relative_path: Path) -> dict[str, Any]:
-        with POUR_OVER_PATH.joinpath(relative_path).open("rb") as compressed:
-            raw = zstd.ZstdDecompressor().stream_reader(compressed).read()
+        raw = read_compressed_record(POUR_OVER_PATH.joinpath(relative_path))
         return json.loads(raw)
 
     @staticmethod
     def _validate_existing_record(row, payload: dict[str, Any]) -> None:
         existing_path = POUR_OVER_PATH.joinpath(row.file)
         if not existing_path.is_file():
-            PourOverHistoryManager._write_record(Path(row.file), payload)
+            PourOverHistoryManager._write_record(Path(row.file), payload, additional_records=0)
             logger.warning("Repaired missing Pour Over history file for session %s", row.uuid)
             return
         if PourOverHistoryManager._read_record(Path(row.file)) != payload:
@@ -220,7 +326,7 @@ class PourOverHistoryManager:
             return PourOverHistoryManager._row_to_metadata(existing), False
 
         relative_path = PourOverHistoryManager._timestamp_to_file_path(session)
-        PourOverHistoryManager._write_record(relative_path, payload)
+        PourOverHistoryManager._write_record(relative_path, payload, additional_records=1)
         try:
             with engine.begin() as connection:
                 result = connection.execute(

--- a/pour_over_history.py
+++ b/pour_over_history.py
@@ -1,0 +1,291 @@
+import hashlib
+import json
+import os
+import uuid
+from datetime import timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import zstandard as zstd
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
+from sqlalchemy import asc, desc, insert, select
+from sqlalchemy.exc import IntegrityError
+
+from config import POUR_OVER_PATH
+from database_models import brew_history
+from log import MeticulousLogger
+from shot_database import ShotDataBase
+
+logger = MeticulousLogger.getLogger(__name__)
+
+
+class PourOverHistoryConflictError(Exception):
+    pass
+
+
+class PourOverContractModel(BaseModel):
+    model_config = ConfigDict(extra="allow", allow_inf_nan=False)
+
+
+class FreePourSample(PourOverContractModel):
+    t: float = Field(ge=0)
+    w: float = Field(ge=0)
+    f: float = Field(ge=0)
+    p: int = Field(ge=0)
+
+
+class FreePourPour(PourOverContractModel):
+    number: int = Field(gt=0)
+    startTimeMs: float = Field(ge=0)
+    endTimeMs: float = Field(ge=0)
+    startWeightG: float = Field(ge=0)
+    endWeightG: float = Field(ge=0)
+    waterG: float = Field(ge=0)
+    averageFlowGps: float = Field(ge=0)
+    peakFlowGps: float = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_range(self):
+        if self.endTimeMs < self.startTimeMs:
+            raise ValueError("Pour end time cannot precede its start time")
+        return self
+
+
+class PourOverPourTarget(PourOverContractModel):
+    number: int = Field(gt=0)
+    startTimeMs: float = Field(ge=0)
+    stopWeightG: float = Field(ge=0)
+    flowGps: float | None = Field(default=None, ge=0)
+    flowRangeGps: tuple[float, float] | None = None
+
+    @model_validator(mode="after")
+    def validate_flow_range(self):
+        if self.flowRangeGps is not None:
+            low, high = self.flowRangeGps
+            if low < 0 or high < 0 or low > high:
+                raise ValueError("Flow range must be non-negative and ordered")
+        return self
+
+
+class PourOverRecipe(PourOverContractModel):
+    profileId: str | None
+    profileName: str = Field(min_length=1, max_length=512)
+    doseG: float = Field(gt=0)
+    temperatureC: float | None = Field(default=None, gt=0)
+    targetWaterG: float | None = Field(gt=0)
+    targetDurationMs: float | None = Field(default=None, gt=0)
+    pourTargets: list[PourOverPourTarget] = Field(max_length=128)
+
+
+class PourOverMeasurements(PourOverContractModel):
+    emptyServerG: float | None = Field(default=None, ge=0)
+    serverBaselineG: float | None = None
+    brewerG: float | None = Field(default=None, ge=0)
+    setupG: float = Field(ge=0)
+    doseG: float | None = Field(default=None, gt=0)
+    waterTemperatureC: float | None = Field(default=None, gt=0)
+    waterPouredG: float = Field(ge=0)
+    beverageG: float | None = Field(ge=0)
+    retainedG: float | None = Field(ge=0)
+    durationMs: float = Field(ge=0)
+    status: Literal["measured", "skipped"]
+
+    @model_validator(mode="after")
+    def validate_server_baseline(self):
+        if self.emptyServerG is None and self.serverBaselineG is None:
+            raise ValueError("A server baseline measurement is required")
+        return self
+
+
+class PourOverSync(PourOverContractModel):
+    status: Literal["pending", "uploaded", "failed"]
+    attempts: int = Field(ge=0)
+    uploadedAt: AwareDatetime | None = None
+
+
+class PourOverSession(PourOverContractModel):
+    schemaVersion: Literal[1, 2, 3, 4]
+    id: str = Field(min_length=1, max_length=256)
+    brewType: Literal["pour_over"]
+    mode: Literal["free_pour", "profile"]
+    name: str = Field(min_length=1, max_length=512)
+    source: Literal["dial"]
+    startedAt: AwareDatetime
+    completedAt: AwareDatetime
+    recipe: PourOverRecipe
+    measurements: PourOverMeasurements
+    pours: list[FreePourPour] = Field(max_length=128)
+    samples: list[FreePourSample] = Field(min_length=1, max_length=20_000)
+    completion: Literal["brewer_removed", "dial_fallback"]
+    sync: PourOverSync
+
+    @model_validator(mode="after")
+    def validate_timestamps(self):
+        if self.completedAt < self.startedAt:
+            raise ValueError("Completion time cannot precede brew start time")
+        return self
+
+
+class PourOverHistoryManager:
+    @staticmethod
+    def _require_engine():
+        if ShotDataBase.engine is None:
+            raise RuntimeError("History database is not initialized")
+        return ShotDataBase.engine
+
+    @staticmethod
+    def _timestamp_to_file_path(session: PourOverSession) -> Path:
+        started = session.startedAt.astimezone(timezone.utc)
+        folder = started.strftime("%Y-%m-%d")
+        digest = hashlib.sha256(session.id.encode("utf-8")).hexdigest()[:12]
+        timestamp = started.strftime("%H-%M-%S-%f")[:12]
+        return Path(folder).joinpath(f"{timestamp}-{digest}.pour-over.json.zst")
+
+    @staticmethod
+    def _row_to_metadata(row) -> dict[str, Any]:
+        started = row.time
+        completed = row.completed_time
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=timezone.utc)
+        if completed.tzinfo is None:
+            completed = completed.replace(tzinfo=timezone.utc)
+        return {
+            "db_key": row.id,
+            "id": row.uuid,
+            "brewType": row.brew_type,
+            "mode": row.mode,
+            "file": row.file,
+            "time": started.timestamp(),
+            "startedAt": started.isoformat().replace("+00:00", "Z"),
+            "completedAt": completed.isoformat().replace("+00:00", "Z"),
+            "name": row.name,
+            "schemaVersion": row.schema_version,
+        }
+
+    @staticmethod
+    def _find_by_id(session_id: str):
+        engine = PourOverHistoryManager._require_engine()
+        with engine.connect() as connection:
+            return connection.execute(
+                select(brew_history).where(brew_history.c.uuid == session_id)
+            ).fetchone()
+
+    @staticmethod
+    def _write_record(relative_path: Path, payload: dict[str, Any]) -> None:
+        destination = POUR_OVER_PATH.joinpath(relative_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        raw = json.dumps(
+            payload,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        compressed = zstd.ZstdCompressor(level=10).compress(raw)
+        temporary = destination.parent.joinpath(f".{destination.name}.{uuid.uuid4()}.tmp")
+        try:
+            with temporary.open("xb") as output:
+                output.write(compressed)
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary, destination)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+
+    @staticmethod
+    def _read_record(relative_path: Path) -> dict[str, Any]:
+        with POUR_OVER_PATH.joinpath(relative_path).open("rb") as compressed:
+            raw = zstd.ZstdDecompressor().stream_reader(compressed).read()
+        return json.loads(raw)
+
+    @staticmethod
+    def _validate_existing_record(row, payload: dict[str, Any]) -> None:
+        existing_path = POUR_OVER_PATH.joinpath(row.file)
+        if not existing_path.is_file():
+            PourOverHistoryManager._write_record(Path(row.file), payload)
+            logger.warning("Repaired missing Pour Over history file for session %s", row.uuid)
+            return
+        if PourOverHistoryManager._read_record(Path(row.file)) != payload:
+            raise PourOverHistoryConflictError(
+                "A different Pour Over record already uses this session id"
+            )
+
+    @staticmethod
+    def save(session: PourOverSession) -> tuple[dict[str, Any], bool]:
+        engine = PourOverHistoryManager._require_engine()
+        payload = session.model_dump(mode="json")
+        existing = PourOverHistoryManager._find_by_id(session.id)
+        if existing is not None:
+            PourOverHistoryManager._validate_existing_record(existing, payload)
+            return PourOverHistoryManager._row_to_metadata(existing), False
+
+        relative_path = PourOverHistoryManager._timestamp_to_file_path(session)
+        PourOverHistoryManager._write_record(relative_path, payload)
+        try:
+            with engine.begin() as connection:
+                result = connection.execute(
+                    insert(brew_history).values(
+                        uuid=session.id,
+                        brew_type=session.brewType,
+                        mode=session.mode,
+                        file=str(relative_path),
+                        time=session.startedAt.astimezone(timezone.utc),
+                        completed_time=session.completedAt.astimezone(timezone.utc),
+                        name=session.name,
+                        schema_version=session.schemaVersion,
+                    )
+                )
+                db_key = result.inserted_primary_key[0]
+        except IntegrityError:
+            existing = PourOverHistoryManager._find_by_id(session.id)
+            if existing is None:
+                POUR_OVER_PATH.joinpath(relative_path).unlink(missing_ok=True)
+                raise
+            if str(relative_path) != existing.file:
+                POUR_OVER_PATH.joinpath(relative_path).unlink(missing_ok=True)
+            PourOverHistoryManager._validate_existing_record(existing, payload)
+            return PourOverHistoryManager._row_to_metadata(existing), False
+        except Exception:
+            POUR_OVER_PATH.joinpath(relative_path).unlink(missing_ok=True)
+            raise
+
+        logger.info("Saved Pour Over session %s in brew history with id %s", session.id, db_key)
+        return {
+            "db_key": db_key,
+            "id": session.id,
+            "brewType": session.brewType,
+            "mode": session.mode,
+            "file": str(relative_path),
+            "time": session.startedAt.timestamp(),
+            "startedAt": session.startedAt.isoformat(),
+            "completedAt": session.completedAt.isoformat(),
+            "name": session.name,
+            "schemaVersion": session.schemaVersion,
+        }, True
+
+    @staticmethod
+    def search(
+        *,
+        max_results: int = 50,
+        descending: bool = True,
+        after: str | None = None,
+        mode: Literal["free_pour", "profile"] | None = None,
+    ) -> list[dict[str, Any]]:
+        engine = PourOverHistoryManager._require_engine()
+        statement = select(brew_history).where(brew_history.c.brew_type == "pour_over")
+        if after:
+            statement = statement.where(brew_history.c.file > after)
+        if mode:
+            statement = statement.where(brew_history.c.mode == mode)
+        order_by = desc if descending else asc
+        statement = statement.order_by(
+            order_by(brew_history.c.file), order_by(brew_history.c.id)
+        ).limit(max_results)
+        with engine.connect() as connection:
+            rows = connection.execute(statement).fetchall()
+        return [PourOverHistoryManager._row_to_metadata(row) for row in rows]
+
+    @staticmethod
+    def latest() -> dict[str, Any] | None:
+        results = PourOverHistoryManager.search(max_results=1, descending=True)
+        return results[0] if results else None

--- a/pour_over_profile_schema/README.md
+++ b/pour_over_profile_schema/README.md
@@ -1,0 +1,75 @@
+# Meticulous Pour Over Profile Format — version 1
+
+`schema.json` is the canonical machine contract for portable, guided Pour Over
+recipes. The backend validates every profile against this schema and the
+cross-field rules below before it writes anything to persistent storage. The
+Dial only lists profiles that passed that boundary.
+
+The running machine exposes the exact schema at:
+
+`GET /api/v1/pour-over/profile/schema`
+
+Community sends a profile with the same local-machine transport used by
+Espresso:
+
+`POST /api/v1/profile/save`
+
+The JSON body is dispatched to the Pour Over validator when
+`brew_type` is `pour_over`. A successful response means the profile was
+validated and durably stored. Validation failures return HTTP 422 with a
+`details` array containing a path, message, and code for each problem.
+
+## Machine limits
+
+- `version`: exactly `1`
+- `brew_type`: exactly `pour_over`
+- `id` and author IDs: UUIDs
+- coffee dose: 5–40 g
+- water temperature: 70–100 °C
+- total water: greater than 0 and no more than 2,000 g
+- pours: 1–5
+- scheduled/profile time: no more than 600 seconds (the Dial also forces a
+  live brew to end at 10:00)
+- stored profiles: at most 100, each no more than 512 KiB after normalization
+- `shortDescription`: at most 100 characters
+- `description`: at most 500 characters
+- portable machine image: optional compact JPEG data URI; decoded image no
+  more than 300 KiB. Community should use the existing Espresso image uploader
+  and machine-thumbnail preparation, which normalizes the source to JPEG.
+
+The flow meter displays 0–10 g/s. Valid recipes may contain a higher value; the
+Dial renders it as `10+` instead of expanding the live scale.
+
+## Time and guidance semantics
+
+`starts_at_s` is an absolute time on the single brew clock, measured from the
+detected start of the first pour. Therefore the first pour is always `0`; later
+values are the familiar `30`, `90`, etc. They are not countdowns.
+
+`duration_s` is the intended active pouring duration. For example, a pour may
+start at 30 seconds, add 50 g over 10 seconds, and then wait until the next
+pour's absolute start time.
+
+`flow_rate_g_s` is the target rate of water addition, not the pour pattern. The
+optional `pattern` field describes center, spiral/circular, ring, edge, pulse,
+or custom guidance. The current Dial guides start time, cumulative stop weight,
+and flow. Pattern, direction, height, and notes remain portable recipe metadata
+for Community and future Dial guidance.
+
+## Required consistency rules
+
+In addition to JSON Schema validation:
+
+1. The first pour starts at 0 seconds.
+2. Pour keys are unique.
+3. Pours do not overlap: each `starts_at_s` is at or after the preceding start
+   plus its `duration_s`.
+4. `flow_rate_g_s` equals `water_g / duration_s`, within 2% or 0.1 g/s.
+5. Every `target_cumulative_water_g` equals the sum of `water_g` through that
+   pour, within 0.1 g.
+6. `recipe.total_water_g` equals the sum of all pours, within 0.1 g.
+7. A flow target sits inside its optional flow range.
+8. Target brew time is not earlier than the end of the final pour, and the
+   optional upper target is not earlier than the target.
+
+See `example_profile.json` for a complete valid profile.

--- a/pour_over_profile_schema/example_profile.json
+++ b/pour_over_profile_schema/example_profile.json
@@ -1,0 +1,59 @@
+{
+  "version": 1,
+  "brew_type": "pour_over",
+  "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "name": "Two Pour V60",
+  "author": "Meticulous",
+  "author_id": "f47ac10b-58cc-4372-a567-0e02b2c3d480",
+  "display": {
+    "accentColor": "#315566",
+    "shortDescription": "A clear two-pour V60 recipe.",
+    "description": "Bloom, wait, then complete the brew with one steady main pour."
+  },
+  "recipe": {
+    "coffee_dose_g": 15,
+    "total_water_g": 250,
+    "water_temperature_c": 92,
+    "target_total_time_s": 180,
+    "target_total_time_max_s": 210,
+    "brewer": {
+      "name": "V60",
+      "size": "02"
+    },
+    "filter": {
+      "name": "Hario 02 paper",
+      "preparation": "Rinse before brewing"
+    },
+    "grind": {
+      "description": "Medium-fine"
+    }
+  },
+  "stages": [
+    {
+      "key": "bloom",
+      "name": "Bloom",
+      "starts_at_s": 0,
+      "pour": {
+        "water_g": 50,
+        "duration_s": 10,
+        "target_cumulative_water_g": 50,
+        "flow_rate_g_s": 5,
+        "flow_range_g_s": [4, 6],
+        "pattern": "spiral_out"
+      },
+      "note": "Wet all grounds evenly"
+    },
+    {
+      "key": "main",
+      "name": "Main pour",
+      "starts_at_s": 45,
+      "pour": {
+        "water_g": 200,
+        "duration_s": 40,
+        "target_cumulative_water_g": 250,
+        "flow_rate_g_s": 5,
+        "pattern": "center"
+      }
+    }
+  ]
+}

--- a/pour_over_profile_schema/schema.json
+++ b/pour_over_profile_schema/schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://meticuloushome.com/schemas/pour-over-profile/v1.json",
+  "title": "Meticulous Pour Over Profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "brew_type",
+    "id",
+    "name",
+    "author",
+    "author_id",
+    "recipe",
+    "stages"
+  ],
+  "properties": {
+    "version": { "const": 1 },
+    "brew_type": { "const": "pour_over" },
+    "id": { "type": "string", "format": "uuid" },
+    "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "author": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "author_id": { "type": "string", "format": "uuid" },
+    "previous_authors": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "author_id", "profile_id"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+          "author_id": { "type": "string", "format": "uuid" },
+          "profile_id": { "type": "string", "format": "uuid" }
+        }
+      }
+    },
+    "display": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "string",
+          "maxLength": 410000,
+          "pattern": "^data:image/jpeg;base64,"
+        },
+        "accentColor": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "shortDescription": { "type": "string", "maxLength": 100 },
+        "description": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "recipe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coffee_dose_g",
+        "total_water_g",
+        "water_temperature_c",
+        "target_total_time_s"
+      ],
+      "properties": {
+        "coffee_dose_g": { "type": "number", "minimum": 5, "maximum": 40 },
+        "total_water_g": { "type": "number", "exclusiveMinimum": 0, "maximum": 2000 },
+        "water_temperature_c": { "type": "number", "minimum": 70, "maximum": 100 },
+        "target_total_time_s": { "type": "number", "exclusiveMinimum": 0, "maximum": 600 },
+        "target_total_time_max_s": { "type": "number", "exclusiveMinimum": 0, "maximum": 600 },
+        "brewer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+            "size": { "type": "string", "maxLength": 80 },
+            "material": { "type": "string", "maxLength": 80 }
+          }
+        },
+        "filter": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+            "preparation": { "type": "string", "maxLength": 200 }
+          }
+        },
+        "grind": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["description"],
+          "properties": {
+            "description": { "type": "string", "minLength": 1, "maxLength": 200 },
+            "target_microns": { "type": "number", "exclusiveMinimum": 0, "maximum": 5000 },
+            "reference_grinder": { "type": "string", "maxLength": 120 },
+            "reference_setting": { "type": "string", "maxLength": 80 }
+          }
+        },
+        "water": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "maxLength": 120 },
+            "total_hardness_ppm": { "type": "number", "minimum": 0, "maximum": 1000 },
+            "alkalinity_ppm": { "type": "number", "minimum": 0, "maximum": 1000 }
+          }
+        },
+        "preparation": { "type": "string", "maxLength": 500 }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "name", "starts_at_s", "pour"],
+        "properties": {
+          "key": { "type": "string", "minLength": 1, "maxLength": 80 },
+          "name": { "type": "string", "minLength": 1, "maxLength": 80 },
+          "starts_at_s": { "type": "number", "minimum": 0, "maximum": 600 },
+          "temperature_c": { "type": "number", "minimum": 70, "maximum": 100 },
+          "pour": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "water_g",
+              "duration_s",
+              "target_cumulative_water_g",
+              "flow_rate_g_s"
+            ],
+            "properties": {
+              "water_g": { "type": "number", "exclusiveMinimum": 0, "maximum": 2000 },
+              "duration_s": { "type": "number", "exclusiveMinimum": 0, "maximum": 600 },
+              "target_cumulative_water_g": { "type": "number", "exclusiveMinimum": 0, "maximum": 2000 },
+              "flow_rate_g_s": { "type": "number", "exclusiveMinimum": 0, "maximum": 100 },
+              "flow_range_g_s": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "prefixItems": [
+                  { "type": "number", "minimum": 0, "maximum": 100 },
+                  { "type": "number", "exclusiveMinimum": 0, "maximum": 100 }
+                ],
+                "items": false
+              },
+              "pattern": {
+                "type": "string",
+                "enum": [
+                  "center",
+                  "spiral_out",
+                  "spiral_in",
+                  "spiral_in_out",
+                  "concentric_rings",
+                  "edge",
+                  "pulse",
+                  "custom"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "enum": ["clockwise", "counterclockwise", "alternating"]
+              },
+              "height_cm": { "type": "number", "minimum": 0, "maximum": 50 }
+            }
+          },
+          "note": { "type": "string", "maxLength": 300 }
+        }
+      }
+    }
+  }
+}

--- a/pour_over_profiles.py
+++ b/pour_over_profiles.py
@@ -1,0 +1,501 @@
+import base64
+import binascii
+import copy
+import json
+import math
+import os
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from log import MeticulousLogger
+
+logger = MeticulousLogger.getLogger(__name__)
+
+POUR_OVER_PROFILE_PATH = Path(
+    os.getenv("POUR_OVER_PROFILE_PATH", "/meticulous-user/pour-over-profiles")
+)
+POUR_OVER_PROFILE_SCHEMA_PATH = Path(__file__).parent.joinpath(
+    "pour_over_profile_schema/schema.json"
+)
+MAX_POUR_OVER_PROFILE_BYTES = 512 * 1024
+MAX_EMBEDDED_PROFILE_IMAGE_BYTES = 300 * 1024
+MAX_POUR_OVER_PROFILES = 100
+MIN_FREE_PROFILE_BYTES = 32 * 1024 * 1024
+
+
+class PourOverProfileError(Exception):
+    pass
+
+
+class PourOverProfileValidationError(PourOverProfileError):
+    def __init__(self, issues: list[dict[str, Any]]):
+        super().__init__("Invalid Pour Over profile")
+        self.issues = issues
+
+
+class PourOverProfileTooLargeError(PourOverProfileError):
+    pass
+
+
+class PourOverProfileLimitError(PourOverProfileError):
+    pass
+
+
+class PourOverProfileStorageError(PourOverProfileError):
+    pass
+
+
+class PourOverProfileUnavailableError(PourOverProfileError):
+    pass
+
+
+def _issue(path: list[str | int], message: str, code: str = "invalid") -> dict[str, Any]:
+    return {"path": path, "message": message, "code": code}
+
+
+def _reject_non_finite(value: Any, path: list[str | int], issues: list[dict[str, Any]]):
+    if isinstance(value, bool) or value is None:
+        return
+    if isinstance(value, (int, float)):
+        if not math.isfinite(value):
+            issues.append(_issue(path, "Number must be finite", "not_finite"))
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_non_finite(child, [*path, index], issues)
+        return
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _reject_non_finite(child, [*path, key], issues)
+
+
+class PourOverProfileManager:
+    _known_profiles: dict[str, dict[str, Any]] = {}
+    _schema: dict[str, Any] | None = None
+    _validator: jsonschema.Draft202012Validator | None = None
+    _available = False
+
+    @classmethod
+    def init(cls):
+        try:
+            cls._ensure_validator()
+            cls._refresh_profile_list()
+            cls._available = True
+        except Exception as error:
+            # Pour Over is optional to the espresso control path. A missing
+            # schema or unavailable user partition must never prevent the
+            # backend (and therefore espresso) from starting.
+            cls._known_profiles = {}
+            cls._available = False
+            logger.exception(
+                "Pour Over profiles are unavailable",
+                exc_info=error,
+            )
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return cls._available
+
+    @classmethod
+    def _require_available(cls):
+        if not cls._available:
+            raise PourOverProfileUnavailableError("Pour Over profiles are unavailable")
+
+    @classmethod
+    def _ensure_validator(cls):
+        if cls._validator is not None:
+            return
+        with POUR_OVER_PROFILE_SCHEMA_PATH.open("r", encoding="utf-8") as schema_file:
+            cls._schema = json.load(schema_file)
+        jsonschema.Draft202012Validator.check_schema(cls._schema)
+        cls._validator = jsonschema.Draft202012Validator(
+            cls._schema,
+            format_checker=jsonschema.FormatChecker(),
+        )
+
+    @classmethod
+    def _ensure_directory(cls):
+        POUR_OVER_PROFILE_PATH.mkdir(mode=0o755, parents=True, exist_ok=True)
+
+    @staticmethod
+    def _without_image(profile: dict[str, Any]) -> dict[str, Any]:
+        summary = copy.deepcopy(profile)
+        summary.get("display", {}).pop("image", None)
+        return summary
+
+    @classmethod
+    def _validate_image(cls, profile: dict[str, Any], issues: list[dict[str, Any]]):
+        image = profile.get("display", {}).get("image")
+        if image is None:
+            return
+        prefix = "data:image/jpeg;base64,"
+        if not image.startswith(prefix):
+            return
+        try:
+            decoded = base64.b64decode(image[len(prefix) :], validate=True)
+        except (binascii.Error, ValueError):
+            issues.append(
+                _issue(["display", "image"], "Image must contain valid base64", "image_base64")
+            )
+            return
+        if len(decoded) > MAX_EMBEDDED_PROFILE_IMAGE_BYTES:
+            issues.append(
+                _issue(
+                    ["display", "image"],
+                    "Embedded image is too large",
+                    "image_too_large",
+                )
+            )
+        if (
+            len(decoded) < 4
+            or not decoded.startswith(b"\xff\xd8")
+            or not decoded.endswith(b"\xff\xd9")
+        ):
+            issues.append(
+                _issue(["display", "image"], "Embedded image must be a JPEG", "image_format")
+            )
+
+    @classmethod
+    def _validate_semantics(cls, profile: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: C901
+        issues: list[dict[str, Any]] = []
+        _reject_non_finite(profile, [], issues)
+        if issues:
+            return issues
+
+        for path in (["name"], ["author"]):
+            value = profile.get(path[0])
+            if isinstance(value, str) and not value.strip():
+                issues.append(_issue(path, "Text cannot be blank", "blank"))
+
+        recipe = profile.get("recipe")
+        stages = profile.get("stages")
+        if not isinstance(recipe, dict) or not isinstance(stages, list) or not stages:
+            return issues
+
+        target_time = recipe["target_total_time_s"]
+        target_time_max = recipe.get("target_total_time_max_s")
+        if target_time_max is not None and target_time_max < target_time:
+            issues.append(
+                _issue(
+                    ["recipe", "target_total_time_max_s"],
+                    "Upper target time cannot be earlier than the target time",
+                    "time_range",
+                )
+            )
+
+        keys: set[str] = set()
+        cumulative_water = 0.0
+        previous_end = 0.0
+        for index, stage in enumerate(stages):
+            key = stage["key"]
+            if not key.strip():
+                issues.append(_issue(["stages", index, "key"], "Key cannot be blank", "blank"))
+            if not stage["name"].strip():
+                issues.append(
+                    _issue(["stages", index, "name"], "Name cannot be blank", "blank")
+                )
+            if key in keys:
+                issues.append(
+                    _issue(["stages", index, "key"], "Stage keys must be unique", "duplicate")
+                )
+            keys.add(key)
+
+            starts_at = stage["starts_at_s"]
+            if index == 0 and starts_at != 0:
+                issues.append(
+                    _issue(
+                        ["stages", index, "starts_at_s"],
+                        "The first pour must start at 0 seconds",
+                        "first_start",
+                    )
+                )
+            if index > 0 and starts_at + 0.001 < previous_end:
+                issues.append(
+                    _issue(
+                        ["stages", index, "starts_at_s"],
+                        "A pour cannot start before the previous pour ends",
+                        "overlap",
+                    )
+                )
+
+            pour = stage["pour"]
+            water = pour["water_g"]
+            duration = pour["duration_s"]
+            cumulative_water += water
+            expected_flow = water / duration
+            target_flow = pour["flow_rate_g_s"]
+            flow_tolerance = max(0.1, expected_flow * 0.02)
+            if abs(target_flow - expected_flow) > flow_tolerance:
+                issues.append(
+                    _issue(
+                        ["stages", index, "pour", "flow_rate_g_s"],
+                        f"Flow must equal water divided by duration ({expected_flow:.2f} g/s)",
+                        "flow_consistency",
+                    )
+                )
+            if abs(pour["target_cumulative_water_g"] - cumulative_water) > 0.1:
+                issues.append(
+                    _issue(
+                        ["stages", index, "pour", "target_cumulative_water_g"],
+                        f"Cumulative target must be {cumulative_water:.1f} g",
+                        "water_consistency",
+                    )
+                )
+            flow_range = pour.get("flow_range_g_s")
+            if flow_range is not None:
+                low, high = flow_range
+                if low > high:
+                    issues.append(
+                        _issue(
+                            ["stages", index, "pour", "flow_range_g_s"],
+                            "Flow range must be ordered",
+                            "flow_range",
+                        )
+                    )
+                elif target_flow < low or target_flow > high:
+                    issues.append(
+                        _issue(
+                            ["stages", index, "pour", "flow_range_g_s"],
+                            "Flow target must sit inside the flow range",
+                            "flow_range",
+                        )
+                    )
+            previous_end = starts_at + duration
+
+        if abs(cumulative_water - recipe["total_water_g"]) > 0.1:
+            issues.append(
+                _issue(
+                    ["recipe", "total_water_g"],
+                    f"Total water must equal the {cumulative_water:.1f} g across all pours",
+                    "water_consistency",
+                )
+            )
+        if previous_end > target_time + 0.001:
+            issues.append(
+                _issue(
+                    ["recipe", "target_total_time_s"],
+                    "Target brew time cannot end before the final pour",
+                    "time_consistency",
+                )
+            )
+
+        cls._validate_image(profile, issues)
+        return issues
+
+    @classmethod
+    def validate_profile(cls, value: Any) -> dict[str, Any]:
+        cls._ensure_validator()
+        if not isinstance(value, dict):
+            raise PourOverProfileValidationError([_issue([], "Profile must be an object")])
+
+        issues = [
+            _issue(list(error.absolute_path), error.message, "schema")
+            for error in sorted(
+                cls._validator.iter_errors(value),
+                key=lambda error: (
+                    tuple(str(part) for part in error.absolute_path),
+                    error.message,
+                ),
+            )
+        ]
+        if not issues:
+            issues.extend(cls._validate_semantics(value))
+        if issues:
+            raise PourOverProfileValidationError(issues)
+        return copy.deepcopy(value)
+
+    @classmethod
+    def _refresh_profile_list(cls):
+        cls._ensure_directory()
+        for temporary_path in POUR_OVER_PROFILE_PATH.glob(".*.tmp"):
+            try:
+                temporary_path.unlink()
+            except OSError as error:
+                logger.warning(
+                    "Could not remove stale Pour Over temporary file %s: %s",
+                    temporary_path.name,
+                    error.__class__.__name__,
+                )
+        valid: dict[str, dict[str, Any]] = {}
+        for path in sorted(POUR_OVER_PROFILE_PATH.glob("*.json")):
+            try:
+                if path.stat().st_size > MAX_POUR_OVER_PROFILE_BYTES:
+                    raise PourOverProfileTooLargeError()
+                with path.open("r", encoding="utf-8") as profile_file:
+                    profile = json.load(
+                        profile_file,
+                        parse_constant=lambda value: (_ for _ in ()).throw(
+                            ValueError(f"Invalid number {value}")
+                        ),
+                    )
+                profile = cls.validate_profile(profile)
+                if path.stem != profile["id"]:
+                    raise PourOverProfileValidationError(
+                        [_issue(["id"], "Stored filename does not match profile id")]
+                    )
+                valid[profile["id"]] = cls._without_image(profile)
+            except Exception as error:
+                logger.warning(
+                    "Skipping invalid stored Pour Over profile %s: %s",
+                    path.name,
+                    error.__class__.__name__,
+                )
+        cls._known_profiles = valid
+
+    @classmethod
+    def refresh_profile_list(cls):
+        cls._require_available()
+        cls._refresh_profile_list()
+
+    @classmethod
+    def list_profiles(cls) -> list[dict[str, Any]]:
+        cls._require_available()
+        return copy.deepcopy(
+            sorted(
+                cls._known_profiles.values(),
+                key=lambda item: (item["name"].casefold(), item["id"]),
+            )
+        )
+
+    @classmethod
+    def get_profile(cls, profile_id: str, include_image: bool = True) -> dict[str, Any] | None:
+        cls._require_available()
+        profile = cls._known_profiles.get(profile_id)
+        if profile is None:
+            return None
+        if not include_image:
+            return copy.deepcopy(profile)
+
+        path = POUR_OVER_PROFILE_PATH.joinpath(f"{profile_id}.json")
+        try:
+            if path.stat().st_size > MAX_POUR_OVER_PROFILE_BYTES:
+                raise PourOverProfileTooLargeError()
+            with path.open("r", encoding="utf-8") as profile_file:
+                stored = json.load(
+                    profile_file,
+                    parse_constant=lambda value: (_ for _ in ()).throw(
+                        ValueError(f"Invalid number {value}")
+                    ),
+                )
+            stored = cls.validate_profile(stored)
+            if stored["id"] != profile_id:
+                raise PourOverProfileValidationError(
+                    [_issue(["id"], "Stored filename does not match profile id")]
+                )
+            return stored
+        except Exception as error:
+            logger.warning(
+                "Could not read stored Pour Over profile %s: %s",
+                profile_id,
+                error.__class__.__name__,
+            )
+            raise PourOverProfileStorageError("Could not read profile") from error
+
+    @classmethod
+    def save_profile(cls, value: Any, change_id: str | None = None) -> dict[str, Any]:
+        cls._require_available()
+        profile = cls.validate_profile(value)
+        serialized = json.dumps(
+            profile,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=2,
+        ).encode("utf-8")
+        if len(serialized) > MAX_POUR_OVER_PROFILE_BYTES:
+            raise PourOverProfileTooLargeError()
+
+        cls._ensure_directory()
+        is_update = profile["id"] in cls._known_profiles
+        if not is_update and len(cls._known_profiles) >= MAX_POUR_OVER_PROFILES:
+            raise PourOverProfileLimitError()
+        required_free = MIN_FREE_PROFILE_BYTES + len(serialized)
+        if shutil.disk_usage(POUR_OVER_PROFILE_PATH).free < required_free:
+            raise PourOverProfileStorageError("Not enough free storage")
+
+        target = POUR_OVER_PROFILE_PATH.joinpath(f"{profile['id']}.json")
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                prefix=f".{profile['id']}.",
+                suffix=".tmp",
+                dir=POUR_OVER_PROFILE_PATH,
+                delete=False,
+            ) as temporary:
+                temporary.write(serialized)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+                temporary_path = Path(temporary.name)
+            os.replace(temporary_path, target)
+            directory_fd = os.open(POUR_OVER_PROFILE_PATH, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except Exception as error:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+            raise PourOverProfileStorageError("Could not save profile") from error
+
+        cls._known_profiles[profile["id"]] = cls._without_image(profile)
+        change_id = change_id or str(uuid.uuid4())
+        cls._emit_change("update" if is_update else "create", profile["id"], change_id)
+        logger.info("Saved Pour Over profile %s", profile["id"])
+        return {"profile": copy.deepcopy(profile), "change_id": change_id}
+
+    @classmethod
+    def delete_profile(cls, profile_id: str, change_id: str | None = None):
+        cls._require_available()
+        profile = cls._known_profiles.get(profile_id)
+        if profile is None:
+            return None
+        path = POUR_OVER_PROFILE_PATH.joinpath(f"{profile_id}.json")
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as error:
+            raise PourOverProfileStorageError("Could not delete profile") from error
+        del cls._known_profiles[profile_id]
+        try:
+            directory_fd = os.open(POUR_OVER_PROFILE_PATH, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError as error:
+            # The unlink already succeeded and the in-memory catalog must not
+            # claim the profile still exists. Log the durability warning but
+            # report the logical deletion accurately to the caller.
+            logger.warning(
+                "Could not fsync Pour Over profile deletion for %s: %s",
+                profile_id,
+                error.__class__.__name__,
+            )
+        change_id = change_id or str(uuid.uuid4())
+        cls._emit_change("delete", profile_id, change_id)
+        logger.info("Deleted Pour Over profile %s", profile_id)
+        return {"profile": copy.deepcopy(profile), "change_id": change_id}
+
+    @staticmethod
+    def _emit_change(change: str, profile_id: str, change_id: str):
+        try:
+            from profiles import PROFILE_EVENT, ProfileManager
+
+            ProfileManager._emit_profile_event(
+                PROFILE_EVENT(change),
+                profile_id,
+                change_id,
+                brew_type="pour_over",
+            )
+        except Exception as error:
+            logger.warning(
+                "Could not emit Pour Over profile change for %s: %s",
+                profile_id,
+                error.__class__.__name__,
+            )

--- a/pour_over_profiles.py
+++ b/pour_over_profiles.py
@@ -397,6 +397,29 @@ class PourOverProfileManager:
             raise PourOverProfileStorageError("Could not read profile") from error
 
     @classmethod
+    def get_profile_image(cls, profile_id: str) -> bytes | None:
+        """Return one validated JPEG without adding images to list responses."""
+        profile = cls.get_profile(profile_id, include_image=True)
+        if profile is None:
+            return None
+        image = profile.get("display", {}).get("image")
+        prefix = "data:image/jpeg;base64,"
+        if not isinstance(image, str) or not image.startswith(prefix):
+            return None
+        try:
+            decoded = base64.b64decode(image[len(prefix) :], validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise PourOverProfileStorageError("Could not read profile image") from error
+        if (
+            len(decoded) > MAX_EMBEDDED_PROFILE_IMAGE_BYTES
+            or len(decoded) < 4
+            or not decoded.startswith(b"\xff\xd8")
+            or not decoded.endswith(b"\xff\xd9")
+        ):
+            raise PourOverProfileStorageError("Could not read profile image")
+        return decoded
+
+    @classmethod
     def save_profile(cls, value: Any, change_id: str | None = None) -> dict[str, Any]:
         cls._require_available()
         profile = cls.validate_profile(value)

--- a/profiles.py
+++ b/profiles.py
@@ -150,6 +150,7 @@ class ProfileManager:
         change: PROFILE_EVENT,
         profile_id: Optional[str] = None,
         change_id: Optional[str] = None,
+        brew_type: Optional[str] = None,
     ) -> None:
 
         if not ProfileManager._loop:
@@ -161,6 +162,8 @@ class ProfileManager:
             payload["profile_id"] = profile_id
         if change_id is not None:
             payload["change_id"] = change_id
+        if brew_type is not None:
+            payload["brew_type"] = brew_type
 
         async def emit() -> None:
             await ProfileManager._sio.emit("profile", payload)

--- a/shot_database.py
+++ b/shot_database.py
@@ -463,6 +463,18 @@ class ShotDataBase:
             return parsed_results
 
     @staticmethod
+    def list_history_files(after: str | None = None, max_results: int = 200):
+        """Return a bounded, cursor-ordered index for the on-machine uploader."""
+        statement = select(history_table.c.file)
+        if after:
+            statement = statement.where(history_table.c.file > after)
+        statement = statement.order_by(asc(history_table.c.file)).limit(
+            min(max(max_results, 1), 200)
+        )
+        with ShotDataBase.engine.connect() as connection:
+            return [{"file": row.file} for row in connection.execute(statement).fetchall()]
+
+    @staticmethod
     def autocomplete_profile_name(prefix):
         with ShotDataBase.session() as session:
             if not prefix:

--- a/tests/test_backend_startup_imports.py
+++ b/tests/test_backend_startup_imports.py
@@ -1,0 +1,98 @@
+import importlib.util
+import ipaddress
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _module(name, **attributes):
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _load_wifi_api(monkeypatch):
+    package_name = "startup_contract_api"
+    package = _module(package_name)
+    package.__path__ = []
+    manager = MagicMock()
+    config = _module(
+        "config",
+        MeticulousConfig={"wifi": {}},
+        CONFIG_WIFI="wifi",
+        WIFI_AP_NAME="ap_name",
+        WIFI_AP_PASSWORD="ap_password",
+        WIFI_MODE="mode",
+        WIFI_MODE_AP="ap",
+        WIFI_MODE_CLIENT="client",
+    )
+    api = MagicMock()
+    api_version = SimpleNamespace(V1="v1")
+    stubs = {
+        package_name: package,
+        f"{package_name}.base_handler": _module(
+            f"{package_name}.base_handler", BaseHandler=object
+        ),
+        f"{package_name}.api": _module(f"{package_name}.api", API=api, APIVersion=api_version),
+        "config": config,
+        "wifi": _module(
+            "wifi",
+            WifiManager=manager,
+            WifiType=MagicMock(),
+            redact_ssid=lambda value: value,
+        ),
+        # Deliberately model current Nightly: ble_gatt no longer exports PORT.
+        "ble_gatt": _module("ble_gatt"),
+        "log": _module("log", MeticulousLogger=MagicMock()),
+    }
+    stubs["log"].MeticulousLogger.getLogger.return_value = MagicMock()
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_name = f"{package_name}.wifi"
+    module_path = Path(__file__).resolve().parents[1] / "api" / "wifi.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module, manager
+
+
+def test_wifi_api_imports_against_current_ble_contract(monkeypatch):
+    """Catch startup imports of symbols removed from current Nightly."""
+    module, _manager = _load_wifi_api(monkeypatch)
+
+    assert module.WiFiQRHandler is not None
+
+
+@pytest.mark.parametrize(
+    ("address", "version", "hostname", "expected"),
+    [
+        ("192.0.2.10", 4, "meticulous", "http://192.0.2.10"),
+        ("2001:db8::10", 6, "meticulous", "http://[2001:db8::10]"),
+        (None, None, "meticulous", "http://meticulous.local"),
+    ],
+)
+def test_wifi_qr_uses_the_public_machine_url(monkeypatch, address, version, hostname, expected):
+    module, manager = _load_wifi_api(monkeypatch)
+    ips = []
+    if address is not None:
+        parsed = ipaddress.ip_address(address)
+        assert parsed.version == version
+        ips.append(SimpleNamespace(ip=parsed))
+    manager.getCurrentConfig.return_value = SimpleNamespace(
+        is_hotspot=lambda: False,
+        ips=ips,
+        hostname=hostname,
+    )
+    qr = MagicMock()
+    create = MagicMock(return_value=qr)
+    monkeypatch.setattr(module.pyqrcode, "create", create)
+
+    module.WiFiQRHandler().generate_wifi_qr()
+
+    create.assert_called_once_with(expected)

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -157,8 +157,7 @@ def mock_wifi_manager():
 class TestWifiConnectUTF8:
     def test_ascii_ssid_and_password(self, mock_wifi_manager):
         result = GATTServer.wifi_connect(bytearray(b"MyNetwork"), bytearray(b"password"))
-        assert result is not None
-        assert any("192.168.1.100" in url for url in result)
+        assert result == ["http://192.168.1.100"]
         call_args = mock_wifi_manager.connectToWifi.call_args[0][0]
         assert call_args.ssid == "MyNetwork"
         assert call_args.password == "password"
@@ -291,9 +290,7 @@ class TestWifiConnectEdgeCases:
         )
         mock_wifi_manager.getCurrentConfig.return_value = config
         result = GATTServer.wifi_connect(bytearray(b"Net"), bytearray(b"pass"))
-        assert result is not None
-        assert any("192.168.1.100" in url for url in result)
-        assert any("fe80::1" in url for url in result)
+        assert result == ["http://192.168.1.100", "http://[fe80::1]"]
 
     def test_ssid_with_spaces(self, mock_wifi_manager):
         ssid = b"My Home Network"

--- a/tests/test_hostname_preservation.py
+++ b/tests/test_hostname_preservation.py
@@ -1,0 +1,150 @@
+"""Regression coverage for stable customer-visible machine identity."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+
+class _Config(dict):
+    def __init__(self, value):
+        super().__init__(value)
+        self.save = MagicMock()
+
+
+def _module(name: str, **attributes):
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _load_hostname_module(monkeypatch, identifier=None, hostname_override=None):
+    config = _Config(
+        {
+            "system": {
+                "machine_name": [] if identifier is None else identifier,
+                "serial": "003312",
+            },
+            "user": {"hostname_override": hostname_override},
+        }
+    )
+    config_module = _module(
+        "config",
+        CONFIG_SYSTEM="system",
+        CONFIG_USER="user",
+        DEVICE_IDENTIFIER="machine_name",
+        HOSTNAME_OVERRIDE="hostname_override",
+        MACHINE_SERIAL_NUMBER="serial",
+        MeticulousConfig=config,
+    )
+    logger = MagicMock()
+    log_module = _module("log", MeticulousLogger=MagicMock())
+    log_module.MeticulousLogger.getLogger.return_value = logger
+    monkeypatch.setitem(sys.modules, "config", config_module)
+    monkeypatch.setitem(sys.modules, "log", log_module)
+
+    module_name = "hostname_preservation_under_test"
+    module_path = Path(__file__).resolve().parents[1] / "hostname.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module, config, logger
+
+
+def test_identifier_is_recovered_from_established_hostname(monkeypatch):
+    module, config, logger = _load_hostname_module(monkeypatch)
+
+    with (
+        patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"),
+        patch.object(
+            module.HostnameManager,
+            "_generateRandomIdentifierComponents",
+            side_effect=AssertionError("must not generate a new identity"),
+        ),
+    ):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["spicy", "Crema"]
+    assert module.HostnameManager.generateDeviceName() == "MeticulousSpicyCrema"
+    assert module.HostnameManager.generateHostname() == "meticulousSpicyCrema-003312"
+    config.save.assert_called_once_with()
+    logger.warning.assert_called_once_with(
+        "Recovered device identifier from established hostname"
+    )
+
+
+def test_matching_existing_identifier_is_not_rewritten(monkeypatch):
+    module, config, _ = _load_hostname_module(monkeypatch, ["spicy", "Crema"])
+
+    with patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["spicy", "Crema"]
+    config.save.assert_not_called()
+
+
+def test_conflicting_identifier_is_repaired_from_established_hostname(monkeypatch):
+    module, config, logger = _load_hostname_module(monkeypatch, ["renowned", "Body"])
+
+    with patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["spicy", "Crema"]
+    config.save.assert_called_once_with()
+    logger.warning.assert_called_once_with(
+        "Recovered device identifier from established hostname"
+    )
+
+
+def test_explicit_override_keeps_configured_identifier(monkeypatch):
+    module, config, _ = _load_hostname_module(
+        monkeypatch,
+        ["renowned", "Body"],
+        hostname_override="custom-machine",
+    )
+
+    with patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["renowned", "Body"]
+    config.save.assert_not_called()
+
+
+def test_factory_hostname_without_identity_gets_new_identifier(monkeypatch):
+    module, config, _ = _load_hostname_module(monkeypatch)
+
+    with (
+        patch.object(module.socket, "gethostname", return_value="imx8mn-var-som"),
+        patch.object(
+            module.HostnameManager,
+            "_generateRandomIdentifierComponents",
+            return_value=("balanced", "Bloom"),
+        ),
+    ):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["balanced", "Bloom"]
+    config.save.assert_called_once_with()
+
+
+def test_non_generated_hostname_is_not_misparsed(monkeypatch):
+    module, _, _ = _load_hostname_module(monkeypatch)
+
+    assert module.HostnameManager.identifierFromHostname("custom-machine") is None
+    assert module.HostnameManager.identifierFromHostname("meticulousSpicyCrema-999999") is None
+
+
+def test_every_generated_identifier_round_trips_through_hostname(monkeypatch):
+    module, config, _ = _load_hostname_module(monkeypatch)
+
+    for adjective in module.HostnameManager.ADJECTIVES:
+        for noun in module.HostnameManager.NOUNS:
+            config["system"]["machine_name"] = [adjective, noun]
+            hostname = module.HostnameManager.generateHostname()
+            assert module.HostnameManager.identifierFromHostname(hostname) == (
+                adjective,
+                noun,
+            )

--- a/tests/test_identity_startup_order.py
+++ b/tests/test_identity_startup_order.py
@@ -1,0 +1,15 @@
+"""Release invariant for identity settlement before backend API readiness."""
+
+from pathlib import Path
+
+
+def test_identity_is_settled_and_signaled_before_http_listen():
+    source = (Path(__file__).resolve().parents[1] / "backend.py").read_text(encoding="utf-8")
+
+    remove_ready = source.index("os.remove(IDENTITY_READY_PATH)")
+    recover_identifier = source.index("HostnameManager.init()")
+    settle_identity = source.index("WifiManager.initializeIdentity()")
+    publish_ready = source.index("os.replace(identity_ready_temporary, IDENTITY_READY_PATH)")
+    listen = source.index('app.listen(PORT, address="127.0.0.1")')
+
+    assert remove_ready < recover_identifier < settle_identity < publish_ready < listen

--- a/tests/test_pour_over_history.py
+++ b/tests/test_pour_over_history.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
 import zstandard as zstd
 from sqlalchemy import create_engine
 from tornado.testing import AsyncHTTPTestCase
@@ -15,7 +16,13 @@ from api.pour_over_history import (
     PourOverHistoryHandler,
 )
 from database_models import metadata
-from pour_over_history import PourOverHistoryManager, PourOverSession
+from pour_over_history import (
+    MAX_POUR_OVER_RECORD_BYTES,
+    PourOverHistoryManager,
+    PourOverHistoryRecordTooLargeError,
+    PourOverSession,
+    read_compressed_record,
+)
 from shot_database import ShotDataBase
 
 
@@ -206,6 +213,33 @@ class TestPourOverHistoryAPI(AsyncHTTPTestCase):
         assert response.code == 200
         assert json.loads(response.body)["history"][0]["id"] == legacy["id"]
 
+    def test_prunes_oldest_records_at_the_history_limit(self):
+        previous_max_records = pour_over_history.MAX_POUR_OVER_HISTORY_RECORDS
+        previous_min_free = pour_over_history.MIN_POUR_OVER_FREE_BYTES
+        try:
+            pour_over_history.MAX_POUR_OVER_HISTORY_RECORDS = 2
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = 0
+            sessions = [
+                free_pour_session(
+                    session_id=f"00000000-0000-4000-8000-{index:012d}",
+                    started_at=f"2026-08-16T0{index}:00:00.000Z",
+                )
+                for index in (1, 2, 3)
+            ]
+            for session in sessions:
+                session["completedAt"] = session["startedAt"]
+                assert self.save(session).code == 201
+
+            records = PourOverHistoryManager.search(descending=False)
+            assert [record["id"] for record in records] == [
+                sessions[1]["id"],
+                sessions[2]["id"],
+            ]
+            assert len(list(self.history_path.rglob("*.zst"))) == 2
+        finally:
+            pour_over_history.MAX_POUR_OVER_HISTORY_RECORDS = previous_max_records
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = previous_min_free
+
 
 def test_session_validation_rejects_non_finite_and_reversed_ranges():
     payload = free_pour_session()
@@ -215,6 +249,30 @@ def test_session_validation_rejects_non_finite_and_reversed_ranges():
         raise AssertionError("Expected non-finite flow to be rejected")
     except ValueError:
         pass
+
+    payload = free_pour_session()
+    payload["measurements"]["durationMs"] = 600_001
+    with pytest.raises(ValueError):
+        PourOverSession.model_validate(payload)
+
+    payload = free_pour_session()
+    payload["samples"][-1]["t"] = 600_001
+    with pytest.raises(ValueError):
+        PourOverSession.model_validate(payload)
+
+    payload = free_pour_session()
+    payload["samples"] = payload["samples"] * 1_501
+    with pytest.raises(ValueError):
+        PourOverSession.model_validate(payload)
+
+
+def test_compressed_record_reader_bounds_expansion(tmp_path):
+    compressed_path = tmp_path.joinpath("oversized.pour-over.json.zst")
+    compressed_path.write_bytes(
+        zstd.ZstdCompressor(level=10).compress(b"0" * (MAX_POUR_OVER_RECORD_BYTES + 1))
+    )
+    with pytest.raises(PourOverHistoryRecordTooLargeError):
+        read_compressed_record(compressed_path)
 
     payload = free_pour_session()
     payload["recipe"]["pourTargets"] = [

--- a/tests/test_pour_over_history.py
+++ b/tests/test_pour_over_history.py
@@ -1,0 +1,227 @@
+import json
+import tempfile
+from pathlib import Path
+
+import zstandard as zstd
+from sqlalchemy import create_engine
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+
+import api.pour_over_history as pour_over_api
+import pour_over_history
+from api.pour_over_history import (
+    LastPourOverHandler,
+    PourOverFileHandler,
+    PourOverHistoryHandler,
+)
+from database_models import metadata
+from pour_over_history import PourOverHistoryManager, PourOverSession
+from shot_database import ShotDataBase
+
+
+def free_pour_session(
+    session_id: str = "11111111-2222-4333-8444-555555555555",
+    started_at: str = "2026-08-16T08:00:00.000Z",
+):
+    return {
+        "schemaVersion": 4,
+        "id": session_id,
+        "brewType": "pour_over",
+        "mode": "free_pour",
+        "name": "Free Pour",
+        "source": "dial",
+        "startedAt": started_at,
+        "completedAt": "2026-08-16T08:02:15.000Z",
+        "recipe": {
+            "profileId": None,
+            "profileName": "Free Pour",
+            "doseG": 15,
+            "temperatureC": 92,
+            "targetWaterG": None,
+            "targetDurationMs": None,
+            "pourTargets": [],
+        },
+        "measurements": {
+            "serverBaselineG": -0.4,
+            "brewerG": 134.2,
+            "setupG": 149.2,
+            "doseG": 15.1,
+            "waterTemperatureC": 92,
+            "waterPouredG": 225.3,
+            "beverageG": 196.8,
+            "retainedG": 28.5,
+            "durationMs": 135_000,
+            "status": "measured",
+        },
+        "pours": [
+            {
+                "number": 1,
+                "startTimeMs": 0,
+                "endTimeMs": 10_000,
+                "startWeightG": 0,
+                "endWeightG": 40.2,
+                "waterG": 40.2,
+                "averageFlowGps": 4.02,
+                "peakFlowGps": 4.8,
+            }
+        ],
+        "samples": [
+            {"t": 0, "w": 0, "f": 0.8, "p": 1},
+            {"t": 10_000, "w": 40.2, "f": 0.1, "p": 0},
+        ],
+        "completion": "brewer_removed",
+        "sync": {"status": "pending", "attempts": 0},
+    }
+
+
+class TestPourOverHistoryAPI(AsyncHTTPTestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        root = Path(self.temporary.name)
+        self.history_path = root.joinpath("pour-over")
+        self.engine = create_engine(f"sqlite:///{root.joinpath('history.sqlite')}")
+        metadata.create_all(self.engine)
+        self.previous_engine = ShotDataBase.engine
+        self.previous_manager_path = pour_over_history.POUR_OVER_PATH
+        self.previous_api_path = pour_over_api.POUR_OVER_PATH
+        ShotDataBase.engine = self.engine
+        pour_over_history.POUR_OVER_PATH = self.history_path
+        pour_over_api.POUR_OVER_PATH = self.history_path
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        self.engine.dispose()
+        ShotDataBase.engine = self.previous_engine
+        pour_over_history.POUR_OVER_PATH = self.previous_manager_path
+        pour_over_api.POUR_OVER_PATH = self.previous_api_path
+        self.temporary.cleanup()
+
+    def get_app(self):
+        return Application(
+            [
+                (r"/api/v1/history/pour-over", PourOverHistoryHandler),
+                (r"/api/v1/history/pour-over/last", LastPourOverHandler),
+                (
+                    r"/api/v1/history/pour-over/files/(.*)",
+                    PourOverFileHandler,
+                    {"path": self.history_path},
+                ),
+            ]
+        )
+
+    def save(self, payload=None, headers=None):
+        return self.fetch(
+            "/api/v1/history/pour-over",
+            method="POST",
+            body=json.dumps(payload or free_pour_session()),
+            headers=headers,
+        )
+
+    def test_saves_compressed_record_and_returns_it_from_history(self):
+        response = self.save()
+
+        assert response.code == 201
+        result = json.loads(response.body)
+        relative_path = result["history"]["file"]
+        stored_path = self.history_path.joinpath(relative_path)
+        assert stored_path.is_file()
+        saved = json.loads(zstd.ZstdDecompressor().decompress(stored_path.read_bytes()))
+        assert saved["brewType"] == "pour_over"
+        assert saved["measurements"]["serverBaselineG"] == -0.4
+
+        last = self.fetch("/api/v1/history/pour-over/last")
+        assert last.code == 200
+        assert json.loads(last.body)["id"] == free_pour_session()["id"]
+
+        raw = self.fetch(f"/api/v1/history/pour-over/files/{relative_path}")
+        assert raw.code == 200
+        assert json.loads(raw.body)["id"] == free_pour_session()["id"]
+
+    def test_duplicate_session_is_idempotent(self):
+        first = self.save()
+        second = self.save()
+
+        assert first.code == 201
+        assert second.code == 200
+        assert json.loads(second.body)["status"] == "existing"
+        assert len(PourOverHistoryManager.search()) == 1
+        assert len(list(self.history_path.rglob("*.zst"))) == 1
+
+    def test_rejects_reused_session_id_with_different_measurements(self):
+        original = free_pour_session()
+        changed = free_pour_session()
+        changed["measurements"]["waterPouredG"] = 250
+
+        assert self.save(original).code == 201
+        response = self.save(changed)
+
+        assert response.code == 409
+        assert len(PourOverHistoryManager.search()) == 1
+
+    def test_rejects_invalid_contract_without_writing_history(self):
+        invalid = free_pour_session()
+        invalid["samples"] = []
+
+        response = self.save(invalid)
+
+        assert response.code == 422
+        assert PourOverHistoryManager.search() == []
+        assert not list(self.history_path.rglob("*.zst"))
+
+    def test_write_endpoint_is_local_only(self):
+        response = self.save(headers={"Host": "machine.local", "X-Real-IP": "192.168.10.20"})
+
+        assert response.code == 403
+        assert PourOverHistoryManager.search() == []
+
+    def test_profile_mode_and_legacy_contract_are_accepted(self):
+        profile = free_pour_session()
+        profile["mode"] = "profile"
+        profile["name"] = "Three Pour 1:15"
+        profile["recipe"]["profileId"] = "profile-1"
+        profile["recipe"]["targetWaterG"] = 225
+        profile["recipe"]["targetDurationMs"] = 135_000
+        profile["recipe"]["pourTargets"] = [
+            {"number": 1, "startTimeMs": 0, "stopWeightG": 40, "flowGps": 4}
+        ]
+        assert self.save(profile).code == 201
+
+        legacy = free_pour_session(
+            session_id="33333333-4444-4555-8666-777777777777",
+            started_at="2026-08-16T07:00:00.000Z",
+        )
+        legacy["schemaVersion"] = 2
+        legacy["measurements"]["emptyServerG"] = 182.4
+        legacy["measurements"].pop("serverBaselineG")
+        legacy["recipe"].pop("temperatureC")
+        legacy["recipe"].pop("targetDurationMs")
+        legacy["measurements"].pop("doseG")
+        legacy["measurements"].pop("waterTemperatureC")
+
+        assert self.save(legacy).code == 201
+        records = PourOverHistoryManager.search(descending=False)
+        assert [record["schemaVersion"] for record in records] == [2, 4]
+        response = self.fetch("/api/v1/history/pour-over?mode=free_pour&max_results=1")
+        assert response.code == 200
+        assert json.loads(response.body)["history"][0]["id"] == legacy["id"]
+
+
+def test_session_validation_rejects_non_finite_and_reversed_ranges():
+    payload = free_pour_session()
+    payload["samples"][0]["f"] = float("inf")
+    try:
+        PourOverSession.model_validate(payload)
+        raise AssertionError("Expected non-finite flow to be rejected")
+    except ValueError:
+        pass
+
+    payload = free_pour_session()
+    payload["recipe"]["pourTargets"] = [
+        {"number": 1, "startTimeMs": 0, "stopWeightG": 40, "flowRangeGps": [5, 4]}
+    ]
+    try:
+        PourOverSession.model_validate(payload)
+        raise AssertionError("Expected reversed flow range to be rejected")
+    except ValueError:
+        pass

--- a/tests/test_pour_over_profiles.py
+++ b/tests/test_pour_over_profiles.py
@@ -1,0 +1,354 @@
+import json
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+import pytest
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+
+os.environ.setdefault("MOTOR_ENERGY_PATH", "/tmp/meticulous-test/motor-energy")
+
+try:
+    import pyprctl  # noqa: F401
+except Exception:
+    sys.modules["pyprctl"] = types.SimpleNamespace(set_name=lambda _name: None)
+
+try:
+    import gpiod  # noqa: F401
+except Exception:
+
+    class _LineRequest:
+        DIRECTION_OUTPUT = 1
+
+    sys.modules["gpiod"] = types.SimpleNamespace(line_request=_LineRequest)
+
+import pour_over_profiles  # noqa: E402
+from api.pour_over_profiles import (  # noqa: E402
+    DeletePourOverProfileHandler,
+    GetPourOverProfileHandler,
+    ListPourOverProfilesHandler,
+    PourOverProfileSchemaHandler,
+)
+from api.profiles import SaveProfileHandler  # noqa: E402
+from pour_over_profiles import (  # noqa: E402
+    MAX_POUR_OVER_PROFILE_BYTES,
+    PourOverProfileManager,
+    PourOverProfileValidationError,
+)
+
+
+def valid_pour_over_profile():
+    return {
+        "version": 1,
+        "brew_type": "pour_over",
+        "id": "11111111-2222-4333-8444-555555555555",
+        "name": "Lance 2 pour",
+        "author": "Recipe author",
+        "author_id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        "display": {
+            "accentColor": "#23383F",
+            "shortDescription": "A bright three-stage recipe",
+            "description": "Two smaller pours followed by the main pour.",
+        },
+        "recipe": {
+            "coffee_dose_g": 15,
+            "total_water_g": 225,
+            "water_temperature_c": 92,
+            "target_total_time_s": 135,
+            "target_total_time_max_s": 180,
+        },
+        "stages": [
+            {
+                "key": "pour-1",
+                "name": "Pour 1",
+                "starts_at_s": 0,
+                "pour": {
+                    "water_g": 35,
+                    "duration_s": 10,
+                    "target_cumulative_water_g": 35,
+                    "flow_rate_g_s": 3.5,
+                    "pattern": "spiral_out",
+                },
+            },
+            {
+                "key": "pour-2",
+                "name": "Pour 2",
+                "starts_at_s": 30,
+                "pour": {
+                    "water_g": 35,
+                    "duration_s": 10,
+                    "target_cumulative_water_g": 70,
+                    "flow_rate_g_s": 3.5,
+                    "flow_range_g_s": [3, 4],
+                },
+            },
+            {
+                "key": "pour-3",
+                "name": "Pour 3",
+                "starts_at_s": 60,
+                "pour": {
+                    "water_g": 155,
+                    "duration_s": 31,
+                    "target_cumulative_water_g": 225,
+                    "flow_rate_g_s": 5,
+                },
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def profile_directory(monkeypatch, tmp_path):
+    monkeypatch.setattr(pour_over_profiles, "POUR_OVER_PROFILE_PATH", tmp_path)
+    monkeypatch.setattr(pour_over_profiles, "MIN_FREE_PROFILE_BYTES", 0)
+    PourOverProfileManager._known_profiles = {}
+    PourOverProfileManager.init()
+    yield tmp_path
+    PourOverProfileManager._known_profiles = {}
+
+
+def test_profile_validation_and_atomic_persistence(profile_directory):
+    result = PourOverProfileManager.save_profile(valid_pour_over_profile())
+
+    assert result["profile"]["recipe"]["coffee_dose_g"] == 15
+    stored = profile_directory.joinpath("11111111-2222-4333-8444-555555555555.json")
+    assert stored.is_file()
+    assert json.loads(stored.read_text())["stages"][2]["starts_at_s"] == 60
+    assert list(profile_directory.glob("*.tmp")) == []
+
+
+def test_documented_example_matches_the_canonical_contract(profile_directory):
+    example_path = (
+        Path(__file__).parents[1].joinpath("pour_over_profile_schema/example_profile.json")
+    )
+
+    validated = PourOverProfileManager.validate_profile(
+        json.loads(example_path.read_text(encoding="utf-8"))
+    )
+
+    assert validated["brew_type"] == "pour_over"
+    assert len(validated["stages"]) == 2
+
+
+def test_debian_package_includes_canonical_pour_over_schema():
+    dockerfile = (
+        Path(__file__).parents[1].joinpath("Dockerfile.deb").read_text(encoding="utf-8")
+    )
+
+    assert "opt/meticulous-backend/pour_over_profile_schema" in dockerfile
+    assert (
+        "COPY pour_over_profile_schema/ "
+        "/pkg/opt/meticulous-backend/pour_over_profile_schema/"
+    ) in dockerfile
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_path"),
+    [
+        (
+            lambda profile: profile["recipe"].update(coffee_dose_g=4.9),
+            ["recipe", "coffee_dose_g"],
+        ),
+        (
+            lambda profile: profile["recipe"].update(water_temperature_c=69),
+            ["recipe", "water_temperature_c"],
+        ),
+        (
+            lambda profile: profile["stages"][0].update(starts_at_s=1),
+            ["stages", 0, "starts_at_s"],
+        ),
+        (
+            lambda profile: profile["stages"][1]["pour"].update(target_cumulative_water_g=71),
+            ["stages", 1, "pour", "target_cumulative_water_g"],
+        ),
+        (
+            lambda profile: profile["stages"][2]["pour"].update(flow_rate_g_s=8),
+            ["stages", 2, "pour", "flow_rate_g_s"],
+        ),
+        (lambda profile: profile.update(unknown=True), []),
+    ],
+)
+def test_rejects_schema_and_semantic_inconsistency(profile_directory, mutate, expected_path):
+    profile = valid_pour_over_profile()
+    mutate(profile)
+
+    with pytest.raises(PourOverProfileValidationError) as error:
+        PourOverProfileManager.save_profile(profile)
+
+    assert expected_path in [issue["path"] for issue in error.value.issues]
+    assert list(profile_directory.glob("*.json")) == []
+
+
+def test_rejects_overlap_and_total_time_before_final_pour(profile_directory):
+    profile = valid_pour_over_profile()
+    profile["stages"][1]["starts_at_s"] = 5
+    profile["recipe"]["target_total_time_s"] = 80
+
+    with pytest.raises(PourOverProfileValidationError) as error:
+        PourOverProfileManager.save_profile(profile)
+
+    codes = {issue["code"] for issue in error.value.issues}
+    assert "overlap" in codes
+    assert "time_consistency" in codes
+
+
+def test_refresh_skips_corrupt_or_filename_mismatched_profiles(profile_directory):
+    profile_directory.joinpath("broken.json").write_text("{not json")
+    profile_directory.joinpath("wrong-id.json").write_text(
+        json.dumps(valid_pour_over_profile())
+    )
+
+    PourOverProfileManager.refresh_profile_list()
+
+    assert PourOverProfileManager.list_profiles() == []
+
+
+def test_optional_feature_init_failure_does_not_raise_or_advertise_available(
+    monkeypatch, tmp_path
+):
+    previous_schema = PourOverProfileManager._schema
+    previous_validator = PourOverProfileManager._validator
+    previous_available = PourOverProfileManager._available
+    monkeypatch.setattr(
+        pour_over_profiles,
+        "POUR_OVER_PROFILE_SCHEMA_PATH",
+        tmp_path.joinpath("missing-schema.json"),
+    )
+    PourOverProfileManager._schema = None
+    PourOverProfileManager._validator = None
+
+    PourOverProfileManager.init()
+
+    assert PourOverProfileManager.is_available() is False
+    PourOverProfileManager._schema = previous_schema
+    PourOverProfileManager._validator = previous_validator
+    PourOverProfileManager._available = previous_available
+
+
+class TestPourOverProfilesAPI(AsyncHTTPTestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.previous_path = pour_over_profiles.POUR_OVER_PROFILE_PATH
+        self.previous_min_free = pour_over_profiles.MIN_FREE_PROFILE_BYTES
+        pour_over_profiles.POUR_OVER_PROFILE_PATH = Path(self.temporary.name)
+        pour_over_profiles.MIN_FREE_PROFILE_BYTES = 0
+        PourOverProfileManager._known_profiles = {}
+        PourOverProfileManager.init()
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        pour_over_profiles.POUR_OVER_PROFILE_PATH = self.previous_path
+        pour_over_profiles.MIN_FREE_PROFILE_BYTES = self.previous_min_free
+        PourOverProfileManager._known_profiles = {}
+        self.temporary.cleanup()
+
+    def get_app(self):
+        return Application(
+            [
+                (r"/api/v1/profile/save", SaveProfileHandler),
+                (r"/api/v1/pour-over/profile/list", ListPourOverProfilesHandler),
+                (
+                    r"/api/v1/pour-over/profile/get/([0-9a-fA-F-]+)",
+                    GetPourOverProfileHandler,
+                ),
+                (
+                    r"/api/v1/pour-over/profile/delete/([0-9a-fA-F-]+)",
+                    DeletePourOverProfileHandler,
+                ),
+                (r"/api/v1/pour-over/profile/schema", PourOverProfileSchemaHandler),
+            ]
+        )
+
+    def test_existing_profile_save_endpoint_dispatches_pour_over(self):
+        profile = valid_pour_over_profile()
+        profile["display"]["image"] = "data:image/jpeg;base64,/9j/2Q=="
+        saved = self.fetch(
+            "/api/v1/profile/save",
+            method="POST",
+            body=json.dumps(profile),
+        )
+        assert saved.code == 200
+        assert json.loads(saved.body)["profile"]["brew_type"] == "pour_over"
+        assert "image" not in PourOverProfileManager._known_profiles[profile["id"]]["display"]
+
+        listed = json.loads(self.fetch("/api/v1/pour-over/profile/list").body)
+        assert len(listed["profiles"]) == 1
+        assert "image" not in listed["profiles"][0].get("display", {})
+
+        fetched = self.fetch(f"/api/v1/pour-over/profile/get/{profile['id']}")
+        assert fetched.code == 200
+        assert json.loads(fetched.body)["name"] == profile["name"]
+        assert json.loads(fetched.body)["display"]["image"].startswith(
+            "data:image/jpeg;base64,"
+        )
+
+        without_image = self.fetch(
+            f"/api/v1/pour-over/profile/get/{profile['id']}?include_image=false"
+        )
+        assert "image" not in json.loads(without_image.body).get("display", {})
+
+        deleted = self.fetch(
+            f"/api/v1/pour-over/profile/delete/{profile['id']}",
+            method="DELETE",
+        )
+        assert deleted.code == 200
+        assert self.fetch(f"/api/v1/pour-over/profile/get/{profile['id']}").code == 404
+
+    def test_delete_endpoint_does_not_mutate_on_get(self):
+        profile = valid_pour_over_profile()
+        assert (
+            self.fetch("/api/v1/profile/save", method="POST", body=json.dumps(profile)).code
+            == 200
+        )
+
+        response = self.fetch(f"/api/v1/pour-over/profile/delete/{profile['id']}")
+
+        assert response.code == 405
+        assert PourOverProfileManager.get_profile(profile["id"]) is not None
+
+    def test_profile_api_returns_503_when_optional_storage_is_unavailable(self):
+        PourOverProfileManager._available = False
+        try:
+            response = self.fetch("/api/v1/pour-over/profile/list")
+            assert response.code == 503
+            assert json.loads(response.body)["error"] == "Pour Over profiles are unavailable"
+        finally:
+            PourOverProfileManager._available = True
+
+    def test_invalid_profile_returns_field_specific_422(self):
+        profile = valid_pour_over_profile()
+        profile["recipe"]["coffee_dose_g"] = 41
+
+        response = self.fetch(
+            "/api/v1/profile/save",
+            method="POST",
+            body=json.dumps(profile),
+        )
+
+        assert response.code == 422
+        body = json.loads(response.body)
+        assert body["error"] == "Invalid Pour Over profile"
+        assert ["recipe", "coffee_dose_g"] in [issue["path"] for issue in body["details"]]
+
+    def test_oversized_pour_over_body_is_rejected_before_json_parsing(self):
+        body = (
+            b'{"brew_type":"pour_over","padding":"' + b"x" * MAX_POUR_OVER_PROFILE_BYTES + b'"}'
+        )
+
+        response = self.fetch(
+            "/api/v1/profile/save",
+            method="POST",
+            body=body,
+        )
+
+        assert response.code == 413
+        assert json.loads(response.body)["error"] == "Pour Over profile is too large"
+
+    def test_schema_endpoint_reports_version_one(self):
+        response = self.fetch("/api/v1/pour-over/profile/schema")
+        assert response.code == 200
+        assert json.loads(response.body)["properties"]["version"]["const"] == 1

--- a/tests/test_pour_over_profiles.py
+++ b/tests/test_pour_over_profiles.py
@@ -29,6 +29,7 @@ import pour_over_profiles  # noqa: E402
 from api.pour_over_profiles import (  # noqa: E402
     DeletePourOverProfileHandler,
     GetPourOverProfileHandler,
+    GetPourOverProfileImageHandler,
     ListPourOverProfilesHandler,
     PourOverProfileSchemaHandler,
 )
@@ -256,6 +257,10 @@ class TestPourOverProfilesAPI(AsyncHTTPTestCase):
                     GetPourOverProfileHandler,
                 ),
                 (
+                    r"/api/v1/pour-over/profile/image/([0-9a-fA-F-]+)",
+                    GetPourOverProfileImageHandler,
+                ),
+                (
                     r"/api/v1/pour-over/profile/delete/([0-9a-fA-F-]+)",
                     DeletePourOverProfileHandler,
                 ),
@@ -291,12 +296,26 @@ class TestPourOverProfilesAPI(AsyncHTTPTestCase):
         )
         assert "image" not in json.loads(without_image.body).get("display", {})
 
+        image = self.fetch(f"/api/v1/pour-over/profile/image/{profile['id']}")
+        assert image.code == 200
+        assert image.headers["Content-Type"].startswith("image/jpeg")
+        assert image.body == b"\xff\xd8\xff\xd9"
+
         deleted = self.fetch(
             f"/api/v1/pour-over/profile/delete/{profile['id']}",
             method="DELETE",
         )
         assert deleted.code == 200
         assert self.fetch(f"/api/v1/pour-over/profile/get/{profile['id']}").code == 404
+
+    def test_profile_image_endpoint_returns_404_without_an_image(self):
+        profile = valid_pour_over_profile()
+        saved = self.fetch("/api/v1/profile/save", method="POST", body=json.dumps(profile))
+        assert saved.code == 200
+
+        response = self.fetch(f"/api/v1/pour-over/profile/image/{profile['id']}")
+
+        assert response.code == 404
 
     def test_delete_endpoint_does_not_mutate_on_get(self):
         profile = valid_pour_over_profile()

--- a/tests/test_shot_database.py
+++ b/tests/test_shot_database.py
@@ -153,6 +153,24 @@ class TestSearchHistory:
         results = ShotDataBase.search_history(params)
         assert len(results) == 3
 
+    def test_upload_index_is_cursor_ordered_and_bounded(self):
+        for index in range(5):
+            ShotDataBase.insert_history(
+                make_history_entry(
+                    id=f"upload-{index}",
+                    file=f"2026-08-16/shot_{index}.shot.json.zst",
+                    time=time.time() + index,
+                )
+            )
+
+        results = ShotDataBase.list_history_files(
+            after="2026-08-16/shot_1.shot.json.zst", max_results=2
+        )
+        assert results == [
+            {"file": "2026-08-16/shot_2.shot.json.zst"},
+            {"file": "2026-08-16/shot_3.shot.json.zst"},
+        ]
+
     def test_search_by_profile_id(self):
         p1 = make_profile(id="p-aaa", name="Ristretto")
         p2 = make_profile(id="p-bbb", name="Lungo")

--- a/tests/test_timezone_manager.py
+++ b/tests/test_timezone_manager.py
@@ -1,0 +1,101 @@
+import asyncio
+
+import pytest
+
+from config import CONFIG_USER, TIME_ZONE, TIMEZONE_SYNC, MeticulousConfig
+from timezone_manager import TimezoneManager
+
+
+class FakeEventLoop:
+    def __init__(self, timezone, before_return=None):
+        self.timezone = timezone
+        self.before_return = before_return
+
+    def run_until_complete(self, request):
+        assert request is REQUEST_SENTINEL
+        if self.before_return:
+            self.before_return()
+        TimezoneManager._TimezoneManager__system_synced = True
+        return self.timezone
+
+
+REQUEST_SENTINEL = object()
+
+
+@pytest.fixture(autouse=True)
+def restore_timezone_state():
+    original_timezone = MeticulousConfig[CONFIG_USER][TIME_ZONE]
+    original_sync_mode = MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC]
+    original_synced = TimezoneManager._TimezoneManager__system_synced
+    original_attempts = TimezoneManager._TimezoneManager__timezone_fetch_attempts
+
+    yield
+
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = original_timezone
+    MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] = original_sync_mode
+    TimezoneManager._TimezoneManager__system_synced = original_synced
+    TimezoneManager._TimezoneManager__timezone_fetch_attempts = original_attempts
+
+
+def configure_background_sync(monkeypatch, timezone, before_return=None):
+    MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] = "automatic"
+    TimezoneManager._TimezoneManager__system_synced = False
+    TimezoneManager._TimezoneManager__timezone_fetch_attempts = 0
+    monkeypatch.setattr(TimezoneManager, "request_and_sync_tz", lambda: REQUEST_SENTINEL)
+    monkeypatch.setattr(
+        asyncio,
+        "get_event_loop",
+        lambda: FakeEventLoop(timezone, before_return),
+    )
+
+
+def test_background_sync_persists_detected_timezone(monkeypatch):
+    save_calls = []
+    configure_background_sync(monkeypatch, "Europe/Zurich")
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Etc/UTC"
+    monkeypatch.setattr(MeticulousConfig, "save", lambda: save_calls.append(True))
+
+    TimezoneManager.tz_background_update()
+
+    assert MeticulousConfig[CONFIG_USER][TIME_ZONE] == "Europe/Zurich"
+    assert save_calls == [True]
+    assert TimezoneManager._TimezoneManager__system_synced is True
+    assert TimezoneManager._TimezoneManager__timezone_fetch_attempts == 0
+
+
+def test_background_sync_retries_when_persistence_fails(monkeypatch):
+    configure_background_sync(monkeypatch, "Europe/Zurich")
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Etc/UTC"
+
+    def fail_save():
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(MeticulousConfig, "save", fail_save)
+
+    TimezoneManager.tz_background_update()
+
+    assert MeticulousConfig[CONFIG_USER][TIME_ZONE] == "Etc/UTC"
+    assert TimezoneManager._TimezoneManager__system_synced is False
+    assert TimezoneManager._TimezoneManager__timezone_fetch_attempts == 1
+
+
+def test_background_sync_does_not_overwrite_manual_change(monkeypatch):
+    restored_timezones = []
+
+    def switch_to_manual():
+        MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] = "manual"
+        MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Europe/London"
+
+    configure_background_sync(monkeypatch, "Europe/Zurich", switch_to_manual)
+    MeticulousConfig[CONFIG_USER][TIME_ZONE] = "Etc/UTC"
+    monkeypatch.setattr(
+        TimezoneManager,
+        "set_system_timezone",
+        lambda timezone: restored_timezones.append(timezone),
+    )
+
+    TimezoneManager.tz_background_update()
+
+    assert MeticulousConfig[CONFIG_USER][TIME_ZONE] == "Europe/London"
+    assert restored_timezones == ["Europe/London"]
+    assert TimezoneManager._TimezoneManager__system_synced is False

--- a/tests/test_wifi_repair.py
+++ b/tests/test_wifi_repair.py
@@ -7,7 +7,7 @@ under an isolated module name with small system dependency stubs.
 import importlib.util
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -165,6 +165,90 @@ def test_identity_initialization_requires_hostname_change_to_settle(monkeypatch)
 
     hostname_manager.setHostname.assert_called_once_with("meticulousSpicyCrema-003312")
     module.MeticulousConfig.save.assert_not_called()
+
+
+def _connected_ipv4_config(module, *, connection_name="Home", address="192.0.2.10"):
+    config = _wifi_config(module, connected=True, connection_name=connection_name)
+    config.ips = [
+        SimpleNamespace(
+            ip=SimpleNamespace(version=4),
+            __str__=lambda: address,
+        )
+    ]
+    config.gateway = "192.0.2.1"
+    return config
+
+
+def _health(module, *, degraded=False, dns_resolves=True):
+    return module.WifiHealthStatus(
+        "client",
+        True,
+        True,
+        True,
+        dns_resolves,
+        True,
+        False,
+        degraded,
+        "dns_unreachable" if degraded else "",
+        "",
+        "",
+    )
+
+
+def test_initial_shallow_health_does_not_cache_unchecked_probe_failures(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    current = _connected_ipv4_config(module)
+
+    manager.invalidateHealthCache()
+    with patch.object(manager, "refreshHealthInBackground") as refresh:
+        result = manager.getHealthStatus(current, deep=False)
+
+    assert result.link_connected is True
+    assert result.has_ipv4 is True
+    assert result.gateway_reachable is False
+    assert result.dns_resolves is False
+    assert result.internet_reachable is False
+    assert result.degraded is False
+    assert manager._cached_health is None
+    refresh.assert_called_once_with(current)
+
+
+def test_expired_matching_health_stays_visible_during_background_refresh(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    current = _connected_ipv4_config(module)
+    previous = _health(module)
+
+    manager._cached_health = previous
+    manager._health_cache_signature = manager.getHealthCacheSignature(current)
+    manager._health_cache_time = 0
+
+    with patch.object(manager, "refreshHealthInBackground") as refresh:
+        result = manager.getHealthStatus(current, deep=False)
+
+    assert result is previous
+    assert result.dns_resolves is True
+    refresh.assert_called_once_with(current)
+
+
+def test_changed_connection_does_not_reuse_previous_network_health(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    manager = module.WifiManager
+    old_config = _connected_ipv4_config(module, connection_name="Old network")
+    current = _connected_ipv4_config(module, connection_name="New network")
+
+    manager._cached_health = _health(module)
+    manager._health_cache_signature = manager.getHealthCacheSignature(old_config)
+    manager._health_cache_time = 0
+
+    with patch.object(manager, "refreshHealthInBackground") as refresh:
+        result = manager.getHealthStatus(current, deep=False)
+
+    assert result is not manager._cached_health
+    assert result.degraded is False
+    assert result.dns_resolves is False
+    refresh.assert_called_once_with(current)
 
 
 def test_repair_without_saved_client_connection_never_resets_hardware(monkeypatch):

--- a/tests/test_wifi_repair.py
+++ b/tests/test_wifi_repair.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def _module(name: str, **attributes):
     module = ModuleType(name)
@@ -19,15 +21,20 @@ def _module(name: str, **attributes):
 
 
 def _load_wifi_module(monkeypatch):
-    config_values = {
-        "wifi": {
-            "mode": "client",
-            "ap_name": "Meticulous",
-            "ap_password": "",
-            "known_wifis": {},
-        },
-        "user": {"hostname_override": None},
-    }
+    class Config(dict):
+        save = MagicMock()
+
+    config_values = Config(
+        {
+            "wifi": {
+                "mode": "client",
+                "ap_name": "Meticulous",
+                "ap_password": "",
+                "known_wifis": {},
+            },
+            "user": {"hostname_override": None},
+        }
+    )
     config_module = _module(
         "config",
         CONFIG_WIFI="wifi",
@@ -85,6 +92,79 @@ def _wifi_config(module, *, connected, connection_name):
         hostname="meticulous",
         domains=[],
     )
+
+
+@pytest.mark.parametrize(
+    ("current", "generated", "override", "expected"),
+    [
+        (
+            "meticulousSpicyCrema-003312",
+            "meticulousRenownedBody-003312",
+            None,
+            None,
+        ),
+        (
+            "meticulousRenownedBody-003312",
+            "meticulousSpicyCrema-003312",
+            None,
+            None,
+        ),
+        ("imx8mn-var-som", "meticulousSpicyCrema-003312", None, "meticulousSpicyCrema-003312"),
+        (
+            "imx8mn-var-som-003312",
+            "meticulousSpicyCrema-003312",
+            None,
+            "meticulousSpicyCrema-003312",
+        ),
+        ("meticulous", "meticulousSpicyCrema-003312", None, "meticulousSpicyCrema-003312"),
+        (
+            "meticulousSpicyCrema-003312",
+            "meticulousRenownedBody-003312",
+            "custom-machine",
+            "custom-machine",
+        ),
+        (
+            "meticulousSpicyCrema-003312",
+            "meticulousRenownedBody-003312",
+            "none",
+            None,
+        ),
+    ],
+)
+def test_hostname_update_only_targets_factory_or_explicit_override(
+    monkeypatch, current, generated, override, expected
+):
+    module = _load_wifi_module(monkeypatch)
+
+    assert module.WifiManager.hostnameUpdateTarget(current, generated, override) == expected
+
+
+def test_identity_initialization_preserves_established_hostname(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    hostname_manager = sys.modules["hostname"].HostnameManager
+    hostname_manager.generateHostname.return_value = "meticulousRenownedBody-003312"
+    hostname_manager.generateDeviceName.return_value = "MeticulousSpicyCrema"
+
+    settled = module.WifiManager.initializeIdentity("meticulousSpicyCrema-003312")
+
+    assert settled == "meticulousSpicyCrema-003312"
+    hostname_manager.setHostname.assert_not_called()
+    assert module.MeticulousConfig["wifi"]["ap_name"] == "MeticulousSpicyCrema"
+    module.MeticulousConfig.save.assert_called_once_with()
+
+
+def test_identity_initialization_requires_hostname_change_to_settle(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    hostname_manager = sys.modules["hostname"].HostnameManager
+    hostname_manager.generateHostname.return_value = "meticulousSpicyCrema-003312"
+    hostname_manager.generateDeviceName.return_value = "MeticulousSpicyCrema"
+
+    with patch.object(module.socket, "gethostname", return_value="meticulous"):
+        with pytest.raises(RuntimeError, match="did not settle"):
+            module.WifiManager.initializeIdentity("meticulous")
+
+    hostname_manager.setHostname.assert_called_once_with("meticulousSpicyCrema-003312")
+    module.MeticulousConfig.save.assert_not_called()
 
 
 def test_repair_without_saved_client_connection_never_resets_hardware(monkeypatch):

--- a/timezone_manager.py
+++ b/timezone_manager.py
@@ -90,7 +90,7 @@ class TimezoneManager:
                 MeticulousConfig.save()
 
     @staticmethod
-    def update_timezone(new_timezone: str) -> None:
+    def update_timezone(new_timezone: str) -> str:
         stripped_new_tz = new_timezone.rstrip('"').lstrip('"')
         if MeticulousConfig[CONFIG_USER][TIME_ZONE] != stripped_new_tz:
             try:
@@ -99,6 +99,22 @@ class TimezoneManager:
             except TimezoneManagerError as e:
                 logger.error(f"Error updating timezone: {e}")
                 raise TimezoneManagerError(f"Error updating timezone: {e}")
+        return stripped_new_tz
+
+    @staticmethod
+    def persist_timezone(timezone: str) -> None:
+        previous_timezone = MeticulousConfig[CONFIG_USER][TIME_ZONE]
+        if previous_timezone == timezone:
+            return
+
+        MeticulousConfig[CONFIG_USER][TIME_ZONE] = timezone
+        try:
+            MeticulousConfig.save()
+        except Exception:
+            # Keep the in-memory value aligned with what was last known to be
+            # persisted so the next background attempt retries the save.
+            MeticulousConfig[CONFIG_USER][TIME_ZONE] = previous_timezone
+            raise
 
     @staticmethod
     def set_system_timezone(new_timezone: str) -> str:
@@ -295,17 +311,29 @@ class TimezoneManager:
             try:
                 logger.info("Timezone is set to automatic, fetching timezone in the background")
                 loop = asyncio.get_event_loop()
-                loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+                new_timezone = loop.run_until_complete(TimezoneManager.request_and_sync_tz())
+                if new_timezone is not None:
+                    if MeticulousConfig[CONFIG_USER][TIMEZONE_SYNC] == "automatic":
+                        TimezoneManager.persist_timezone(new_timezone)
+                    else:
+                        # Automatic sync may finish after the user switches to
+                        # manual mode. Restore the saved manual timezone instead
+                        # of letting the stale request overwrite that choice.
+                        configured_timezone = MeticulousConfig[CONFIG_USER][TIME_ZONE]
+                        if configured_timezone and configured_timezone != new_timezone:
+                            TimezoneManager.set_system_timezone(configured_timezone)
+                        TimezoneManager.__system_synced = False
                 # Clear the attempt counter on a successful request so that, if
                 # __system_synced is ever reset, an unstable network gets a fresh
                 # batch of attempts instead of inheriting an exhausted counter.
                 TimezoneManager.__timezone_fetch_attempts = 0
             except Exception as e:
+                TimezoneManager.__system_synced = False
                 logger.error(f"Error while fetching timezone in the background: {e}")
 
     @staticmethod
-    async def request_and_sync_tz() -> str:
-        async def request_tz_task() -> str:
+    async def request_and_sync_tz() -> str | None:
+        async def request_tz_task() -> str | None:
             # nonlocal error
             import aiohttp
 
@@ -319,7 +347,7 @@ class TimezoneManager:
                             str_content = await response.text()
                             tz = json.loads(str_content).get("tz")
                             if tz is not None:
-                                TimezoneManager.update_timezone(
+                                tz = TimezoneManager.update_timezone(
                                     tz
                                 )  # raises TimezoneManagerError if fails
                                 TimezoneManager.__system_synced = True

--- a/wifi.py
+++ b/wifi.py
@@ -252,6 +252,62 @@ class WifiManager:
     _scan_in_progress = False
     _scan_lock = threading.Lock()
 
+    @staticmethod
+    def hostnameUpdateTarget(
+        current_hostname: str,
+        generated_hostname: str,
+        hostname_override,
+    ) -> str | None:
+        """Return an explicitly requested hostname change, if one is safe to make."""
+        if hostname_override is not None and hostname_override != "none":
+            return str(hostname_override)
+
+        # Automatic naming is only appropriate for an unprovisioned factory hostname.
+        # An existing Meticulous name is user-visible over Wi-Fi and Bluetooth and must
+        # remain stable even if stored identity data is briefly missing or inconsistent.
+        factory_hostname = (
+            current_hostname == "meticulous"
+            or current_hostname == "imx8mn-var-som"
+            or current_hostname.startswith("imx8mn-var-som-")
+        )
+        if hostname_override is None and factory_hostname:
+            return generated_hostname
+        return None
+
+    @staticmethod
+    def initializeIdentity(current_hostname: str | None = None) -> str:
+        """Synchronously settle hostname and advertised identity before API readiness."""
+        if current_hostname is None:
+            current_hostname = socket.gethostname()
+
+        logger.info(f"Current hostname is '{current_hostname}'")
+        hostname_override = MeticulousConfig[CONFIG_USER][HOSTNAME_OVERRIDE]
+        generated_hostname = HostnameManager.generateHostname()
+        requested_hostname = WifiManager.hostnameUpdateTarget(
+            current_hostname,
+            generated_hostname,
+            hostname_override,
+        )
+        if requested_hostname is not None and current_hostname != requested_hostname:
+            if hostname_override is None:
+                logger.info(f"Naming factory hostname as {requested_hostname}")
+            else:
+                logger.info(f"Hostname override is set to {hostname_override}")
+                logger.info(f"Setting hostname to override: {hostname_override}")
+            HostnameManager.setHostname(requested_hostname)
+            current_hostname = socket.gethostname()
+            if current_hostname != requested_hostname:
+                raise RuntimeError("Hostname update did not settle to the requested identity")
+        elif hostname_override is None and current_hostname != generated_hostname:
+            logger.warning(f"Preserving established hostname '{current_hostname}'")
+        elif hostname_override is not None and hostname_override != "none":
+            logger.info(f"Hostname override is set to {hostname_override}")
+
+        ap_name = HostnameManager.generateDeviceName()
+        MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME] = ap_name[:31]
+        MeticulousConfig.save()
+        return current_hostname
+
     def clearLastConnectionError():
         WifiManager._last_connection_error_code = ""
         WifiManager._last_connection_error_message = ""
@@ -388,32 +444,6 @@ class WifiManager:
         except Exception as e:
             logger.warning(f"Networking unavailable! {e}")
             WifiManager._networking_available = False
-
-        config = WifiManager.getCurrentConfig()
-
-        # Only update the hostname if it is a new system or if the hostname has been
-        # set before. Do so in case the lookup table ever changed or the hostname is only
-        # saved transient
-        logger.info(f"Current hostname is '{config.hostname}'")
-
-        hostname_override = MeticulousConfig[CONFIG_USER][HOSTNAME_OVERRIDE]
-        # Check if we are on a deployed machine, a container or if we are running elsewhere
-        # In the later case we dont want to set the hostname
-        MACHINE_HOSTNAMES = ("imx8mn-var-som", "meticulous")
-        if config.hostname.startswith(MACHINE_HOSTNAMES) and hostname_override is None:
-            new_hostname = HostnameManager.generateHostname()
-            if config.hostname != new_hostname:
-                logger.info(f"Changing hostname new = {new_hostname}")
-                HostnameManager.setHostname(new_hostname)
-        elif hostname_override is not None and hostname_override != "none":
-            logger.info(f"Hostname override is set to {hostname_override}")
-            if config.hostname != str(hostname_override):
-                logger.info(f"Setting hostname to override: {hostname_override}")
-                HostnameManager.setHostname(str(hostname_override))
-
-        ap_name = HostnameManager.generateDeviceName()
-        MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME] = ap_name[:31]
-        MeticulousConfig.save()
 
         if WifiManager._zeroconf is None:
             logger.info("Creating Zeroconf Object")

--- a/wifi.py
+++ b/wifi.py
@@ -425,10 +425,16 @@ class WifiManager:
         )
 
     def healthCacheIsValid(config: WifiSystemConfig = None):
-        if (
-            WifiManager._cached_health is None
-            or time.time() - WifiManager._health_cache_time >= WifiManager._health_cache_ttl
-        ):
+        if not WifiManager.healthCacheMatches(config):
+            return False
+
+        if time.time() - WifiManager._health_cache_time >= WifiManager._health_cache_ttl:
+            return False
+
+        return True
+
+    def healthCacheMatches(config: WifiSystemConfig = None):
+        if WifiManager._cached_health is None:
             return False
 
         signature = WifiManager.getHealthCacheSignature(config)
@@ -872,11 +878,21 @@ class WifiManager:
     def getHealthStatus(
         config: WifiSystemConfig = None, force: bool = False, deep: bool = True
     ) -> WifiHealthStatus:
+        if config is None:
+            config = WifiManager.getCurrentConfig()
+
         if not force and WifiManager.healthCacheIsValid(config):
             return WifiManager._cached_health
 
         if not deep:
-            health = WifiManager.buildHealthStatus(config, deep=False)
+            # Keep displaying the last conclusive result while its replacement is
+            # calculated. A shallow result has not run any probes, so caching its
+            # default False values would make the UI report a false failure on
+            # every cache refresh.
+            if WifiManager.healthCacheMatches(config):
+                health = WifiManager._cached_health
+            else:
+                health = WifiManager.buildHealthStatus(config, deep=False)
             WifiManager.refreshHealthInBackground(config)
             return health
 
@@ -942,7 +958,10 @@ class WifiManager:
             return health
 
         if config.connected and has_ipv4 and not deep:
-            health = WifiHealthStatus(
+            # False means "not checked yet" in this shallow response. Do not cache
+            # it as a completed health check; the background deep check below will
+            # replace it with conclusive probe results.
+            return WifiHealthStatus(
                 mode,
                 config.connected,
                 has_ipv4,
@@ -955,10 +974,6 @@ class WifiManager:
                 WifiManager._last_recovery_action,
                 WifiManager._last_recovery_result,
             )
-            WifiManager._cached_health = health
-            WifiManager._health_cache_time = time.time()
-            WifiManager._health_cache_signature = signature
-            return health
 
         if config.connected and has_ipv4:
             gateway_reachable = WifiManager.gatewayReachable(config.gateway)


### PR DESCRIPTION
## What changed

- Adds the accumulated backend support for Pour Over history, validated portable profiles, automatic-upload persistence, and the applicable identity, timezone, and Wi-Fi hardening on this branch.
- Adds a dedicated per-profile JPEG endpoint for the Dial home card.
- Keeps embedded images out of profile-list responses and preserves the existing 300 KiB JPEG validation limit.
- Returns a safe 404 when a profile has no image and a storage error for corrupt on-disk data.

## Why

The Dial profile list intentionally omits embedded images to avoid large memory use, but there was no bounded way for an individual home card to retrieve its image. Guided profiles therefore always showed the fallback color/icon.

## Validation

- 19 Pour Over profile manager and HTTP API tests passed
- Black formatting check passed
- Image response, missing-image fallback, list omission, validation, save, delete, and schema behavior covered

The new image endpoint still needs a real-machine pass with the matching Dial draft, so this remains a draft.