### PR TITLE
Advertise public machine URL over Improv and Wi-Fi QR

### DIFF
--- a/api/wifi.py
+++ b/api/wifi.py
@@ -12,8 +12,6 @@ from config import (
     WIFI_MODE_CLIENT,
 )
 from wifi import WifiManager, WifiType, redact_ssid
-from ble_gatt import PORT
-
 from .base_handler import BaseHandler
 from .api import API, APIVersion
 
@@ -69,11 +67,11 @@ class WiFiQRHandler(BaseHandler):
         elif len(config.ips) > 0:
             current_ip = config.ips[0]
             if current_ip.ip.version == 6:
-                qr_contents = f"http://[{str(current_ip.ip)}]:{PORT}"
+                qr_contents = f"http://[{str(current_ip.ip)}]"
             else:
-                qr_contents = f"http://{str(current_ip.ip)}:{PORT}"
+                qr_contents = f"http://{str(current_ip.ip)}"
         else:
-            qr_contents = f"http://{str(config.hostname)}.local:{PORT}"
+            qr_contents = f"http://{str(config.hostname)}.local"
 
         buffer = io.BytesIO()
 

--- a/ble_gatt.py
+++ b/ble_gatt.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import sys
 import time
 from threading import Thread
@@ -87,10 +86,6 @@ async def register_pairing_agent():
         return bus  # keep reference alive
     except Exception as e:
         logger.warning(f"[BLE Agent] Failed to register pairing agent: {type(e).__name__}")
-
-
-# FIXME Remove once the tornado server logic is in its own class
-PORT = int(os.getenv("PORT", "8080"))
 
 
 class GATTServer:
@@ -540,9 +535,9 @@ class GATTServer:
                 localServer = []
                 for localIP in networkConfig.ips:
                     if localIP.ip.version == 6:
-                        localServer.append(f"http://[{str(localIP.ip)}]:{PORT}")
+                        localServer.append(f"http://[{str(localIP.ip)}]")
                     else:
-                        localServer.append(f"http://{str(localIP.ip)}:{PORT}")
+                        localServer.append(f"http://{str(localIP.ip)}")
 
                 logger.debug(f"Backend redirect IP/URL: {localServer}")
                 return localServer

--- a/tests/test_backend_startup_imports.py
+++ b/tests/test_backend_startup_imports.py
@@ -1,0 +1,98 @@
+import importlib.util
+import ipaddress
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _module(name, **attributes):
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _load_wifi_api(monkeypatch):
+    package_name = "startup_contract_api"
+    package = _module(package_name)
+    package.__path__ = []
+    manager = MagicMock()
+    config = _module(
+        "config",
+        MeticulousConfig={"wifi": {}},
+        CONFIG_WIFI="wifi",
+        WIFI_AP_NAME="ap_name",
+        WIFI_AP_PASSWORD="ap_password",
+        WIFI_MODE="mode",
+        WIFI_MODE_AP="ap",
+        WIFI_MODE_CLIENT="client",
+    )
+    api = MagicMock()
+    api_version = SimpleNamespace(V1="v1")
+    stubs = {
+        package_name: package,
+        f"{package_name}.base_handler": _module(
+            f"{package_name}.base_handler", BaseHandler=object
+        ),
+        f"{package_name}.api": _module(f"{package_name}.api", API=api, APIVersion=api_version),
+        "config": config,
+        "wifi": _module(
+            "wifi",
+            WifiManager=manager,
+            WifiType=MagicMock(),
+            redact_ssid=lambda value: value,
+        ),
+        # Deliberately model current Nightly: ble_gatt no longer exports PORT.
+        "ble_gatt": _module("ble_gatt"),
+        "log": _module("log", MeticulousLogger=MagicMock()),
+    }
+    stubs["log"].MeticulousLogger.getLogger.return_value = MagicMock()
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_name = f"{package_name}.wifi"
+    module_path = Path(__file__).resolve().parents[1] / "api" / "wifi.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module, manager
+
+
+def test_wifi_api_imports_against_current_ble_contract(monkeypatch):
+    """Catch startup imports of symbols removed from current Nightly."""
+    module, _manager = _load_wifi_api(monkeypatch)
+
+    assert module.WiFiQRHandler is not None
+
+
+@pytest.mark.parametrize(
+    ("address", "version", "hostname", "expected"),
+    [
+        ("192.0.2.10", 4, "meticulous", "http://192.0.2.10"),
+        ("2001:db8::10", 6, "meticulous", "http://[2001:db8::10]"),
+        (None, None, "meticulous", "http://meticulous.local"),
+    ],
+)
+def test_wifi_qr_uses_the_public_machine_url(monkeypatch, address, version, hostname, expected):
+    module, manager = _load_wifi_api(monkeypatch)
+    ips = []
+    if address is not None:
+        parsed = ipaddress.ip_address(address)
+        assert parsed.version == version
+        ips.append(SimpleNamespace(ip=parsed))
+    manager.getCurrentConfig.return_value = SimpleNamespace(
+        is_hotspot=lambda: False,
+        ips=ips,
+        hostname=hostname,
+    )
+    qr = MagicMock()
+    create = MagicMock(return_value=qr)
+    monkeypatch.setattr(module.pyqrcode, "create", create)
+
+    module.WiFiQRHandler().generate_wifi_qr()
+
+    create.assert_called_once_with(expected)

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -157,8 +157,7 @@ def mock_wifi_manager():
 class TestWifiConnectUTF8:
     def test_ascii_ssid_and_password(self, mock_wifi_manager):
         result = GATTServer.wifi_connect(bytearray(b"MyNetwork"), bytearray(b"password"))
-        assert result is not None
-        assert any("192.168.1.100" in url for url in result)
+        assert result == ["http://192.168.1.100"]
         call_args = mock_wifi_manager.connectToWifi.call_args[0][0]
         assert call_args.ssid == "MyNetwork"
         assert call_args.password == "password"
@@ -291,9 +290,7 @@ class TestWifiConnectEdgeCases:
         )
         mock_wifi_manager.getCurrentConfig.return_value = config
         result = GATTServer.wifi_connect(bytearray(b"Net"), bytearray(b"pass"))
-        assert result is not None
-        assert any("192.168.1.100" in url for url in result)
-        assert any("fe80::1" in url for url in result)
+        assert result == ["http://192.168.1.100", "http://[fe80::1]"]
 
     def test_ssid_with_spaces(self, mock_wifi_manager):
         ssid = b"My Home Network"


### PR DESCRIPTION
## Summary
- The Wi-Fi provisioning QR code and the BLE Improv redirect URL now point at the machine's public web UI (`http://<ip>` / `http://<hostname>.local`, port 80) instead of the backend's internal `:8080`, so a phone scanning the QR or finishing Improv provisioning lands on the web UI directly.
- Removes the leftover `PORT` re-export from `ble_gatt` and its import in `api/wifi.py`; a new import-contract test catches this class of removed-symbol breakage at test time rather than at backend startup.

Split out from #395.

**Why draft:** this assumes nginx serves the web UI on port 80 on all image channels. That needs validation on a physical machine (per channel) before merge.

## Validation
- `pytest tests/test_ble_gatt_wifi.py tests/test_backend_startup_imports.py` — 29 passed (URL assertions updated to the portless form; QR contents covered for IPv4, IPv6 and hostname fallback).
- `flake8` and `black --check` clean on the touched files.
- Run locally on Windows with a minimal virtualenv; full suite runs in CI. On-machine validation of the port-80 assumption is pending (see above).
- CI on this branch: lint passes; the `test` job fails on two performance-budget tests (`tests/test_log_redaction_filter.py::ThroughputTests::test_throughput_budget`, `log_redactor/tests/test_log_redactor.py::LogRedactorTests::test_ten_megabyte_runtime_and_memory_budget`) and the `redactor-pin` check fails on the pinned `log_redactor` submodule commit. Both failures are pre-existing: the same jobs fail on the `nightly` base commit and are unrelated to this change.
