### PR TITLE
Settle machine identity at startup

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -58,6 +58,37 @@ tornado.log.gen_log = MeticulousLogger.getLogger("tornado.general")
 
 PORT = int(os.getenv("PORT", "8080"))
 DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1", "y")
+IDENTITY_READY_PATH = os.getenv("IDENTITY_READY_PATH", "/run/meticulous-backend-identity-ready")
+
+
+def clear_identity_ready_marker():
+    try:
+        os.remove(IDENTITY_READY_PATH)
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        logger.warning(
+            f"Could not clear identity-ready marker at {IDENTITY_READY_PATH}: "
+            f"{type(error).__name__}"
+        )
+
+
+def publish_identity_ready_marker():
+    # Best-effort: consumers treat a missing marker as "identity not settled
+    # yet". Failing to write it (e.g. non-root development runs without access
+    # to /run) must never prevent the backend from serving.
+    try:
+        identity_ready_temporary = f"{IDENTITY_READY_PATH}.{os.getpid()}"
+        with open(identity_ready_temporary, "w", encoding="utf-8") as ready_file:
+            ready_file.write("ready\n")
+            ready_file.flush()
+            os.fsync(ready_file.fileno())
+        os.replace(identity_ready_temporary, IDENTITY_READY_PATH)
+    except OSError as error:
+        logger.warning(
+            f"Could not publish identity-ready marker at {IDENTITY_READY_PATH}: "
+            f"{type(error).__name__}"
+        )
 
 
 sio = socketio.AsyncServer(
@@ -276,7 +307,18 @@ def main():
     pyprctl.set_name("Main")
 
     DBusMonitor.init()
+    clear_identity_ready_marker()
     HostnameManager.init()
+    # Identity settling is best-effort: any failure is logged and startup
+    # continues, so a slow or missing systemd-hostnamed can never keep the
+    # backend from serving.
+    try:
+        WifiManager.initializeIdentity()
+    except Exception as error:
+        logger.warning(
+            f"Could not settle machine identity, continuing startup: {type(error).__name__}"
+        )
+    publish_identity_ready_marker()
     UpdateManager.init()
 
     try:

--- a/hostname.py
+++ b/hostname.py
@@ -1,13 +1,54 @@
 import subprocess
 import random
+import socket
 
-from config import CONFIG_SYSTEM, MeticulousConfig, DEVICE_IDENTIFIER, MACHINE_SERIAL_NUMBER
+from config import (
+    CONFIG_SYSTEM,
+    CONFIG_USER,
+    DEVICE_IDENTIFIER,
+    HOSTNAME_OVERRIDE,
+    MACHINE_SERIAL_NUMBER,
+    MeticulousConfig,
+)
 from log import MeticulousLogger
 
 logger = MeticulousLogger.getLogger(__name__)
 
 
 class HostnameManager:
+
+    @staticmethod
+    def _configuredIdentifierIsValid() -> bool:
+        identifier = MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER]
+        return (
+            isinstance(identifier, list)
+            and len(identifier) == 2
+            and all(isinstance(component, str) and component for component in identifier)
+        )
+
+    @staticmethod
+    def identifierFromHostname(hostname: str) -> tuple[str, str] | None:
+        """Recover a generated machine identifier from an established hostname."""
+        serial = MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER]
+        if not isinstance(hostname, str) or not hostname or serial is None:
+            return None
+
+        short_hostname = hostname.split(".", 1)[0]
+        prefix = "meticulous"
+        suffix = f"-{serial}"
+        if not short_hostname.startswith(prefix) or not short_hostname.endswith(suffix):
+            return None
+
+        encoded_identifier = short_hostname[len(prefix) : -len(suffix)]
+        for adjective in HostnameManager.ADJECTIVES:
+            adjective_component = adjective.capitalize()
+            if not encoded_identifier.casefold().startswith(adjective_component.casefold()):
+                continue
+            noun_component = encoded_identifier[len(adjective_component) :]
+            for noun in HostnameManager.NOUNS:
+                if noun_component.casefold() == noun.casefold():
+                    return (adjective, noun)
+        return None
 
     # We are using random identifier here instead of deriving it from something
     def _generateRandomIdentifierComponents() -> tuple[str, str]:
@@ -20,11 +61,32 @@ class HostnameManager:
         return (adjective, noun)
 
     def init():
-        if len(MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER]) == 2:
+        recovered_identifier = HostnameManager.identifierFromHostname(socket.gethostname())
+        hostname_override = MeticulousConfig[CONFIG_USER][HOSTNAME_OVERRIDE]
+        configured_identifier = MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER]
+
+        # A recognizable deployed hostname is the safest canonical source when no
+        # explicit override exists. This repairs both missing and conflicting config
+        # without changing the customer-visible OS hostname.
+        if hostname_override is None and recovered_identifier is not None:
+            recovered_list = list(recovered_identifier)
+            if configured_identifier != recovered_list:
+                logger.warning("Recovered device identifier from established hostname")
+                MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER] = recovered_list
+                MeticulousConfig.save()
+            return
+
+        if HostnameManager._configuredIdentifierIsValid():
+            return
+
+        if recovered_identifier is not None:
+            logger.warning("Recovered missing device identifier from established hostname")
+            MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER] = list(recovered_identifier)
+            MeticulousConfig.save()
             return
 
         adjective, noun = HostnameManager._generateRandomIdentifierComponents()
-        logger.info("Created new device identifier pair:")
+        logger.info("Created new device identifier pair")
         MeticulousConfig[CONFIG_SYSTEM][DEVICE_IDENTIFIER] = [adjective, noun]
         MeticulousConfig.save()
 

--- a/tests/test_hostname_preservation.py
+++ b/tests/test_hostname_preservation.py
@@ -1,0 +1,150 @@
+"""Regression coverage for stable customer-visible machine identity."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+
+class _Config(dict):
+    def __init__(self, value):
+        super().__init__(value)
+        self.save = MagicMock()
+
+
+def _module(name: str, **attributes):
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _load_hostname_module(monkeypatch, identifier=None, hostname_override=None):
+    config = _Config(
+        {
+            "system": {
+                "machine_name": [] if identifier is None else identifier,
+                "serial": "003312",
+            },
+            "user": {"hostname_override": hostname_override},
+        }
+    )
+    config_module = _module(
+        "config",
+        CONFIG_SYSTEM="system",
+        CONFIG_USER="user",
+        DEVICE_IDENTIFIER="machine_name",
+        HOSTNAME_OVERRIDE="hostname_override",
+        MACHINE_SERIAL_NUMBER="serial",
+        MeticulousConfig=config,
+    )
+    logger = MagicMock()
+    log_module = _module("log", MeticulousLogger=MagicMock())
+    log_module.MeticulousLogger.getLogger.return_value = logger
+    monkeypatch.setitem(sys.modules, "config", config_module)
+    monkeypatch.setitem(sys.modules, "log", log_module)
+
+    module_name = "hostname_preservation_under_test"
+    module_path = Path(__file__).resolve().parents[1] / "hostname.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module, config, logger
+
+
+def test_identifier_is_recovered_from_established_hostname(monkeypatch):
+    module, config, logger = _load_hostname_module(monkeypatch)
+
+    with (
+        patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"),
+        patch.object(
+            module.HostnameManager,
+            "_generateRandomIdentifierComponents",
+            side_effect=AssertionError("must not generate a new identity"),
+        ),
+    ):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["spicy", "Crema"]
+    assert module.HostnameManager.generateDeviceName() == "MeticulousSpicyCrema"
+    assert module.HostnameManager.generateHostname() == "meticulousSpicyCrema-003312"
+    config.save.assert_called_once_with()
+    logger.warning.assert_called_once_with(
+        "Recovered device identifier from established hostname"
+    )
+
+
+def test_matching_existing_identifier_is_not_rewritten(monkeypatch):
+    module, config, _ = _load_hostname_module(monkeypatch, ["spicy", "Crema"])
+
+    with patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["spicy", "Crema"]
+    config.save.assert_not_called()
+
+
+def test_conflicting_identifier_is_repaired_from_established_hostname(monkeypatch):
+    module, config, logger = _load_hostname_module(monkeypatch, ["renowned", "Body"])
+
+    with patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["spicy", "Crema"]
+    config.save.assert_called_once_with()
+    logger.warning.assert_called_once_with(
+        "Recovered device identifier from established hostname"
+    )
+
+
+def test_explicit_override_keeps_configured_identifier(monkeypatch):
+    module, config, _ = _load_hostname_module(
+        monkeypatch,
+        ["renowned", "Body"],
+        hostname_override="custom-machine",
+    )
+
+    with patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["renowned", "Body"]
+    config.save.assert_not_called()
+
+
+def test_factory_hostname_without_identity_gets_new_identifier(monkeypatch):
+    module, config, _ = _load_hostname_module(monkeypatch)
+
+    with (
+        patch.object(module.socket, "gethostname", return_value="imx8mn-var-som"),
+        patch.object(
+            module.HostnameManager,
+            "_generateRandomIdentifierComponents",
+            return_value=("balanced", "Bloom"),
+        ),
+    ):
+        module.HostnameManager.init()
+
+    assert config["system"]["machine_name"] == ["balanced", "Bloom"]
+    config.save.assert_called_once_with()
+
+
+def test_non_generated_hostname_is_not_misparsed(monkeypatch):
+    module, _, _ = _load_hostname_module(monkeypatch)
+
+    assert module.HostnameManager.identifierFromHostname("custom-machine") is None
+    assert module.HostnameManager.identifierFromHostname("meticulousSpicyCrema-999999") is None
+
+
+def test_every_generated_identifier_round_trips_through_hostname(monkeypatch):
+    module, config, _ = _load_hostname_module(monkeypatch)
+
+    for adjective in module.HostnameManager.ADJECTIVES:
+        for noun in module.HostnameManager.NOUNS:
+            config["system"]["machine_name"] = [adjective, noun]
+            hostname = module.HostnameManager.generateHostname()
+            assert module.HostnameManager.identifierFromHostname(hostname) == (
+                adjective,
+                noun,
+            )

--- a/tests/test_identity_settling.py
+++ b/tests/test_identity_settling.py
@@ -1,0 +1,186 @@
+"""Regression tests for machine identity settling at startup.
+
+The production module has hardware-only dependencies, so these tests load it
+under an isolated module name with small system dependency stubs.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _module(name: str, **attributes):
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _load_wifi_module(monkeypatch):
+    class Config(dict):
+        save = MagicMock()
+
+    config_values = Config(
+        {
+            "wifi": {
+                "mode": "client",
+                "ap_name": "Meticulous",
+                "ap_password": "",
+                "known_wifis": {},
+            },
+            "user": {"hostname_override": None},
+        }
+    )
+    config_module = _module(
+        "config",
+        CONFIG_WIFI="wifi",
+        CONFIG_USER="user",
+        HOSTNAME_OVERRIDE="hostname_override",
+        WIFI_AP_NAME="ap_name",
+        WIFI_AP_PASSWORD="ap_password",
+        WIFI_KNOWN_WIFIS="known_wifis",
+        WIFI_MODE="mode",
+        WIFI_MODE_AP="ap",
+        WIFI_MODE_CLIENT="client",
+        MeticulousConfig=config_values,
+    )
+
+    api_module = _module("api")
+    api_module.__path__ = []
+    zeroconf_module = _module("api.zeroconf_announcement", ZeroConfAnnouncement=MagicMock)
+    log_module = _module("log", MeticulousLogger=MagicMock())
+    log_module.MeticulousLogger.getLogger.return_value = MagicMock()
+
+    stub_modules = {
+        "api": api_module,
+        "api.zeroconf_announcement": zeroconf_module,
+        "config": config_module,
+        "hostname": _module("hostname", HostnameManager=MagicMock()),
+        "log": log_module,
+        "machine": _module("machine", Machine=MagicMock()),
+        "named_thread": _module("named_thread", NamedThread=MagicMock()),
+        "netaddr": _module("netaddr", IPAddress=MagicMock(), IPNetwork=MagicMock()),
+        "nmcli": MagicMock(),
+        "sentry_sdk": MagicMock(),
+        "timezone_manager": _module("timezone_manager", TimezoneManager=MagicMock()),
+    }
+    for name, module in stub_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_name = "wifi_identity_under_test"
+    module_path = Path(__file__).resolve().parents[1] / "wifi.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("current", "generated", "override", "expected"),
+    [
+        (
+            "meticulousSpicyCrema-003312",
+            "meticulousRenownedBody-003312",
+            None,
+            None,
+        ),
+        (
+            "meticulousRenownedBody-003312",
+            "meticulousSpicyCrema-003312",
+            None,
+            None,
+        ),
+        ("imx8mn-var-som", "meticulousSpicyCrema-003312", None, "meticulousSpicyCrema-003312"),
+        (
+            "imx8mn-var-som-003312",
+            "meticulousSpicyCrema-003312",
+            None,
+            "meticulousSpicyCrema-003312",
+        ),
+        ("meticulous", "meticulousSpicyCrema-003312", None, "meticulousSpicyCrema-003312"),
+        (
+            "meticulousSpicyCrema-003312",
+            "meticulousRenownedBody-003312",
+            "custom-machine",
+            "custom-machine",
+        ),
+        (
+            "meticulousSpicyCrema-003312",
+            "meticulousRenownedBody-003312",
+            "none",
+            None,
+        ),
+    ],
+)
+def test_hostname_update_only_targets_factory_or_explicit_override(
+    monkeypatch, current, generated, override, expected
+):
+    module = _load_wifi_module(monkeypatch)
+
+    assert module.WifiManager.hostnameUpdateTarget(current, generated, override) == expected
+
+
+def test_identity_initialization_preserves_established_hostname(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    hostname_manager = sys.modules["hostname"].HostnameManager
+    hostname_manager.generateHostname.return_value = "meticulousRenownedBody-003312"
+    hostname_manager.generateDeviceName.return_value = "MeticulousSpicyCrema"
+
+    settled = module.WifiManager.initializeIdentity("meticulousSpicyCrema-003312")
+
+    assert settled == "meticulousSpicyCrema-003312"
+    hostname_manager.setHostname.assert_not_called()
+    assert module.MeticulousConfig["wifi"]["ap_name"] == "MeticulousSpicyCrema"
+    module.MeticulousConfig.save.assert_called_once_with()
+
+
+def test_identity_initialization_settles_factory_hostname(monkeypatch):
+    module = _load_wifi_module(monkeypatch)
+    hostname_manager = sys.modules["hostname"].HostnameManager
+    hostname_manager.generateHostname.return_value = "meticulousSpicyCrema-003312"
+    hostname_manager.generateDeviceName.return_value = "MeticulousSpicyCrema"
+
+    with patch.object(module.socket, "gethostname", return_value="meticulousSpicyCrema-003312"):
+        settled = module.WifiManager.initializeIdentity("meticulous")
+
+    assert settled == "meticulousSpicyCrema-003312"
+    hostname_manager.setHostname.assert_called_once_with("meticulousSpicyCrema-003312")
+    assert module.MeticulousConfig["wifi"]["ap_name"] == "MeticulousSpicyCrema"
+
+
+def test_identity_initialization_continues_when_hostname_does_not_settle(monkeypatch):
+    """A slow systemd-hostnamed must never keep the backend from serving."""
+    module = _load_wifi_module(monkeypatch)
+    hostname_manager = sys.modules["hostname"].HostnameManager
+    hostname_manager.generateHostname.return_value = "meticulousSpicyCrema-003312"
+    hostname_manager.generateDeviceName.return_value = "MeticulousSpicyCrema"
+
+    with patch.object(module.socket, "gethostname", return_value="meticulous"):
+        settled = module.WifiManager.initializeIdentity("meticulous")
+
+    assert settled == "meticulous"
+    hostname_manager.setHostname.assert_called_once_with("meticulousSpicyCrema-003312")
+    # Identity settling is best-effort; the advertised name is still configured.
+    assert module.MeticulousConfig["wifi"]["ap_name"] == "MeticulousSpicyCrema"
+    module.MeticulousConfig.save.assert_called_once_with()
+
+
+def test_identity_initialization_survives_missing_hostnamectl(monkeypatch):
+    """Development hosts without hostnamectl must not crash-loop the backend."""
+    module = _load_wifi_module(monkeypatch)
+    hostname_manager = sys.modules["hostname"].HostnameManager
+    hostname_manager.generateHostname.return_value = "meticulousSpicyCrema-003312"
+    hostname_manager.generateDeviceName.return_value = "MeticulousSpicyCrema"
+    hostname_manager.setHostname.side_effect = FileNotFoundError("hostnamectl")
+
+    settled = module.WifiManager.initializeIdentity("meticulous")
+
+    assert settled == "meticulous"
+    hostname_manager.setHostname.assert_called_once_with("meticulousSpicyCrema-003312")
+    assert module.MeticulousConfig["wifi"]["ap_name"] == "MeticulousSpicyCrema"
+    module.MeticulousConfig.save.assert_called_once_with()

--- a/wifi.py
+++ b/wifi.py
@@ -252,6 +252,77 @@ class WifiManager:
     _scan_in_progress = False
     _scan_lock = threading.Lock()
 
+    @staticmethod
+    def hostnameUpdateTarget(
+        current_hostname: str,
+        generated_hostname: str,
+        hostname_override,
+    ) -> str | None:
+        """Return an explicitly requested hostname change, if one is safe to make."""
+        if hostname_override is not None and hostname_override != "none":
+            return str(hostname_override)
+
+        # Automatic naming is only appropriate for an unprovisioned factory hostname.
+        # An existing Meticulous name is user-visible over Wi-Fi and Bluetooth and must
+        # remain stable even if stored identity data is briefly missing or inconsistent.
+        factory_hostname = (
+            current_hostname == "meticulous"
+            or current_hostname == "imx8mn-var-som"
+            or current_hostname.startswith("imx8mn-var-som-")
+        )
+        if hostname_override is None and factory_hostname:
+            return generated_hostname
+        return None
+
+    @staticmethod
+    def initializeIdentity(current_hostname: str | None = None) -> str:
+        """Settle hostname and advertised identity before API readiness.
+
+        Best-effort by design: a hostname update that fails or has not settled
+        yet is logged and startup continues. This must never raise for an
+        environmental reason (missing hostnamectl, slow systemd-hostnamed,
+        containers), because it runs synchronously before the API can serve.
+        """
+        if current_hostname is None:
+            current_hostname = socket.gethostname()
+
+        logger.info(f"Current hostname is '{current_hostname}'")
+        hostname_override = MeticulousConfig[CONFIG_USER][HOSTNAME_OVERRIDE]
+        generated_hostname = HostnameManager.generateHostname()
+        requested_hostname = WifiManager.hostnameUpdateTarget(
+            current_hostname,
+            generated_hostname,
+            hostname_override,
+        )
+        if requested_hostname is not None and current_hostname != requested_hostname:
+            if hostname_override is None:
+                logger.info(f"Naming factory hostname as {requested_hostname}")
+            else:
+                logger.info(f"Hostname override is set to {hostname_override}")
+                logger.info(f"Setting hostname to override: {hostname_override}")
+            try:
+                HostnameManager.setHostname(requested_hostname)
+                current_hostname = socket.gethostname()
+            except Exception as error:
+                logger.warning(
+                    f"Could not update the hostname to {requested_hostname}: "
+                    f"{type(error).__name__}"
+                )
+            if current_hostname != requested_hostname:
+                logger.warning(
+                    f"Hostname has not settled to '{requested_hostname}' yet, "
+                    f"continuing with '{current_hostname}'"
+                )
+        elif hostname_override is None and current_hostname != generated_hostname:
+            logger.warning(f"Preserving established hostname '{current_hostname}'")
+        elif hostname_override is not None and hostname_override != "none":
+            logger.info(f"Hostname override is set to {hostname_override}")
+
+        ap_name = HostnameManager.generateDeviceName()
+        MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME] = ap_name[:31]
+        MeticulousConfig.save()
+        return current_hostname
+
     def clearLastConnectionError():
         WifiManager._last_connection_error_code = ""
         WifiManager._last_connection_error_message = ""
@@ -388,32 +459,6 @@ class WifiManager:
         except Exception as e:
             logger.warning(f"Networking unavailable! {e}")
             WifiManager._networking_available = False
-
-        config = WifiManager.getCurrentConfig()
-
-        # Only update the hostname if it is a new system or if the hostname has been
-        # set before. Do so in case the lookup table ever changed or the hostname is only
-        # saved transient
-        logger.info(f"Current hostname is '{config.hostname}'")
-
-        hostname_override = MeticulousConfig[CONFIG_USER][HOSTNAME_OVERRIDE]
-        # Check if we are on a deployed machine, a container or if we are running elsewhere
-        # In the later case we dont want to set the hostname
-        MACHINE_HOSTNAMES = ("imx8mn-var-som", "meticulous")
-        if config.hostname.startswith(MACHINE_HOSTNAMES) and hostname_override is None:
-            new_hostname = HostnameManager.generateHostname()
-            if config.hostname != new_hostname:
-                logger.info(f"Changing hostname new = {new_hostname}")
-                HostnameManager.setHostname(new_hostname)
-        elif hostname_override is not None and hostname_override != "none":
-            logger.info(f"Hostname override is set to {hostname_override}")
-            if config.hostname != str(hostname_override):
-                logger.info(f"Setting hostname to override: {hostname_override}")
-                HostnameManager.setHostname(str(hostname_override))
-
-        ap_name = HostnameManager.generateDeviceName()
-        MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME] = ap_name[:31]
-        MeticulousConfig.save()
 
         if WifiManager._zeroconf is None:
             logger.info("Creating Zeroconf Object")


### PR DESCRIPTION
## Summary
- The machine's hostname and advertised identity (Wi-Fi AP name, generated hostname) are now settled synchronously at startup, before the API begins listening, instead of racing inside the background Wi-Fi initialization.
- `HostnameManager.init()` can recover the device identifier from an established generated hostname, repairing missing or conflicting config identity without changing the customer-visible name. An explicit hostname override always wins.
- Automatic renaming only applies to unprovisioned factory hostnames (`meticulous`, `imx8mn-var-som*`) or an explicit override; an established Meticulous name stays stable even if stored identity data is briefly inconsistent.
- Identity settling is strictly best-effort: a failed or not-yet-settled hostname change (slow systemd-hostnamed on first boot, missing `hostnamectl` in development) is logged as a warning and startup continues — it can never prevent the backend from serving.
- After settling, a ready marker is written atomically to `IDENTITY_READY_PATH` (default `/run/meticulous-backend-identity-ready`) for other services to consume; writing it is also best-effort so non-root runs do not crash.

Split out from #395.

**Open questions for the team (why this is a draft):**
- Policy: this PR makes an established hostname win over restored/edited config identity (config is repaired from the hostname, not the other way around). That precedence needs team agreement before merging.
- First-boot behavior (factory hostname renaming with a slow systemd-hostnamed) still needs validation on a physical machine.

## Validation
- `pytest tests/test_identity_settling.py tests/test_hostname_preservation.py tests/test_wifi_repair.py` — 21 passed (includes new tests: identity settling continues when the hostname does not settle, and survives a missing `hostnamectl`).
- `flake8` and `black --check` clean on the touched files.
- Run locally on Windows with a minimal virtualenv; full suite runs in CI. First-boot behavior not yet validated on hardware (see above).
- CI on this branch: lint passes; the `test` job fails on two performance-budget tests (`tests/test_log_redaction_filter.py::ThroughputTests::test_throughput_budget`, `log_redactor/tests/test_log_redactor.py::LogRedactorTests::test_ten_megabyte_runtime_and_memory_budget`) and the `redactor-pin` check fails on the pinned `log_redactor` submodule commit. Both failures are pre-existing: the same jobs fail on the `nightly` base commit and are unrelated to this change.
