### PR TITLE
Add durable Pour Over history storage and API

### DIFF
--- a/alembic/versions/2026_08_16_1500-b71d84a4c2ef_add_brew_history_table.py
+++ b/alembic/versions/2026_08_16_1500-b71d84a4c2ef_add_brew_history_table.py
@@ -1,0 +1,43 @@
+"""add first-class brew history table
+
+Revision ID: b71d84a4c2ef
+Revises: 8f4e7b2c9d10
+Create Date: 2026-08-16 15:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b71d84a4c2ef"
+down_revision: Union[str, None] = "8f4e7b2c9d10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "brew_history",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("uuid", sa.Text(), nullable=False),
+        sa.Column("brew_type", sa.Text(), nullable=False),
+        sa.Column("mode", sa.Text(), nullable=False),
+        sa.Column("file", sa.Text(), nullable=False),
+        sa.Column("time", sa.DateTime(), nullable=False),
+        sa.Column("completed_time", sa.DateTime(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("schema_version", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("file"),
+        sa.UniqueConstraint("uuid"),
+    )
+    op.create_index("ix_brew_history_completed_time", "brew_history", ["completed_time"])
+    op.create_index("ix_brew_history_brew_type", "brew_history", ["brew_type"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_brew_history_brew_type", table_name="brew_history")
+    op.drop_index("ix_brew_history_completed_time", table_name="brew_history")
+    op.drop_table("brew_history")

--- a/api/api.py
+++ b/api/api.py
@@ -41,6 +41,7 @@ class API:
     def get_routes(cls):
         from . import action as _action  # noqa
         from . import history as _history  # noqa
+        from . import pour_over_history as _pour_over_history  # noqa
         from . import bug_report as _bug_report  # noqa
         from . import notifications as _noti  # noqa
         from . import profiles as _profiles  # noqa

--- a/api/history.py
+++ b/api/history.py
@@ -13,7 +13,7 @@ from config import DEBUG_HISTORY_PATH, SHOT_PATH
 from shot_manager import ShotManager
 
 from .api import API, APIVersion
-from .base_handler import BaseHandler
+from .base_handler import BaseHandler, LocalAccessHandler
 import asyncio
 from shot_debug_manager import ShotDebugManager
 from pathlib import Path
@@ -215,6 +215,22 @@ class LastShotHandler(BaseHandler):
         self.write(last_shot_json)
 
 
+class UploadHistoryIndexHandler(LocalAccessHandler):
+    async def get(self):
+        try:
+            max_results = min(max(int(self.get_query_argument("max_results", "200")), 1), 200)
+        except ValueError:
+            self.set_status(400)
+            self.write({"status": "error", "error": "max_results must be an integer"})
+            return
+        after = self.get_query_argument("after", None)
+        loop = asyncio.get_event_loop()
+        history = await loop.run_in_executor(
+            None, ShotDataBase.list_history_files, after, max_results
+        )
+        self.write({"history": history})
+
+
 class HistoryHandler(BaseHandler):
     async def searchHistory(self, params: SearchParams):
         loop = asyncio.get_event_loop()
@@ -309,6 +325,7 @@ class ShotRatingHandler(BaseHandler):
 API.register_handler(APIVersion.V1, r"/history/search", ProfileSearchHandler),
 API.register_handler(APIVersion.V1, r"/history/current", CurrentShotHandler),
 API.register_handler(APIVersion.V1, r"/history/last", LastShotHandler),
+API.register_handler(APIVersion.V1, r"/history/upload-index", UploadHistoryIndexHandler),
 API.register_handler(APIVersion.V1, r"/history/stats", StatisticsHandler),
 
 API.register_handler(APIVersion.V1, r"/history", HistoryHandler),

--- a/api/pour_over_history.py
+++ b/api/pour_over_history.py
@@ -1,0 +1,194 @@
+import asyncio
+import functools
+import json
+from pathlib import Path
+
+import tornado.web
+import zstandard as zstd
+from pydantic import ValidationError
+
+from config import POUR_OVER_PATH
+from log import MeticulousLogger
+from pour_over_history import (
+    PourOverHistoryConflictError,
+    PourOverHistoryManager,
+    PourOverHistoryRecordTooLargeError,
+    PourOverSession,
+    MAX_POUR_OVER_RECORD_BYTES,
+    read_compressed_record,
+)
+
+from .api import API, APIVersion
+from .base_handler import BaseHandler, LocalAccessHandler
+
+logger = MeticulousLogger.getLogger(__name__)
+last_version_path = f"/api/{APIVersion.latest_version().name.lower()}"
+MAX_POUR_OVER_BODY_BYTES = MAX_POUR_OVER_RECORD_BYTES
+MAX_DIRECTORY_RESULTS = 200
+
+
+class PourOverFileHandler(BaseHandler):
+    def initialize(self, path):
+        self.root = Path(path).resolve()
+
+    async def get(self, relative_path):
+        try:
+            requested = self.root.joinpath(relative_path).resolve()
+            requested.relative_to(self.root)
+        except ValueError:
+            self.set_status(404)
+            self.write({"status": "error", "error": "history entry not found"})
+            return
+
+        loop = asyncio.get_event_loop()
+        if requested.is_dir():
+            entries = await loop.run_in_executor(
+                None,
+                lambda: sorted(
+                    requested.iterdir(),
+                    key=lambda entry: entry.stat().st_mtime,
+                    reverse=True,
+                )[:MAX_DIRECTORY_RESULTS],
+            )
+            self.write(
+                [
+                    {
+                        "name": entry.name.removesuffix(".zst"),
+                        "url": entry.name,
+                    }
+                    for entry in entries
+                ]
+            )
+            return
+
+        compressed_path = requested
+        if not compressed_path.is_file() and not str(compressed_path).endswith(".zst"):
+            compressed_path = Path(f"{compressed_path}.zst")
+        if not compressed_path.is_file():
+            self.set_status(404)
+            self.write(
+                {
+                    "status": "error",
+                    "error": "history entry not found",
+                    "path": relative_path,
+                }
+            )
+            return
+
+        try:
+            raw = await loop.run_in_executor(None, read_compressed_record, compressed_path)
+        except (zstd.ZstdError, PourOverHistoryRecordTooLargeError):
+            logger.warning("Invalid compressed Pour Over history file: %s", compressed_path)
+            self.set_status(500)
+            self.write({"status": "error", "error": "Invalid history entry"})
+            return
+        self.set_header("Content-Type", "application/json")
+        self.write(raw)
+
+
+class PourOverHistoryHandler(LocalAccessHandler):
+    async def post(self):
+        if len(self.request.body) > MAX_POUR_OVER_BODY_BYTES:
+            self.set_status(413)
+            self.write({"status": "error", "error": "Pour Over record is too large"})
+            return
+        try:
+            raw = json.loads(self.request.body)
+            session = PourOverSession.model_validate(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.set_status(400)
+            self.write({"status": "error", "error": "Invalid JSON"})
+            return
+        except ValidationError as error:
+            self.set_status(422)
+            self.write(
+                {
+                    "status": "error",
+                    "error": "Invalid Pour Over record",
+                    "details": json.loads(error.json(include_url=False)),
+                }
+            )
+            return
+
+        # The save performs SQL queries, zstd compression, fsync and disk usage
+        # checks; run it off the event loop like the other history handlers.
+        loop = asyncio.get_event_loop()
+        try:
+            history, created = await loop.run_in_executor(
+                None, PourOverHistoryManager.save, session
+            )
+        except PourOverHistoryRecordTooLargeError:
+            self.set_status(413)
+            self.write({"status": "error", "error": "Pour Over record is too large"})
+            return
+        except PourOverHistoryConflictError:
+            self.set_status(409)
+            self.write(
+                {
+                    "status": "error",
+                    "error": "A different Pour Over record already uses this id",
+                }
+            )
+            return
+        except Exception as error:
+            logger.exception("Failed to save Pour Over history", exc_info=error)
+            self.set_status(500)
+            self.write({"status": "error", "error": "Could not save Pour Over record"})
+            return
+
+        self.set_status(201 if created else 200)
+        self.write({"status": "created" if created else "existing", "history": history})
+
+    async def get(self):
+        try:
+            max_results = min(max(int(self.get_query_argument("max_results", "50")), 1), 200)
+        except ValueError:
+            self.set_status(400)
+            self.write({"status": "error", "error": "max_results must be an integer"})
+            return
+        descending = self.get_query_argument("sort", "desc") != "asc"
+        after = self.get_query_argument("after", None)
+        mode = self.get_query_argument("mode", None)
+        if mode not in (None, "free_pour", "profile"):
+            self.set_status(400)
+            self.write({"status": "error", "error": "Invalid Pour Over mode"})
+            return
+        loop = asyncio.get_event_loop()
+        history = await loop.run_in_executor(
+            None,
+            functools.partial(
+                PourOverHistoryManager.search,
+                max_results=max_results,
+                descending=descending,
+                after=after,
+                mode=mode,
+            ),
+        )
+        self.write({"history": history})
+
+
+class LastPourOverHandler(BaseHandler):
+    async def get(self):
+        loop = asyncio.get_event_loop()
+        history = await loop.run_in_executor(None, PourOverHistoryManager.latest)
+        if history is None:
+            self.set_status(404)
+            self.write({"status": "error", "error": "No Pour Over records found"})
+            return
+        self.write(history)
+
+
+API.register_handler(APIVersion.V1, r"/history/pour-over", PourOverHistoryHandler)
+API.register_handler(APIVersion.V1, r"/history/pour-over/last", LastPourOverHandler)
+API.register_handler(
+    APIVersion.V1,
+    r"/history/pour-over/files",
+    tornado.web.RedirectHandler,
+    url=f"{last_version_path}/history/pour-over/files/",
+)
+API.register_handler(
+    APIVersion.V1,
+    r"/history/pour-over/files/(.*)",
+    PourOverFileHandler,
+    path=POUR_OVER_PATH,
+)

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ DATABASE_FILE = "history.sqlite"
 ABSOLUTE_DATABASE_FILE = Path(HISTORY_PATH).joinpath(DATABASE_FILE).resolve()
 DATABASE_URL = f"sqlite:///{ABSOLUTE_DATABASE_FILE}"
 SHOT_PATH = Path(HISTORY_PATH).joinpath("shots")
+POUR_OVER_PATH = Path(HISTORY_PATH).joinpath("pour-over")
 DEBUG_HISTORY_PATH = os.getenv("DEBUG_HISTORY_PATH", "/meticulous-user/history/debug")
 
 # Config Compontents

--- a/database_models.py
+++ b/database_models.py
@@ -2,6 +2,7 @@ from sqlalchemy import (
     MetaData,
     Table,
     Column,
+    Index,
     Integer,
     Text,
     DateTime,
@@ -51,6 +52,24 @@ history = Table(
     Column("profile_id", Text, nullable=False),
     Column("profile_key", Integer, ForeignKey("profile.key"), nullable=False),
     Column("debug_file", Text, nullable=True),
+)
+
+brew_history = Table(
+    "brew_history",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("uuid", Text, nullable=False, unique=True),
+    Column("brew_type", Text, nullable=False),
+    Column("mode", Text, nullable=False),
+    Column("file", Text, nullable=False, unique=True),
+    Column("time", DateTime, nullable=False),
+    Column("completed_time", DateTime, nullable=False),
+    Column("name", Text, nullable=False),
+    Column("schema_version", Integer, nullable=False),
+    # Keep in sync with the b71d84a4c2ef migration so metadata.create_all
+    # produces the same schema as the alembic upgrade path.
+    Index("ix_brew_history_completed_time", "completed_time"),
+    Index("ix_brew_history_brew_type", "brew_type"),
 )
 
 shot_annotation = Table(

--- a/db_migration_updater.py
+++ b/db_migration_updater.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 
 logger = MeticulousLogger.getLogger(__name__)
 
-DB_VERSION_REQUIRED = "8f4e7b2c9d10"
+DB_VERSION_REQUIRED = "b71d84a4c2ef"
 
 USER_DB_MIGRATION_DIR = os.getenv("USER_DB_MIGRATION_DIR", "/meticulous-user/.dbmigrations")
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/pour_over_history.py
+++ b/pour_over_history.py
@@ -1,0 +1,415 @@
+import hashlib
+import json
+import os
+import shutil
+import uuid
+from datetime import timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import zstandard as zstd
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
+from sqlalchemy import asc, delete, desc, insert, select
+from sqlalchemy.exc import IntegrityError
+
+from config import POUR_OVER_PATH
+from database_models import brew_history
+from log import MeticulousLogger
+from shot_database import ShotDataBase
+
+logger = MeticulousLogger.getLogger(__name__)
+
+MAX_POUR_OVER_DURATION_MS = 10 * 60 * 1000
+MAX_POUR_OVER_SAMPLES = MAX_POUR_OVER_DURATION_MS // 200 + 1
+MAX_POUR_OVER_RECORD_BYTES = 2 * 1024 * 1024
+MAX_POUR_OVER_HISTORY_RECORDS = 1_000
+MAX_POUR_OVER_HISTORY_BYTES = 128 * 1024 * 1024
+MIN_POUR_OVER_FREE_BYTES = 128 * 1024 * 1024
+
+
+class PourOverHistoryConflictError(Exception):
+    pass
+
+
+class PourOverHistoryRecordTooLargeError(Exception):
+    pass
+
+
+def read_compressed_record(path: Path) -> bytes:
+    with path.open("rb") as compressed:
+        raw = (
+            zstd.ZstdDecompressor()
+            .stream_reader(compressed)
+            .read(MAX_POUR_OVER_RECORD_BYTES + 1)
+        )
+    if len(raw) > MAX_POUR_OVER_RECORD_BYTES:
+        raise PourOverHistoryRecordTooLargeError(
+            "Pour Over history entry exceeds the decompressed size limit"
+        )
+    return raw
+
+
+class PourOverContractModel(BaseModel):
+    model_config = ConfigDict(extra="allow", allow_inf_nan=False)
+
+
+class FreePourSample(PourOverContractModel):
+    t: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
+    w: float = Field(ge=0)
+    f: float = Field(ge=0)
+    p: int = Field(ge=0)
+
+
+class FreePourPour(PourOverContractModel):
+    number: int = Field(gt=0)
+    startTimeMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
+    endTimeMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
+    startWeightG: float = Field(ge=0)
+    endWeightG: float = Field(ge=0)
+    waterG: float = Field(ge=0)
+    averageFlowGps: float = Field(ge=0)
+    peakFlowGps: float = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_range(self):
+        if self.endTimeMs < self.startTimeMs:
+            raise ValueError("Pour end time cannot precede its start time")
+        return self
+
+
+class PourOverPourTarget(PourOverContractModel):
+    number: int = Field(gt=0)
+    startTimeMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
+    stopWeightG: float = Field(ge=0)
+    flowGps: float | None = Field(default=None, ge=0)
+    flowRangeGps: tuple[float, float] | None = None
+
+    @model_validator(mode="after")
+    def validate_flow_range(self):
+        if self.flowRangeGps is not None:
+            low, high = self.flowRangeGps
+            if low < 0 or high < 0 or low > high:
+                raise ValueError("Flow range must be non-negative and ordered")
+        return self
+
+
+class PourOverRecipe(PourOverContractModel):
+    profileId: str | None
+    profileName: str = Field(min_length=1, max_length=512)
+    doseG: float = Field(gt=0)
+    temperatureC: float | None = Field(default=None, gt=0)
+    targetWaterG: float | None = Field(gt=0)
+    targetDurationMs: float | None = Field(default=None, gt=0, le=MAX_POUR_OVER_DURATION_MS)
+    pourTargets: list[PourOverPourTarget] = Field(max_length=128)
+
+
+class PourOverMeasurements(PourOverContractModel):
+    emptyServerG: float | None = Field(default=None, ge=0)
+    serverBaselineG: float | None = None
+    brewerG: float | None = Field(default=None, ge=0)
+    setupG: float = Field(ge=0)
+    doseG: float | None = Field(default=None, gt=0)
+    waterTemperatureC: float | None = Field(default=None, gt=0)
+    waterPouredG: float = Field(ge=0)
+    beverageG: float | None = Field(ge=0)
+    retainedG: float | None = Field(ge=0)
+    durationMs: float = Field(ge=0, le=MAX_POUR_OVER_DURATION_MS)
+    status: Literal["measured", "skipped"]
+
+    @model_validator(mode="after")
+    def validate_server_baseline(self):
+        if self.emptyServerG is None and self.serverBaselineG is None:
+            raise ValueError("A server baseline measurement is required")
+        return self
+
+
+class PourOverSync(PourOverContractModel):
+    status: Literal["pending", "uploaded", "failed"]
+    attempts: int = Field(ge=0)
+    uploadedAt: AwareDatetime | None = None
+
+
+class PourOverSession(PourOverContractModel):
+    schemaVersion: Literal[1, 2, 3, 4]
+    id: str = Field(min_length=1, max_length=256)
+    brewType: Literal["pour_over"]
+    mode: Literal["free_pour", "profile"]
+    name: str = Field(min_length=1, max_length=512)
+    source: Literal["dial"]
+    startedAt: AwareDatetime
+    completedAt: AwareDatetime
+    recipe: PourOverRecipe
+    measurements: PourOverMeasurements
+    pours: list[FreePourPour] = Field(max_length=128)
+    samples: list[FreePourSample] = Field(min_length=1, max_length=MAX_POUR_OVER_SAMPLES)
+    completion: Literal["brewer_removed", "dial_fallback"]
+    sync: PourOverSync
+
+    @model_validator(mode="after")
+    def validate_timestamps(self):
+        if self.completedAt < self.startedAt:
+            raise ValueError("Completion time cannot precede brew start time")
+        return self
+
+
+class PourOverHistoryManager:
+    @staticmethod
+    def _require_engine():
+        if ShotDataBase.engine is None:
+            raise RuntimeError("History database is not initialized")
+        return ShotDataBase.engine
+
+    @staticmethod
+    def _timestamp_to_file_path(session: PourOverSession) -> Path:
+        started = session.startedAt.astimezone(timezone.utc)
+        folder = started.strftime("%Y-%m-%d")
+        digest = hashlib.sha256(session.id.encode("utf-8")).hexdigest()[:12]
+        timestamp = started.strftime("%H-%M-%S-%f")[:12]
+        return Path(folder).joinpath(f"{timestamp}-{digest}.pour-over.json.zst")
+
+    @staticmethod
+    def _row_to_metadata(row) -> dict[str, Any]:
+        started = row.time
+        completed = row.completed_time
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=timezone.utc)
+        if completed.tzinfo is None:
+            completed = completed.replace(tzinfo=timezone.utc)
+        return {
+            "db_key": row.id,
+            "id": row.uuid,
+            "brewType": row.brew_type,
+            "mode": row.mode,
+            "file": row.file,
+            "time": started.timestamp(),
+            "startedAt": started.isoformat().replace("+00:00", "Z"),
+            "completedAt": completed.isoformat().replace("+00:00", "Z"),
+            "name": row.name,
+            "schemaVersion": row.schema_version,
+        }
+
+    @staticmethod
+    def _find_by_id(session_id: str):
+        engine = PourOverHistoryManager._require_engine()
+        with engine.connect() as connection:
+            return connection.execute(
+                select(brew_history).where(brew_history.c.uuid == session_id)
+            ).fetchone()
+
+    @staticmethod
+    def _history_rows():
+        engine = PourOverHistoryManager._require_engine()
+        statement = (
+            select(brew_history)
+            .where(brew_history.c.brew_type == "pour_over")
+            .order_by(asc(brew_history.c.time), asc(brew_history.c.id))
+        )
+        with engine.connect() as connection:
+            return connection.execute(statement).fetchall()
+
+    @staticmethod
+    def _available_history_bytes() -> int:
+        path = POUR_OVER_PATH if POUR_OVER_PATH.exists() else POUR_OVER_PATH.parent
+        path.mkdir(parents=True, exist_ok=True)
+        return shutil.disk_usage(path).free
+
+    @staticmethod
+    def _remove_history_row(row) -> int:
+        engine = PourOverHistoryManager._require_engine()
+        record_path = POUR_OVER_PATH.joinpath(row.file)
+        try:
+            record_size = record_path.stat().st_size
+        except OSError:
+            record_size = 0
+        with engine.begin() as connection:
+            connection.execute(delete(brew_history).where(brew_history.c.id == row.id))
+        try:
+            record_path.unlink(missing_ok=True)
+        except OSError as error:
+            logger.warning(
+                "Could not remove pruned Pour Over history file %s: %s",
+                record_path,
+                type(error).__name__,
+            )
+        logger.info("Pruned Pour Over history entry %s", row.uuid)
+        return record_size
+
+    @staticmethod
+    def _ensure_storage_capacity(incoming_bytes: int, additional_records: int) -> None:
+        if incoming_bytes > MAX_POUR_OVER_HISTORY_BYTES:
+            raise OSError("Pour Over record exceeds the history storage quota")
+
+        rows = PourOverHistoryManager._history_rows()
+        sizes = []
+        for row in rows:
+            try:
+                sizes.append(POUR_OVER_PATH.joinpath(row.file).stat().st_size)
+            except OSError:
+                sizes.append(0)
+        total_bytes = sum(sizes)
+
+        # Prune oldest entries only to enforce this store's own quotas (record
+        # count and total stored bytes), and never the most recent record. Low
+        # free disk space is usually caused by unrelated data, so deleting Pour
+        # Over history could wipe it without recovering any meaningful space.
+        while len(rows) > 1 and (
+            len(rows) + additional_records > MAX_POUR_OVER_HISTORY_RECORDS
+            or total_bytes + incoming_bytes > MAX_POUR_OVER_HISTORY_BYTES
+        ):
+            row = rows.pop(0)
+            expected_size = sizes.pop(0)
+            removed_size = PourOverHistoryManager._remove_history_row(row)
+            total_bytes = max(0, total_bytes - max(expected_size, removed_size))
+
+        if (
+            len(rows) + additional_records > MAX_POUR_OVER_HISTORY_RECORDS
+            or total_bytes + incoming_bytes > MAX_POUR_OVER_HISTORY_BYTES
+        ):
+            raise OSError("Pour Over history quota cannot accommodate this record")
+
+        free_bytes = PourOverHistoryManager._available_history_bytes()
+        if free_bytes < MIN_POUR_OVER_FREE_BYTES + incoming_bytes:
+            raise OSError(
+                "Insufficient free disk space for Pour Over history; "
+                "existing records were preserved"
+            )
+
+    @staticmethod
+    def _write_record(
+        relative_path: Path,
+        payload: dict[str, Any],
+        *,
+        additional_records: int,
+    ) -> None:
+        destination = POUR_OVER_PATH.joinpath(relative_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        raw = json.dumps(
+            payload,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(raw) > MAX_POUR_OVER_RECORD_BYTES:
+            raise PourOverHistoryRecordTooLargeError(
+                "Pour Over history entry exceeds the size limit"
+            )
+        compressed = zstd.ZstdCompressor(level=10).compress(raw)
+        PourOverHistoryManager._ensure_storage_capacity(len(compressed), additional_records)
+        temporary = destination.parent.joinpath(f".{destination.name}.{uuid.uuid4()}.tmp")
+        try:
+            with temporary.open("xb") as output:
+                output.write(compressed)
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary, destination)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+
+    @staticmethod
+    def _read_record(relative_path: Path) -> dict[str, Any]:
+        raw = read_compressed_record(POUR_OVER_PATH.joinpath(relative_path))
+        return json.loads(raw)
+
+    @staticmethod
+    def _comparable_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        # The "sync" block (status/attempts/uploadedAt) mutates between upload
+        # attempts, so it must not participate in conflict detection: the Dial
+        # re-POSTing the same session after an upload attempt is idempotent,
+        # not a conflict. The block is still stored as part of the record.
+        return {key: value for key, value in payload.items() if key != "sync"}
+
+    @staticmethod
+    def _validate_existing_record(row, payload: dict[str, Any]) -> None:
+        existing_path = POUR_OVER_PATH.joinpath(row.file)
+        if not existing_path.is_file():
+            PourOverHistoryManager._write_record(Path(row.file), payload, additional_records=0)
+            logger.warning("Repaired missing Pour Over history file for session %s", row.uuid)
+            return
+        existing_payload = PourOverHistoryManager._read_record(Path(row.file))
+        if PourOverHistoryManager._comparable_payload(
+            existing_payload
+        ) != PourOverHistoryManager._comparable_payload(payload):
+            raise PourOverHistoryConflictError(
+                "A different Pour Over record already uses this session id"
+            )
+
+    @staticmethod
+    def save(session: PourOverSession) -> tuple[dict[str, Any], bool]:
+        engine = PourOverHistoryManager._require_engine()
+        payload = session.model_dump(mode="json")
+        existing = PourOverHistoryManager._find_by_id(session.id)
+        if existing is not None:
+            PourOverHistoryManager._validate_existing_record(existing, payload)
+            return PourOverHistoryManager._row_to_metadata(existing), False
+
+        relative_path = PourOverHistoryManager._timestamp_to_file_path(session)
+        PourOverHistoryManager._write_record(relative_path, payload, additional_records=1)
+        try:
+            with engine.begin() as connection:
+                result = connection.execute(
+                    insert(brew_history).values(
+                        uuid=session.id,
+                        brew_type=session.brewType,
+                        mode=session.mode,
+                        file=str(relative_path),
+                        time=session.startedAt.astimezone(timezone.utc),
+                        completed_time=session.completedAt.astimezone(timezone.utc),
+                        name=session.name,
+                        schema_version=session.schemaVersion,
+                    )
+                )
+                db_key = result.inserted_primary_key[0]
+        except IntegrityError:
+            existing = PourOverHistoryManager._find_by_id(session.id)
+            if existing is None:
+                POUR_OVER_PATH.joinpath(relative_path).unlink(missing_ok=True)
+                raise
+            if str(relative_path) != existing.file:
+                POUR_OVER_PATH.joinpath(relative_path).unlink(missing_ok=True)
+            PourOverHistoryManager._validate_existing_record(existing, payload)
+            return PourOverHistoryManager._row_to_metadata(existing), False
+        except Exception:
+            POUR_OVER_PATH.joinpath(relative_path).unlink(missing_ok=True)
+            raise
+
+        logger.info("Saved Pour Over session %s in brew history with id %s", session.id, db_key)
+        return {
+            "db_key": db_key,
+            "id": session.id,
+            "brewType": session.brewType,
+            "mode": session.mode,
+            "file": str(relative_path),
+            "time": session.startedAt.timestamp(),
+            "startedAt": session.startedAt.isoformat(),
+            "completedAt": session.completedAt.isoformat(),
+            "name": session.name,
+            "schemaVersion": session.schemaVersion,
+        }, True
+
+    @staticmethod
+    def search(
+        *,
+        max_results: int = 50,
+        descending: bool = True,
+        after: str | None = None,
+        mode: Literal["free_pour", "profile"] | None = None,
+    ) -> list[dict[str, Any]]:
+        engine = PourOverHistoryManager._require_engine()
+        statement = select(brew_history).where(brew_history.c.brew_type == "pour_over")
+        if after:
+            statement = statement.where(brew_history.c.file > after)
+        if mode:
+            statement = statement.where(brew_history.c.mode == mode)
+        order_by = desc if descending else asc
+        statement = statement.order_by(
+            order_by(brew_history.c.file), order_by(brew_history.c.id)
+        ).limit(max_results)
+        with engine.connect() as connection:
+            rows = connection.execute(statement).fetchall()
+        return [PourOverHistoryManager._row_to_metadata(row) for row in rows]
+
+    @staticmethod
+    def latest() -> dict[str, Any] | None:
+        results = PourOverHistoryManager.search(max_results=1, descending=True)
+        return results[0] if results else None

--- a/shot_database.py
+++ b/shot_database.py
@@ -463,6 +463,18 @@ class ShotDataBase:
             return parsed_results
 
     @staticmethod
+    def list_history_files(after: str | None = None, max_results: int = 200):
+        """Return a bounded, cursor-ordered index for the on-machine uploader."""
+        statement = select(history_table.c.file)
+        if after:
+            statement = statement.where(history_table.c.file > after)
+        statement = statement.order_by(asc(history_table.c.file)).limit(
+            min(max(max_results, 1), 200)
+        )
+        with ShotDataBase.engine.connect() as connection:
+            return [{"file": row.file} for row in connection.execute(statement).fetchall()]
+
+    @staticmethod
     def autocomplete_profile_name(prefix):
         with ShotDataBase.session() as session:
             if not prefix:

--- a/tests/test_pour_over_history.py
+++ b/tests/test_pour_over_history.py
@@ -1,0 +1,355 @@
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import zstandard as zstd
+from sqlalchemy import create_engine
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+
+import api.pour_over_history as pour_over_api
+import pour_over_history
+from api.pour_over_history import (
+    LastPourOverHandler,
+    PourOverFileHandler,
+    PourOverHistoryHandler,
+)
+from database_models import metadata
+from pour_over_history import (
+    MAX_POUR_OVER_RECORD_BYTES,
+    PourOverHistoryManager,
+    PourOverHistoryRecordTooLargeError,
+    PourOverSession,
+    read_compressed_record,
+)
+from shot_database import ShotDataBase
+
+
+def free_pour_session(
+    session_id: str = "11111111-2222-4333-8444-555555555555",
+    started_at: str = "2026-08-16T08:00:00.000Z",
+):
+    return {
+        "schemaVersion": 4,
+        "id": session_id,
+        "brewType": "pour_over",
+        "mode": "free_pour",
+        "name": "Free Pour",
+        "source": "dial",
+        "startedAt": started_at,
+        "completedAt": "2026-08-16T08:02:15.000Z",
+        "recipe": {
+            "profileId": None,
+            "profileName": "Free Pour",
+            "doseG": 15,
+            "temperatureC": 92,
+            "targetWaterG": None,
+            "targetDurationMs": None,
+            "pourTargets": [],
+        },
+        "measurements": {
+            "serverBaselineG": -0.4,
+            "brewerG": 134.2,
+            "setupG": 149.2,
+            "doseG": 15.1,
+            "waterTemperatureC": 92,
+            "waterPouredG": 225.3,
+            "beverageG": 196.8,
+            "retainedG": 28.5,
+            "durationMs": 135_000,
+            "status": "measured",
+        },
+        "pours": [
+            {
+                "number": 1,
+                "startTimeMs": 0,
+                "endTimeMs": 10_000,
+                "startWeightG": 0,
+                "endWeightG": 40.2,
+                "waterG": 40.2,
+                "averageFlowGps": 4.02,
+                "peakFlowGps": 4.8,
+            }
+        ],
+        "samples": [
+            {"t": 0, "w": 0, "f": 0.8, "p": 1},
+            {"t": 10_000, "w": 40.2, "f": 0.1, "p": 0},
+        ],
+        "completion": "brewer_removed",
+        "sync": {"status": "pending", "attempts": 0},
+    }
+
+
+class TestPourOverHistoryAPI(AsyncHTTPTestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        root = Path(self.temporary.name)
+        self.history_path = root.joinpath("pour-over")
+        self.engine = create_engine(f"sqlite:///{root.joinpath('history.sqlite')}")
+        metadata.create_all(self.engine)
+        self.previous_engine = ShotDataBase.engine
+        self.previous_manager_path = pour_over_history.POUR_OVER_PATH
+        self.previous_api_path = pour_over_api.POUR_OVER_PATH
+        ShotDataBase.engine = self.engine
+        pour_over_history.POUR_OVER_PATH = self.history_path
+        pour_over_api.POUR_OVER_PATH = self.history_path
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        self.engine.dispose()
+        ShotDataBase.engine = self.previous_engine
+        pour_over_history.POUR_OVER_PATH = self.previous_manager_path
+        pour_over_api.POUR_OVER_PATH = self.previous_api_path
+        self.temporary.cleanup()
+
+    def get_app(self):
+        return Application(
+            [
+                (r"/api/v1/history/pour-over", PourOverHistoryHandler),
+                (r"/api/v1/history/pour-over/last", LastPourOverHandler),
+                (
+                    r"/api/v1/history/pour-over/files/(.*)",
+                    PourOverFileHandler,
+                    {"path": self.history_path},
+                ),
+            ]
+        )
+
+    def save(self, payload=None, headers=None):
+        return self.fetch(
+            "/api/v1/history/pour-over",
+            method="POST",
+            body=json.dumps(payload or free_pour_session()),
+            headers=headers,
+        )
+
+    def test_saves_compressed_record_and_returns_it_from_history(self):
+        response = self.save()
+
+        assert response.code == 201
+        result = json.loads(response.body)
+        relative_path = result["history"]["file"]
+        stored_path = self.history_path.joinpath(relative_path)
+        assert stored_path.is_file()
+        saved = json.loads(zstd.ZstdDecompressor().decompress(stored_path.read_bytes()))
+        assert saved["brewType"] == "pour_over"
+        assert saved["measurements"]["serverBaselineG"] == -0.4
+
+        last = self.fetch("/api/v1/history/pour-over/last")
+        assert last.code == 200
+        assert json.loads(last.body)["id"] == free_pour_session()["id"]
+
+        raw = self.fetch(f"/api/v1/history/pour-over/files/{relative_path}")
+        assert raw.code == 200
+        assert json.loads(raw.body)["id"] == free_pour_session()["id"]
+
+    def test_duplicate_session_is_idempotent(self):
+        first = self.save()
+        second = self.save()
+
+        assert first.code == 201
+        assert second.code == 200
+        assert json.loads(second.body)["status"] == "existing"
+        assert len(PourOverHistoryManager.search()) == 1
+        assert len(list(self.history_path.rglob("*.zst"))) == 1
+
+    def test_repost_with_changed_sync_state_is_idempotent(self):
+        original = free_pour_session()
+        after_upload_attempt = free_pour_session()
+        after_upload_attempt["sync"] = {
+            "status": "uploaded",
+            "attempts": 3,
+            "uploadedAt": "2026-08-16T08:05:00.000Z",
+        }
+
+        assert self.save(original).code == 201
+        response = self.save(after_upload_attempt)
+
+        assert response.code == 200
+        assert json.loads(response.body)["status"] == "existing"
+        assert len(PourOverHistoryManager.search()) == 1
+
+    def test_rejects_reused_session_id_with_different_measurements(self):
+        original = free_pour_session()
+        changed = free_pour_session()
+        changed["measurements"]["waterPouredG"] = 250
+
+        assert self.save(original).code == 201
+        response = self.save(changed)
+
+        assert response.code == 409
+        assert len(PourOverHistoryManager.search()) == 1
+
+    def test_rejects_invalid_contract_without_writing_history(self):
+        invalid = free_pour_session()
+        invalid["samples"] = []
+
+        response = self.save(invalid)
+
+        assert response.code == 422
+        assert PourOverHistoryManager.search() == []
+        assert not list(self.history_path.rglob("*.zst"))
+
+    def test_write_endpoint_is_local_only(self):
+        response = self.save(headers={"Host": "machine.local", "X-Real-IP": "192.168.10.20"})
+
+        assert response.code == 403
+        assert PourOverHistoryManager.search() == []
+
+    def test_profile_mode_and_legacy_contract_are_accepted(self):
+        profile = free_pour_session()
+        profile["mode"] = "profile"
+        profile["name"] = "Three Pour 1:15"
+        profile["recipe"]["profileId"] = "profile-1"
+        profile["recipe"]["targetWaterG"] = 225
+        profile["recipe"]["targetDurationMs"] = 135_000
+        profile["recipe"]["pourTargets"] = [
+            {"number": 1, "startTimeMs": 0, "stopWeightG": 40, "flowGps": 4}
+        ]
+        assert self.save(profile).code == 201
+
+        legacy = free_pour_session(
+            session_id="33333333-4444-4555-8666-777777777777",
+            started_at="2026-08-16T07:00:00.000Z",
+        )
+        legacy["schemaVersion"] = 2
+        legacy["measurements"]["emptyServerG"] = 182.4
+        legacy["measurements"].pop("serverBaselineG")
+        legacy["recipe"].pop("temperatureC")
+        legacy["recipe"].pop("targetDurationMs")
+        legacy["measurements"].pop("doseG")
+        legacy["measurements"].pop("waterTemperatureC")
+
+        assert self.save(legacy).code == 201
+        records = PourOverHistoryManager.search(descending=False)
+        assert [record["schemaVersion"] for record in records] == [2, 4]
+        response = self.fetch("/api/v1/history/pour-over?mode=free_pour&max_results=1")
+        assert response.code == 200
+        assert json.loads(response.body)["history"][0]["id"] == legacy["id"]
+
+    def test_prunes_oldest_records_at_the_history_limit(self):
+        previous_max_records = pour_over_history.MAX_POUR_OVER_HISTORY_RECORDS
+        previous_min_free = pour_over_history.MIN_POUR_OVER_FREE_BYTES
+        try:
+            pour_over_history.MAX_POUR_OVER_HISTORY_RECORDS = 2
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = 0
+            sessions = [
+                free_pour_session(
+                    session_id=f"00000000-0000-4000-8000-{index:012d}",
+                    started_at=f"2026-08-16T0{index}:00:00.000Z",
+                )
+                for index in (1, 2, 3)
+            ]
+            for session in sessions:
+                session["completedAt"] = session["startedAt"]
+                assert self.save(session).code == 201
+
+            records = PourOverHistoryManager.search(descending=False)
+            assert [record["id"] for record in records] == [
+                sessions[1]["id"],
+                sessions[2]["id"],
+            ]
+            assert len(list(self.history_path.rglob("*.zst"))) == 2
+        finally:
+            pour_over_history.MAX_POUR_OVER_HISTORY_RECORDS = previous_max_records
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = previous_min_free
+
+    def test_low_disk_refusal_preserves_existing_records(self):
+        first = free_pour_session()
+        assert self.save(first).code == 201
+        stored_files = list(self.history_path.rglob("*.zst"))
+        assert len(stored_files) == 1
+
+        previous_min_free = pour_over_history.MIN_POUR_OVER_FREE_BYTES
+        try:
+            # More free space than any disk provides: the save must be refused
+            # without pruning history that cannot recover the shortfall.
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = 1 << 60
+            second = free_pour_session(
+                session_id="99999999-8888-4777-8666-555555555555",
+                started_at="2026-08-16T09:00:00.000Z",
+            )
+            second["completedAt"] = second["startedAt"]
+            response = self.save(second)
+        finally:
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = previous_min_free
+
+        assert response.code == 500
+        records = PourOverHistoryManager.search()
+        assert [record["id"] for record in records] == [first["id"]]
+        assert stored_files[0].is_file()
+
+    def test_prune_never_removes_the_most_recent_record(self):
+        first = free_pour_session()
+        assert self.save(first).code == 201
+        stored = list(self.history_path.rglob("*.zst"))
+        assert len(stored) == 1
+
+        previous_max_bytes = pour_over_history.MAX_POUR_OVER_HISTORY_BYTES
+        previous_min_free = pour_over_history.MIN_POUR_OVER_FREE_BYTES
+        try:
+            # A quota the existing record plus the incoming one cannot fit in.
+            # Pruning must stop at the newest stored record and refuse the save
+            # instead of destroying the whole history.
+            pour_over_history.MAX_POUR_OVER_HISTORY_BYTES = stored[0].stat().st_size + 10
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = 0
+            second = free_pour_session(
+                session_id="99999999-8888-4777-8666-555555555555",
+                started_at="2026-08-16T09:00:00.000Z",
+            )
+            second["completedAt"] = second["startedAt"]
+            response = self.save(second)
+        finally:
+            pour_over_history.MAX_POUR_OVER_HISTORY_BYTES = previous_max_bytes
+            pour_over_history.MIN_POUR_OVER_FREE_BYTES = previous_min_free
+
+        assert response.code == 500
+        records = PourOverHistoryManager.search()
+        assert [record["id"] for record in records] == [first["id"]]
+        assert stored[0].is_file()
+
+
+def test_session_validation_rejects_non_finite_and_reversed_ranges():
+    payload = free_pour_session()
+    payload["samples"][0]["f"] = float("inf")
+    try:
+        PourOverSession.model_validate(payload)
+        raise AssertionError("Expected non-finite flow to be rejected")
+    except ValueError:
+        pass
+
+    payload = free_pour_session()
+    payload["measurements"]["durationMs"] = 600_001
+    with pytest.raises(ValueError):
+        PourOverSession.model_validate(payload)
+
+    payload = free_pour_session()
+    payload["samples"][-1]["t"] = 600_001
+    with pytest.raises(ValueError):
+        PourOverSession.model_validate(payload)
+
+    payload = free_pour_session()
+    payload["samples"] = payload["samples"] * 1_501
+    with pytest.raises(ValueError):
+        PourOverSession.model_validate(payload)
+
+
+def test_compressed_record_reader_bounds_expansion(tmp_path):
+    compressed_path = tmp_path.joinpath("oversized.pour-over.json.zst")
+    compressed_path.write_bytes(
+        zstd.ZstdCompressor(level=10).compress(b"0" * (MAX_POUR_OVER_RECORD_BYTES + 1))
+    )
+    with pytest.raises(PourOverHistoryRecordTooLargeError):
+        read_compressed_record(compressed_path)
+
+    payload = free_pour_session()
+    payload["recipe"]["pourTargets"] = [
+        {"number": 1, "startTimeMs": 0, "stopWeightG": 40, "flowRangeGps": [5, 4]}
+    ]
+    try:
+        PourOverSession.model_validate(payload)
+        raise AssertionError("Expected reversed flow range to be rejected")
+    except ValueError:
+        pass

--- a/tests/test_shot_database.py
+++ b/tests/test_shot_database.py
@@ -153,6 +153,24 @@ class TestSearchHistory:
         results = ShotDataBase.search_history(params)
         assert len(results) == 3
 
+    def test_upload_index_is_cursor_ordered_and_bounded(self):
+        for index in range(5):
+            ShotDataBase.insert_history(
+                make_history_entry(
+                    id=f"upload-{index}",
+                    file=f"2026-08-16/shot_{index}.shot.json.zst",
+                    time=time.time() + index,
+                )
+            )
+
+        results = ShotDataBase.list_history_files(
+            after="2026-08-16/shot_1.shot.json.zst", max_results=2
+        )
+        assert results == [
+            {"file": "2026-08-16/shot_2.shot.json.zst"},
+            {"file": "2026-08-16/shot_3.shot.json.zst"},
+        ]
+
     def test_search_by_profile_id(self):
         p1 = make_profile(id="p-aaa", name="Ristretto")
         p2 = make_profile(id="p-bbb", name="Lungo")


### PR DESCRIPTION
## Summary
- Pour Over sessions recorded on the Dial now survive on the machine: they are stored as zstd-compressed JSON records in a new `brew_history` table and exposed over a REST API for the Dial and web UI.
- **API contract**: `POST /api/v1/history/pour-over` (local-only) is idempotent — re-posting the same session returns 200/"existing". Conflict detection (409) excludes the mutable `sync` block (status/attempts/uploadedAt), so the Dial re-posting after an upload attempt is not a conflict; the sync block is still stored with the record. `GET .../pour-over`, `.../pour-over/last` and `.../pour-over/files/` read the history with cursor pagination.
- `GET /api/v1/history/upload-index` (local-only) gives the on-machine uploader a bounded, cursor-ordered index of shot files.
- Storage is bounded (per-record size, record count, total bytes) and prunes oldest-first, but never the most recent record. Pruning only enforces the store's own quotas: if the disk is low on free space (typically from unrelated data), the save is refused with a clear error instead of history being destroyed.
- Handlers run their blocking work (SQL, zstd compression, fsync, disk/file stats) in an executor off the Tornado event loop, matching the existing history handlers.
- Includes the alembic migration (`b71d84a4c2ef`) plus matching `Index` definitions on the model so `metadata.create_all` produces the same schema as the migration.

Split out from #395.

## Validation
- `pytest tests/test_pour_over_history.py tests/test_shot_database.py` — 54 passed (includes new tests: idempotent re-POST with changed sync block, low-disk refusal preserves existing records, pruning never removes the most recent record).
- `pytest tests/test_config.py tests/test_smoke_validation.py` — 12 passed.
- `flake8` and `black --check` clean on all touched files.
- Run locally on Windows with a minimal virtualenv; full suite and alembic upgrade path run in CI / on-machine.
- CI on this branch: lint passes; the `test` job fails on two performance-budget tests (`tests/test_log_redaction_filter.py::ThroughputTests::test_throughput_budget`, `log_redactor/tests/test_log_redactor.py::LogRedactorTests::test_ten_megabyte_runtime_and_memory_budget`) and the `redactor-pin` check fails on the pinned `log_redactor` submodule commit. Both failures are pre-existing: the same jobs fail on the `nightly` base commit and are unrelated to this change.
