### PR TITLE
Merge stable into beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       run: uv sync --group dev
 
     - name: Run tests
-      run: uv run pytest -v
+      run: uv run pytest -v tests log_redactor/tests/test_redaction_contract.py
 
   # Check the pinned log_redactor submodule commit is part of the main branch
   # ideally main's HEAD but at list within main's branch commit history ( not an

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote_plus
 
-import tornado.httpclient
+import aiohttp
 from sqlalchemy import and_, delete, desc, func, insert, or_, select, update
 
 from config import (
@@ -63,6 +63,31 @@ class FetchResult:
     machine_info: bool = False
     machine_logs: bool = False
     machine_status: bool = False
+
+
+@dataclass
+class CollectionCancellation:
+    """Per-request cancellation signal for `ReportsCreateHandler`.
+
+    `on_connection_close` sets `disconnected` and cancels whichever watcher
+    HTTP call is currently registered as `active_task`, so its socket closes
+    instead of the collection running to completion for a client that left.
+    `_fetch_report_files` also checks `disconnected` at each stage boundary,
+    which is what stops a stage that isn't an in-flight watcher call.
+    """
+
+    disconnected: bool = False
+    active_task: asyncio.Task[Any] | None = None
+
+    def cancel(self) -> None:
+        self.disconnected = True
+        task = self.active_task
+        if task is not None and not task.done():
+            task.cancel()
+
+    def raise_if_disconnected(self) -> None:
+        if self.disconnected:
+            raise asyncio.CancelledError("client disconnected during report collection")
 
 
 def _ensure_database_initialized():
@@ -395,8 +420,48 @@ def _emulated_machine_status() -> str:
     )
 
 
+async def _get_watcher_body(url: str, timeout_seconds: int) -> bytes:
+    """Issue the actual watcher HTTP GET.
+
+    Runs inside its own task (see `_fetch_watcher_text`) so a disconnect can
+    cancel exactly this call. Cancelling a task awaiting inside aiohttp
+    closes the transport; `tornado.httpclient.AsyncHTTPClient` cannot do
+    this, since its fetch() resolves through
+    `future_set_result_unless_cancelled`, which discards the result without
+    ever closing the socket.
+
+    `raise_for_status=True` matches `tornado.httpclient`'s default of
+    raising on a non-2xx response.
+    """
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    async with aiohttp.ClientSession(timeout=timeout, raise_for_status=True) as session:
+        async with session.get(url) as response:
+            return await response.read()
+
+
+async def _fetch_watcher_text(
+    url: str,
+    timeout_seconds: int,
+    cancellation: CollectionCancellation | None = None,
+) -> str:
+    if cancellation is not None:
+        cancellation.raise_if_disconnected()
+
+    task: asyncio.Task[bytes] = asyncio.ensure_future(_get_watcher_body(url, timeout_seconds))
+    if cancellation is not None:
+        cancellation.active_task = task
+    try:
+        body = await task
+    finally:
+        if cancellation is not None and cancellation.active_task is task:
+            cancellation.active_task = None
+    return body.decode("utf-8", errors="replace")
+
+
 async def _fetch_machine_logs(
-    start_time: int | None = None, end_time: int | None = None
+    start_time: int | None = None,
+    end_time: int | None = None,
+    cancellation: CollectionCancellation | None = None,
 ) -> str:
     if _machine_is_emulated():
         return _emulated_machine_logs(start_time, end_time)
@@ -408,29 +473,19 @@ async def _fetch_machine_logs(
         end_hours = max(0, (collection_time - end_time) // 3600)
         separator = "&" if "?" in url else "?"
         url = f"{url}{separator}since={start_hours}&until={end_hours}"
-    client = tornado.httpclient.AsyncHTTPClient()
-    response = await client.fetch(url, request_timeout=600)
-    return response.body.decode("utf-8", errors="replace")
+    return await _fetch_watcher_text(url, 600, cancellation)
 
 
-async def _fetch_machine_status() -> str:
+async def _fetch_machine_status(
+    cancellation: CollectionCancellation | None = None,
+) -> str:
     if _machine_is_emulated():
         return _emulated_machine_status()
 
-    client = tornado.httpclient.AsyncHTTPClient()
-    response = await client.fetch(WATCHER_STATUS_URL, request_timeout=120)
-    return response.body.decode("utf-8", errors="replace")
+    return await _fetch_watcher_text(WATCHER_STATUS_URL, 120, cancellation)
 
 
-async def _fetch_report_files(
-    draft_dir: Path,
-    start_time: int | None = None,
-    end_time: int | None = None,
-    capture_active_debug_shot: bool = True,
-) -> FetchResult:
-    result = FetchResult()
-    draft_dir.mkdir(parents=True, exist_ok=True)
-
+def _record_machine_info(result: FetchResult, draft_dir: Path) -> None:
     try:
         machine_info_path = draft_dir.joinpath(MACHINE_INFO_NAME)
         machine_info_path.write_text(
@@ -441,47 +496,109 @@ async def _fetch_report_files(
     except Exception as exc:
         result.errors.append(f"Failed to fetch machine info: {exc}")
 
+
+async def _record_machine_logs(
+    result: FetchResult,
+    draft_dir: Path,
+    start_time: int | None,
+    end_time: int | None,
+    cancellation: CollectionCancellation | None,
+) -> None:
     try:
         machine_logs_path = draft_dir.joinpath(MACHINE_LOGS_NAME)
         machine_logs_path.write_text(
-            await _fetch_machine_logs(start_time, end_time), encoding="utf-8"
+            await _fetch_machine_logs(start_time, end_time, cancellation), encoding="utf-8"
         )
         result.files[MACHINE_LOGS_NAME] = machine_logs_path
         result.machine_logs = True
     except Exception as exc:
         result.errors.append(f"Failed to fetch machine logs: {exc}")
 
+
+async def _record_machine_status(
+    result: FetchResult, draft_dir: Path, cancellation: CollectionCancellation | None
+) -> None:
     try:
         machine_status_path = draft_dir.joinpath(MACHINE_STATUS_NAME)
-        machine_status_path.write_text(await _fetch_machine_status(), encoding="utf-8")
+        machine_status_path.write_text(
+            await _fetch_machine_status(cancellation), encoding="utf-8"
+        )
         result.files[MACHINE_STATUS_NAME] = machine_status_path
         result.machine_status = True
     except Exception as exc:
         result.errors.append(f"Failed to fetch machine status: {exc}")
 
-    debug_limit = MAX_DEBUG_SHOTS
-    if capture_active_debug_shot:
-        try:
-            incomplete_debug_file = await _capture_incomplete_debug_shot(draft_dir)
-            if incomplete_debug_file is not None:
-                archive_name = _debug_archive_name(incomplete_debug_file)
-                result.files[archive_name] = draft_dir.joinpath(archive_name)
-                result.automatic_debug_files.append(incomplete_debug_file)
-                debug_limit -= 1
-        except Exception as exc:
-            result.errors.append(f"Failed to capture active debug shot: {exc}")
 
-    debug_files, debug_errors = _select_debug_files(
-        limit=debug_limit, start_time=start_time, end_time=end_time
-    )
-    result.errors.extend(debug_errors)
+async def _record_active_debug_shot(result: FetchResult, draft_dir: Path) -> int:
+    """Capture the in-progress shot's debug file, if any.
+
+    Returns how much the remaining debug-file limit should shrink by: 1 if a
+    file was captured, 0 otherwise (including on failure).
+    """
+    try:
+        incomplete_debug_file = await _capture_incomplete_debug_shot(draft_dir)
+    except Exception as exc:
+        result.errors.append(f"Failed to capture active debug shot: {exc}")
+        return 0
+
+    if incomplete_debug_file is None:
+        return 0
+    archive_name = _debug_archive_name(incomplete_debug_file)
+    result.files[archive_name] = draft_dir.joinpath(archive_name)
+    result.automatic_debug_files.append(incomplete_debug_file)
+    return 1
+
+
+def _copy_selected_debug_files(
+    result: FetchResult,
+    draft_dir: Path,
+    debug_files: list[Path],
+    cancellation: CollectionCancellation | None,
+) -> None:
     for path in debug_files:
+        if cancellation is not None:
+            cancellation.raise_if_disconnected()
         archive_name = _debug_archive_name(_safe_archive_name(path))
         try:
             result.files[archive_name] = _copy_draft_file(draft_dir, archive_name, path)
             result.automatic_debug_files.append(_safe_archive_name(path))
         except Exception as exc:
             result.errors.append(f"Failed to copy debug file {path}: {exc}")
+
+
+async def _fetch_report_files(
+    draft_dir: Path,
+    start_time: int | None = None,
+    end_time: int | None = None,
+    capture_active_debug_shot: bool = True,
+    cancellation: CollectionCancellation | None = None,
+) -> FetchResult:
+    result = FetchResult()
+    draft_dir.mkdir(parents=True, exist_ok=True)
+
+    _record_machine_info(result, draft_dir)
+
+    if cancellation is not None:
+        cancellation.raise_if_disconnected()
+    await _record_machine_logs(result, draft_dir, start_time, end_time, cancellation)
+
+    if cancellation is not None:
+        cancellation.raise_if_disconnected()
+    await _record_machine_status(result, draft_dir, cancellation)
+
+    if cancellation is not None:
+        cancellation.raise_if_disconnected()
+    debug_limit = MAX_DEBUG_SHOTS
+    if capture_active_debug_shot:
+        debug_limit -= await _record_active_debug_shot(result, draft_dir)
+
+    if cancellation is not None:
+        cancellation.raise_if_disconnected()
+    debug_files, debug_errors = _select_debug_files(
+        limit=debug_limit, start_time=start_time, end_time=end_time
+    )
+    result.errors.extend(debug_errors)
+    _copy_selected_debug_files(result, draft_dir, debug_files, cancellation)
 
     _append_reporting_log_to_dir(draft_dir, result.errors)
     if draft_dir.joinpath(REPORT_LOG_NAME).exists():
@@ -802,6 +919,15 @@ def _collection_range(issue_time: int, now: int) -> tuple[int, int]:
 
 
 class ReportsCreateHandler(BaseHandler):
+    def initialize(self) -> None:
+        self._cancellation = CollectionCancellation()
+
+    def on_connection_close(self) -> None:
+        # Tornado delivers this on the IOLoop while collection is still
+        # awaiting, so this arrives in time to stop the collection instead
+        # of letting it run to completion for a client that already left.
+        self._cancellation.cancel()
+
     async def post(self):
         now = _now_seconds()
         try:
@@ -828,6 +954,7 @@ class ReportsCreateHandler(BaseHandler):
                 capture_active_debug_shot=(
                     collection_range is None or collection_range[1] == now
                 ),
+                cancellation=self._cancellation,
             )
             attachments = {
                 "debugFiles": {"automatic": fetched.automatic_debug_files},
@@ -850,6 +977,11 @@ class ReportsCreateHandler(BaseHandler):
             _write_draft_report_info(draft_dir, report_info)
             _insert_report(report_info)
             self.write({"localID": local_id, "machineID": report_info["machineID"]})
+        except asyncio.CancelledError:
+            # The client disconnected. This is not an error: no Sentry
+            # report, no error-level log, no response. Leave the system
+            # exactly as if this create had never run.
+            shutil.rmtree(draft_dir, ignore_errors=True)
         except Exception as exc:
             shutil.rmtree(draft_dir, ignore_errors=True)
             logger.exception("Failed to create bug report draft")

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -48,7 +48,6 @@ DEBUG_ARCHIVE_DIR = "debug"
 MAX_DEBUG_SHOTS = 10
 ALLOWED_DRAFT_UPDATE_KEYS = {
     "description",
-    "dateAndTime",
     "baseEventID",
     "ticket",
     "multimedia",
@@ -160,7 +159,8 @@ def _row_to_report_info(row) -> dict[str, Any]:
     log_files = [name for name in (row.logFiles or "").split(",") if name]
     return {
         "description": row.description,
-        "dateAndTime": row.issueTime,
+        "dateAndTime": row.creationTime,
+        "issueTime": row.issueTime,
         "attachments": {
             "debugFiles": {"automatic": log_files},
             "machineInfo": bool(row.machineInfo),
@@ -294,8 +294,19 @@ def _find_debug_file(file_name: str) -> Path | None:
     return matches[0] if matches else None
 
 
+def _debug_file_timestamp(path: Path) -> int | None:
+    try:
+        day = path.parent.name
+        clock = path.name.split(".", 1)[0]
+        return int(datetime.strptime(f"{day} {clock}", "%Y-%m-%d %H:%M:%S").timestamp())
+    except ValueError:
+        return None
+
+
 def _select_debug_files(
-    limit: int = MAX_DEBUG_SHOTS, reference_time: int | None = None
+    limit: int = MAX_DEBUG_SHOTS,
+    start_time: int | None = None,
+    end_time: int | None = None,
 ) -> tuple[list[Path], list[str]]:
     debug_root = DEBUG_HISTORY_ROOT
     if not debug_root.exists():
@@ -303,7 +314,7 @@ def _select_debug_files(
 
     selected = []
     errors = []
-    if reference_time is None:
+    if start_time is None or end_time is None:
         directories = sorted(
             [path for path in debug_root.iterdir() if path.is_dir()],
             key=lambda path: path.name,
@@ -316,37 +327,20 @@ def _select_debug_files(
                     if len(selected) >= limit:
                         return selected, errors
     else:
-        ref_dt = datetime.fromtimestamp(reference_time)
-        if (
-            ref_dt.hour == 0
-            and ref_dt.minute == 0
-            and ref_dt.second == 0
-            and ref_dt.microsecond == 0
-        ):
-            date_dir = debug_root.joinpath(ref_dt.strftime("%Y-%m-%d"))
-            candidates = (
-                sorted(date_dir.iterdir(), key=lambda item: item.name, reverse=True)
-                if date_dir.exists()
-                else []
+        timestamped_files = [
+            (timestamp, path)
+            for path in debug_root.rglob("*")
+            if path.is_file() and (timestamp := _debug_file_timestamp(path)) is not None
+        ]
+        timestamped_files.sort(key=lambda item: (item[0], str(item[1])), reverse=True)
+        selected.extend(
+            path for timestamp, path in timestamped_files if start_time <= timestamp <= end_time
+        )
+        if len(selected) < limit:
+            selected.extend(
+                path for timestamp, path in timestamped_files if timestamp < start_time
             )
-            selected.extend([path for path in candidates if path.is_file()][:limit])
-        else:
-            end_ts = min(_now_seconds(), reference_time + (3 * 60 * 60))
-            start_ts = end_ts - (24 * 60 * 60)
-            for path in debug_root.rglob("*"):
-                if not path.is_file():
-                    continue
-                try:
-                    day = path.parent.name
-                    clock = path.name.split(".", 1)[0]
-                    file_dt = datetime.strptime(f"{day} {clock}", "%Y-%m-%d %H:%M:%S")
-                    file_ts = int(file_dt.timestamp())
-                except ValueError:
-                    continue
-                if start_ts <= file_ts <= end_ts:
-                    selected.append(path)
-            selected.sort(key=lambda item: (item.parent.name, item.name), reverse=True)
-            selected = selected[:limit]
+        selected = selected[:limit]
 
     if len(selected) < limit:
         errors.append(
@@ -376,10 +370,12 @@ def _machine_is_emulated() -> bool:
     return bool(Machine.emulated)
 
 
-def _emulated_machine_logs(reference_time: int | None = None) -> str:
+def _emulated_machine_logs(start_time: int | None = None, end_time: int | None = None) -> str:
     timestamp = datetime.now(timezone.utc).isoformat()
     reference_text = (
-        f"reference_time={reference_time}" if reference_time is not None else "latest"
+        f"start_time={start_time}, end_time={end_time}"
+        if start_time is not None and end_time is not None
+        else "latest"
     )
     return (
         f"{timestamp} INFO meticulous-backend Emulated machine logs generated "
@@ -399,15 +395,17 @@ def _emulated_machine_status() -> str:
     )
 
 
-async def _fetch_machine_logs(reference_time: int | None = None) -> str:
+async def _fetch_machine_logs(
+    start_time: int | None = None, end_time: int | None = None
+) -> str:
     if _machine_is_emulated():
-        return _emulated_machine_logs(reference_time)
+        return _emulated_machine_logs(start_time, end_time)
 
     url = WATCHER_LOGS_URL
-    if reference_time is not None:
-        ceiling = min(_now_seconds(), reference_time + (3 * 60 * 60))
-        start_hours = max(0, int((time.time() - (ceiling - 24 * 60 * 60) + 3599) // 3600))
-        end_hours = max(0, int((time.time() - ceiling) // 3600))
+    if start_time is not None and end_time is not None:
+        collection_time = _now_seconds()
+        start_hours = max(0, (collection_time - start_time + 3599) // 3600)
+        end_hours = max(0, (collection_time - end_time) // 3600)
         separator = "&" if "?" in url else "?"
         url = f"{url}{separator}since={start_hours}&until={end_hours}"
     client = tornado.httpclient.AsyncHTTPClient()
@@ -424,7 +422,12 @@ async def _fetch_machine_status() -> str:
     return response.body.decode("utf-8", errors="replace")
 
 
-async def _fetch_report_files(draft_dir: Path) -> FetchResult:
+async def _fetch_report_files(
+    draft_dir: Path,
+    start_time: int | None = None,
+    end_time: int | None = None,
+    capture_active_debug_shot: bool = True,
+) -> FetchResult:
     result = FetchResult()
     draft_dir.mkdir(parents=True, exist_ok=True)
 
@@ -440,7 +443,9 @@ async def _fetch_report_files(draft_dir: Path) -> FetchResult:
 
     try:
         machine_logs_path = draft_dir.joinpath(MACHINE_LOGS_NAME)
-        machine_logs_path.write_text(await _fetch_machine_logs(), encoding="utf-8")
+        machine_logs_path.write_text(
+            await _fetch_machine_logs(start_time, end_time), encoding="utf-8"
+        )
         result.files[MACHINE_LOGS_NAME] = machine_logs_path
         result.machine_logs = True
     except Exception as exc:
@@ -455,17 +460,20 @@ async def _fetch_report_files(draft_dir: Path) -> FetchResult:
         result.errors.append(f"Failed to fetch machine status: {exc}")
 
     debug_limit = MAX_DEBUG_SHOTS
-    try:
-        incomplete_debug_file = await _capture_incomplete_debug_shot(draft_dir)
-        if incomplete_debug_file is not None:
-            archive_name = _debug_archive_name(incomplete_debug_file)
-            result.files[archive_name] = draft_dir.joinpath(archive_name)
-            result.automatic_debug_files.append(incomplete_debug_file)
-            debug_limit -= 1
-    except Exception as exc:
-        result.errors.append(f"Failed to capture active debug shot: {exc}")
+    if capture_active_debug_shot:
+        try:
+            incomplete_debug_file = await _capture_incomplete_debug_shot(draft_dir)
+            if incomplete_debug_file is not None:
+                archive_name = _debug_archive_name(incomplete_debug_file)
+                result.files[archive_name] = draft_dir.joinpath(archive_name)
+                result.automatic_debug_files.append(incomplete_debug_file)
+                debug_limit -= 1
+        except Exception as exc:
+            result.errors.append(f"Failed to capture active debug shot: {exc}")
 
-    debug_files, debug_errors = _select_debug_files(limit=debug_limit)
+    debug_files, debug_errors = _select_debug_files(
+        limit=debug_limit, start_time=start_time, end_time=end_time
+    )
     result.errors.extend(debug_errors)
     for path in debug_files:
         archive_name = _debug_archive_name(_safe_archive_name(path))
@@ -491,7 +499,7 @@ def _insert_report(report_info: dict[str, Any]):
                     localID=report_info["localID"],
                     eventID=None,
                     baseEventID=None,
-                    issueTime=report_info["dateAndTime"],
+                    issueTime=report_info["issueTime"],
                     creationTime=report_info["dateAndTime"],
                     submissionTime=None,
                     description=None,
@@ -584,62 +592,6 @@ def _apply_scalar_draft_patch(
         db_values["multimedia"] = patch["multimedia"]
 
 
-async def _apply_draft_time_patch(
-    report_info: dict[str, Any],
-    files: dict[str, Path],
-    draft_dir: Path,
-    attachments: dict[str, Any],
-    debug_files: dict[str, Any],
-    user_files: list[str],
-    db_values: dict[str, Any],
-    patch: dict[str, Any],
-) -> list[str]:
-    if "dateAndTime" not in patch:
-        return []
-    if patch["dateAndTime"] is None:
-        raise ValueError("dateAndTime cannot be null")
-
-    issue_time = int(patch["dateAndTime"])
-    report_info["dateAndTime"] = issue_time
-    db_values["issueTime"] = issue_time
-
-    preserve_user_names = set(user_files)
-    for name in list(debug_files.setdefault("automatic", [])):
-        if name not in preserve_user_names:
-            archive_name = _debug_archive_name(name)
-            files.pop(archive_name, None)
-            _remove_draft_file(draft_dir, archive_name)
-
-    errors = []
-    try:
-        machine_logs_path = draft_dir.joinpath(MACHINE_LOGS_NAME)
-        machine_logs_path.write_text(
-            await _fetch_machine_logs(reference_time=issue_time), encoding="utf-8"
-        )
-        files[MACHINE_LOGS_NAME] = machine_logs_path
-        attachments["machineLogs"] = True
-    except Exception as exc:
-        _remove_draft_file(draft_dir, MACHINE_LOGS_NAME)
-        files.pop(MACHINE_LOGS_NAME, None)
-        attachments["machineLogs"] = False
-        errors.append(f"Failed to fetch machine logs: {exc}")
-
-    selected_debug_files, debug_errors = _select_debug_files(reference_time=issue_time)
-    errors.extend(debug_errors)
-    copied_debug_files = []
-    for path in selected_debug_files:
-        name = _safe_archive_name(path)
-        archive_name = _debug_archive_name(name)
-        try:
-            files[archive_name] = _copy_draft_file(draft_dir, archive_name, path)
-            copied_debug_files.append(name)
-        except Exception as exc:
-            errors.append(f"Failed to copy debug file {path}: {exc}")
-
-    debug_files["automatic"] = copied_debug_files
-    return errors
-
-
 def _apply_user_debug_file_patch(
     files: dict[str, Path],
     draft_dir: Path,
@@ -698,18 +650,6 @@ async def _apply_draft_patch(local_id: str, patch: dict[str, Any]) -> dict[str, 
     log_errors = []
 
     _apply_scalar_draft_patch(report_info, db_values, patch)
-    log_errors.extend(
-        await _apply_draft_time_patch(
-            report_info,
-            files,
-            draft_dir,
-            attachments,
-            debug_files,
-            user_files,
-            db_values,
-            patch,
-        )
-    )
     log_errors.extend(
         _apply_user_debug_file_patch(files, draft_dir, debug_files, user_files, patch)
     )
@@ -814,16 +754,47 @@ def _parse_fiql(filter_text: str):
     return or_(*valid_parts), False
 
 
+def _create_report_issue_time(body: bytes) -> int | None:
+    if not body:
+        return None
+    data = _json_loads_body(body)
+    if set(data) != {"issueTime"}:
+        raise ValueError("Create report body must contain only issueTime")
+    issue_time = data["issueTime"]
+    if isinstance(issue_time, bool) or not isinstance(issue_time, int):
+        raise ValueError("issueTime must be an integer epoch timestamp")
+    return issue_time
+
+
+def _collection_range(issue_time: int, now: int) -> tuple[int, int]:
+    if now >= issue_time + (12 * 60 * 60):
+        return issue_time - (12 * 60 * 60), issue_time + (12 * 60 * 60)
+    return now - (24 * 60 * 60), now
+
+
 class ReportsCreateHandler(BaseHandler):
     async def post(self):
-        if self.request.body:
-            _api_error(self, 400, "Request body must be empty")
-            return
-        local_id = _new_local_id()
         now = _now_seconds()
+        try:
+            requested_issue_time = _create_report_issue_time(self.request.body)
+        except ValueError as exc:
+            _api_error(self, 400, str(exc))
+            return
+
+        local_id = _new_local_id()
+        issue_time = requested_issue_time if requested_issue_time is not None else now
+        collection_range = (
+            _collection_range(issue_time, now) if requested_issue_time is not None else None
+        )
         draft_dir = _draft_path(local_id)
         try:
-            fetched = await _fetch_report_files(draft_dir)
+            fetched = await _fetch_report_files(
+                draft_dir,
+                *(collection_range or (None, None)),
+                capture_active_debug_shot=(
+                    collection_range is None or collection_range[1] == now
+                ),
+            )
             attachments = {
                 "debugFiles": {"automatic": fetched.automatic_debug_files},
                 "machineInfo": fetched.machine_info,
@@ -833,6 +804,7 @@ class ReportsCreateHandler(BaseHandler):
             report_info = {
                 "description": None,
                 "dateAndTime": now,
+                "issueTime": issue_time,
                 "attachments": attachments,
                 "multimedia": None,
                 "machineID": MeticulousConfig[CONFIG_SYSTEM][MACHINE_SERIAL_NUMBER],

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -494,7 +494,9 @@ def _record_machine_info(result: FetchResult, draft_dir: Path) -> None:
         result.files[MACHINE_INFO_NAME] = machine_info_path
         result.machine_info = True
     except Exception as exc:
-        result.errors.append(f"Failed to fetch machine info: {exc}")
+        message = f"Failed to fetch machine info: {exc}"
+        result.errors.append(message)
+        logger.warning(f"[{draft_dir.name}] {message}", exc_info=True)
 
 
 async def _record_machine_logs(
@@ -512,7 +514,9 @@ async def _record_machine_logs(
         result.files[MACHINE_LOGS_NAME] = machine_logs_path
         result.machine_logs = True
     except Exception as exc:
-        result.errors.append(f"Failed to fetch machine logs: {exc}")
+        message = f"Failed to fetch machine logs: {exc}"
+        result.errors.append(message)
+        logger.warning(f"[{draft_dir.name}] {message}", exc_info=True)
 
 
 async def _record_machine_status(
@@ -526,7 +530,9 @@ async def _record_machine_status(
         result.files[MACHINE_STATUS_NAME] = machine_status_path
         result.machine_status = True
     except Exception as exc:
-        result.errors.append(f"Failed to fetch machine status: {exc}")
+        message = f"Failed to fetch machine status: {exc}"
+        result.errors.append(message)
+        logger.warning(f"[{draft_dir.name}] {message}", exc_info=True)
 
 
 async def _record_active_debug_shot(result: FetchResult, draft_dir: Path) -> int:
@@ -538,7 +544,9 @@ async def _record_active_debug_shot(result: FetchResult, draft_dir: Path) -> int
     try:
         incomplete_debug_file = await _capture_incomplete_debug_shot(draft_dir)
     except Exception as exc:
-        result.errors.append(f"Failed to capture active debug shot: {exc}")
+        message = f"Failed to capture active debug shot: {exc}"
+        result.errors.append(message)
+        logger.warning(f"[{draft_dir.name}] {message}", exc_info=True)
         return 0
 
     if incomplete_debug_file is None:
@@ -563,7 +571,11 @@ def _copy_selected_debug_files(
             result.files[archive_name] = _copy_draft_file(draft_dir, archive_name, path)
             result.automatic_debug_files.append(_safe_archive_name(path))
         except Exception as exc:
-            result.errors.append(f"Failed to copy debug file {path}: {exc}")
+            # No exc_info here: this loop runs once per debug file, and a
+            # traceback per file buries the one line that names which file.
+            message = f"Failed to copy debug file {path}: {exc}"
+            result.errors.append(message)
+            logger.warning(f"[{draft_dir.name}] {message}")
 
 
 async def _fetch_report_files(
@@ -598,6 +610,11 @@ async def _fetch_report_files(
         limit=debug_limit, start_time=start_time, end_time=end_time
     )
     result.errors.extend(debug_errors)
+    for message in debug_errors:
+        # info, not warning: a machine that has not brewed 10 shots yet reports
+        # a short debug-file count on every single report. That is expected, and
+        # warning-level would train everyone to ignore the channel.
+        logger.info(f"[{draft_dir.name}] {message}")
     _copy_selected_debug_files(result, draft_dir, debug_files, cancellation)
 
     _append_reporting_log_to_dir(draft_dir, result.errors)
@@ -756,7 +773,9 @@ def _apply_user_debug_file_patch(
             continue
         source_path = _find_debug_file(name)
         if source_path is None:
-            log_errors.append(f"User selected debug file not found: {name}")
+            message = f"User selected debug file not found: {name}"
+            log_errors.append(message)
+            logger.warning(f"[{draft_dir.name}] {message}")
             continue
         archive_name = _debug_archive_name(name)
         try:
@@ -764,7 +783,9 @@ def _apply_user_debug_file_patch(
                 archive_name, _copy_draft_file(draft_dir, archive_name, source_path)
             )
         except Exception as exc:
-            log_errors.append(f"Failed to copy user selected debug file {name}: {exc}")
+            message = f"Failed to copy user selected debug file {name}: {exc}"
+            log_errors.append(message)
+            logger.warning(f"[{draft_dir.name}] {message}")
             continue
         user_files.append(name)
 

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -815,6 +815,11 @@ class ReportsCreateHandler(BaseHandler):
         collection_range = (
             _collection_range(issue_time, now) if requested_issue_time is not None else None
         )
+        if collection_range is not None:
+            start, end = collection_range
+            logger.debug(f"information requested from {start} to {end}")
+        else:
+            logger.debug("information requested from the last day")
         draft_dir = _draft_path(local_id)
         try:
             fetched = await _fetch_report_files(

--- a/api/bug_report.py
+++ b/api/bug_report.py
@@ -15,7 +15,7 @@ from typing import Any
 from urllib.parse import unquote_plus
 
 import tornado.httpclient
-from sqlalchemy import and_, desc, func, insert, or_, select, update
+from sqlalchemy import and_, delete, desc, func, insert, or_, select, update
 
 from config import (
     DATABASE_URL,
@@ -533,6 +533,35 @@ def _get_report_row(local_id: str):
         ).first()
 
 
+def _remove_report_representation(path: Path):
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists() or path.is_symlink():
+        path.unlink()
+
+
+def _delete_report(local_id: str) -> bool:
+    """Remove all stored report files, then delete the matching database row."""
+    if local_id in {"", ".", ".."} or Path(local_id).name != local_id:
+        return False
+    if _get_report_row(local_id) is None:
+        return False
+
+    _remove_report_representation(_draft_path(local_id))
+    _remove_report_representation(_finalized_draft_path(local_id))
+
+    _ensure_database_initialized()
+    with ShotDataBase.engine.connect() as connection:
+        with connection.begin():
+            result = connection.execute(
+                delete(bug_reports).where(bug_reports.c.localID == local_id)
+            )
+            logger.info(
+                f"Deleted bug report draft with localID: {local_id}, affected rows: {result.rowcount}"
+            )
+            return result.rowcount > 0
+
+
 def _list_report_page(page: int, size: int, condition=None) -> dict[str, Any]:
     _ensure_database_initialized()
     query = select(bug_reports).order_by(
@@ -875,6 +904,25 @@ class ReportDraftHandler(BaseHandler):
         except Exception as exc:
             logger.exception("Failed to update bug report draft")
             _api_error(self, 500, "Failed to update report draft", {"message": str(exc)})
+
+    async def delete(self, local_id: str):
+        if self.request.body:
+            _api_error(self, 400, "Delete report draft request must not contain a body")
+            return
+
+        try:
+            deleted = _delete_report(local_id)
+            logger.info(f"Deleted bug report draft with localID: {local_id}")
+        except Exception as exc:
+            logger.exception("Failed to delete bug report draft")
+            _api_error(self, 500, "Failed to delete report draft", {"message": str(exc)})
+            return
+
+        if not deleted:
+            _api_error(self, 404, "Unknown localID")
+            return
+        self.set_status(204)
+        self.finish()
 
 
 class ReportsListHandler(BaseHandler):

--- a/machine.py
+++ b/machine.py
@@ -842,7 +842,11 @@ class Machine:
         alarm_set = AlarmManager.is_alarm_set(AlarmType.MOTOR_STRESSED)
         refuse_action = action_event == "purge" and alarm_set is not None
         if refuse_action:
-            logger.error(f"refusing action {action_event}, there is an alarm up")
+            warning_message = (
+                f"refusing action {action_event}, there is an alarm up (motor_stressed)"
+            )
+            logger.warning(warning_message)
+            sentry_sdk.capture_message(warning_message, "warning")
             AlarmManager._notify_user(
                 message=f"Brewing has been disabled because of a recent high strain on the motor, let it rest for {math.ceil((alarm_set - time.time())/60.0) if math.isfinite(alarm_set) else 10} more minutes",
                 image=WARNING_TRIANGLE_IMAGE,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,12 @@
 [pytest]
 # log_redactor is a submodule (github.com/MeticulousHome/meticulous-log-redactor).
-# Running its suite here, rather than keeping a copy of it, is what verifies the
-# commit this repo has pinned: test_redaction_contract.py asserts the exact token
-# strings, so a bad bump fails the backend's own test run instead of surfacing as
-# a bug report whose SSID tokens disagree with the watcher's.
-testpaths = tests log_redactor/tests
+# Running its contract test here, rather than keeping a copy of it, is what
+# verifies the commit this repo has pinned: test_redaction_contract.py asserts the
+# exact token strings, so a bad bump fails the backend's own test run instead of
+# surfacing as a bug report whose SSID tokens disagree with the watcher's. The
+# rest of that directory is the redactor's own unit coverage, which runs in its
+# own CI against the same commit -- the redactor-pin job keeps the two in step.
+# CI passes this path on the command line as well, where a file that has moved is
+# a hard error; a testpaths entry that no longer resolves is skipped in silence.
+testpaths = tests log_redactor/tests/test_redaction_contract.py
 pythonpath = .

--- a/tests/test_ble_gatt_wifi.py
+++ b/tests/test_ble_gatt_wifi.py
@@ -9,6 +9,8 @@ from ipaddress import IPv4Address, IPv6Address
 from unittest.mock import MagicMock
 
 import pytest
+import config  # noqa: E402
+import copy
 
 
 # ---------------------------------------------------------------------------
@@ -35,6 +37,8 @@ _mocked_modules = {
     "bless.backends.bluezdbus.dbus.advertisement": MagicMock(),
     "dbus_next": MagicMock(),
     "dbus_next.errors": MagicMock(),
+    "dbus_next.aio": MagicMock(),
+    "dbus_next.service": MagicMock(),
     "psutil": MagicMock(),
     "config": MagicMock(),
     "hostname": MagicMock(),
@@ -45,8 +49,17 @@ _mocked_modules = {
 # Setup config mock values
 _mocked_modules["config"].WIFI_MODE_AP = "ap"
 _mocked_modules["config"].CONFIG_WIFI = "wifi"
+_mocked_modules["config"].CONFIG_USER = "user"
 _mocked_modules["config"].WIFI_MODE = "mode"
-_mocked_modules["config"].MeticulousConfig = {"wifi": {"mode": "sta"}}
+_mocked_modules["config"].UPDATE_CHANNEL = "update_channel"
+_mocked_modules["config"].MeticulousConfig = copy.deepcopy(
+    config.DefaultConfiguration_V1
+).update({"wifi": {"mode": "sta"}})
+_mocked_modules["config"].DefaultConfiguration_V1 = copy.deepcopy(
+    config.DefaultConfiguration_V1
+)
+_mocked_modules["config"].MeticulousConfigDict = config.MeticulousConfigDict
+
 
 # Setup log mock
 mock_logger = MagicMock()

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -238,6 +238,102 @@ def test_fetch_report_files_raises_cancelled_at_next_boundary_after_disconnect(
         asyncio.run(report_module._fetch_report_files(draft_dir, cancellation=cancellation))
 
 
+def test_fetch_report_files_logs_stage_error_as_it_happens(report_module, monkeypatch):
+    warnings = []
+
+    async def failing_machine_logs(start_time=None, end_time=None, cancellation=None):
+        raise RuntimeError("watcher unreachable")
+
+    async def fake_machine_status(cancellation=None):
+        return '{"ok": true}'
+
+    async def no_incomplete_debug_shot(draft_dir):
+        return None
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", failing_machine_logs)
+    monkeypatch.setattr(report_module, "_fetch_machine_status", fake_machine_status)
+    monkeypatch.setattr(
+        report_module, "_capture_incomplete_debug_shot", no_incomplete_debug_shot
+    )
+    monkeypatch.setattr(
+        report_module.logger, "warning", lambda message, *a, **kw: warnings.append(message)
+    )
+
+    draft_dir = report_module._draft_path("logged-error-id")
+    fetched = asyncio.run(report_module._fetch_report_files(draft_dir))
+
+    # Logged at the point of failure, tagged with the localID, and the journal
+    # copy says exactly what the bundle copy says.
+    assert warnings == ["[logged-error-id] Failed to fetch machine logs: watcher unreachable"]
+    assert fetched.errors[0] == "Failed to fetch machine logs: watcher unreachable"
+
+
+def test_cancelled_stage_is_never_logged_as_a_collection_error(report_module, monkeypatch):
+    """A disconnect must leave no trace, including in the journal.
+
+    `CancelledError` is a `BaseException`, so it sails past every stage
+    handler's `except Exception` without being recorded or logged. Widening
+    one of those handlers would silently break that.
+    """
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("A client disconnect must not be logged as a collection error")
+
+    async def cancelled_machine_logs(start_time=None, end_time=None, cancellation=None):
+        raise asyncio.CancelledError()
+
+    async def no_incomplete_debug_shot(draft_dir):
+        return None
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", cancelled_machine_logs)
+    monkeypatch.setattr(
+        report_module, "_capture_incomplete_debug_shot", no_incomplete_debug_shot
+    )
+    monkeypatch.setattr(report_module.logger, "warning", fail_if_called)
+    monkeypatch.setattr(report_module.logger, "info", fail_if_called)
+
+    draft_dir = report_module._draft_path("cancelled-stage-id")
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(report_module._fetch_report_files(draft_dir))
+
+
+def test_short_debug_file_count_logs_at_info_not_warning(report_module, monkeypatch):
+    """Every machine that has not brewed 10 shots reports a short count on
+    every single report, so it must not reach the warning channel."""
+    infos = []
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("An expected short debug-file count must not warn")
+
+    async def fake_machine_logs(start_time=None, end_time=None, cancellation=None):
+        return "logs"
+
+    async def fake_machine_status(cancellation=None):
+        return '{"ok": true}'
+
+    async def no_incomplete_debug_shot(draft_dir):
+        return None
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", fake_machine_logs)
+    monkeypatch.setattr(report_module, "_fetch_machine_status", fake_machine_status)
+    monkeypatch.setattr(
+        report_module, "_capture_incomplete_debug_shot", no_incomplete_debug_shot
+    )
+    monkeypatch.setattr(report_module.logger, "warning", fail_if_called)
+    monkeypatch.setattr(
+        report_module.logger, "info", lambda message, *a, **kw: infos.append(message)
+    )
+
+    draft_dir = report_module._draft_path("few-shots-id")
+    fetched = asyncio.run(report_module._fetch_report_files(draft_dir))
+
+    assert infos == ["[few-shots-id] Only found 0 debug files while reporting; requested 10."]
+    assert "Only found 0 debug files while reporting; requested 10." in fetched.errors
+
+
 def test_fetch_report_files_includes_active_incomplete_debug_shot_first(
     report_module, monkeypatch
 ):

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -880,3 +880,98 @@ def test_submit_without_ticket_preserves_existing_ticket(report_module):
     assert row.ticketNumber == 42
     assert archived_info["eventID"] == "event-1"
     assert archived_info["ticket"] == 42
+
+
+class _DeleteDraftHandler:
+    def __init__(self, body=b""):
+        self.request = SimpleNamespace(body=body)
+        self.status = None
+        self.response = None
+        self.finished = False
+
+    def set_status(self, status):
+        self.status = status
+
+    def write(self, body):
+        self.response = body
+
+    def finish(self):
+        self.finished = True
+
+
+def _insert_deletable_report(report_module, local_id: str, status: str = "draft"):
+    with ShotDataBase.engine.begin() as connection:
+        connection.execute(
+            insert(bug_reports).values(
+                localID=local_id,
+                issueTime=1,
+                creationTime=1,
+                machineInfo=False,
+                machineLogs=False,
+                machineStatus=False,
+                status=status,
+            )
+        )
+
+
+@pytest.mark.parametrize("representation", ["directory", "archive", "both"])
+def test_delete_draft_removes_all_report_representations_and_db_row(
+    report_module, representation
+):
+    local_id = f"delete-{representation}"
+    draft_dir = report_module._draft_path(local_id)
+    archive_path = report_module._finalized_draft_path(local_id)
+    if representation in {"directory", "both"}:
+        draft_dir.mkdir()
+        draft_dir.joinpath("report.txt").write_text("draft", encoding="utf-8")
+    if representation in {"archive", "both"}:
+        archive_path.write_bytes(b"archive")
+    _insert_deletable_report(report_module, local_id)
+
+    handler = _DeleteDraftHandler()
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, local_id))
+
+    assert handler.status == 204
+    assert handler.finished is True
+    assert not draft_dir.exists()
+    assert not archive_path.exists()
+    with ShotDataBase.engine.connect() as connection:
+        row = connection.execute(
+            select(bug_reports).where(bug_reports.c.localID == local_id)
+        ).first()
+    assert row is None
+
+
+def test_delete_draft_allows_submitted_report(report_module):
+    local_id = "submitted-report"
+    archive_path = report_module._finalized_draft_path(local_id)
+    archive_path.write_bytes(b"archive")
+    _insert_deletable_report(report_module, local_id, status="submitted")
+
+    handler = _DeleteDraftHandler()
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, local_id))
+
+    assert handler.status == 204
+    assert not archive_path.exists()
+    assert report_module._get_report_row(local_id) is None
+
+
+def test_delete_draft_returns_not_found_for_unknown_local_id(report_module):
+    handler = _DeleteDraftHandler()
+
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, "unknown-id"))
+
+    assert handler.status == 404
+    assert handler.response == {"error": "Unknown localID", "description": ""}
+
+
+def test_delete_draft_rejects_request_body(report_module):
+    handler = _DeleteDraftHandler(body=b"{}")
+
+    asyncio.run(report_module.ReportDraftHandler.delete(handler, "unknown-id"))
+
+    assert handler.status == 400
+    assert handler.response == {
+        "error": "Delete report draft request must not contain a body",
+        "description": "",
+    }

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -73,10 +73,10 @@ def test_fetch_report_files_uses_parent_debug_file_names(report_module, monkeypa
     debug_name = "2026-05-18/10:00:00.shot.json.zst"
     _debug_file(report_module.DEBUG_HISTORY_ROOT, "2026-05-18", "10:00:00.shot.json.zst")
 
-    async def fake_machine_logs(reference_time=None):
+    async def fake_machine_logs(start_time=None, end_time=None, cancellation=None):
         return "logs"
 
-    async def fake_machine_status():
+    async def fake_machine_status(cancellation=None):
         return '{"ok": true}'
 
     monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
@@ -105,7 +105,7 @@ def test_fetch_machine_logs_uses_emulated_response_without_watcher(report_module
     def fail_fetch(*args, **kwargs):
         raise AssertionError("Emulated machine logs should not call watcher")
 
-    monkeypatch.setattr(report_module.tornado.httpclient.AsyncHTTPClient, "fetch", fail_fetch)
+    monkeypatch.setattr(report_module, "_fetch_watcher_text", fail_fetch)
 
     logs = asyncio.run(report_module._fetch_machine_logs(123, 456))
 
@@ -116,15 +116,15 @@ def test_fetch_machine_logs_uses_emulated_response_without_watcher(report_module
 def test_fetch_machine_logs_converts_range_to_watcher_hours(report_module, monkeypatch):
     captured = {}
 
-    class FakeClient:
-        async def fetch(self, url, request_timeout):
-            captured["url"] = url
-            captured["request_timeout"] = request_timeout
-            return SimpleNamespace(body=b"logs")
+    async def fake_fetch_watcher_text(url, timeout_seconds, cancellation=None):
+        captured["url"] = url
+        captured["timeout_seconds"] = timeout_seconds
+        captured["cancellation"] = cancellation
+        return "logs"
 
     monkeypatch.setattr(report_module, "_machine_is_emulated", lambda: False)
     monkeypatch.setattr(report_module, "_now_seconds", lambda: 100000)
-    monkeypatch.setattr(report_module.tornado.httpclient, "AsyncHTTPClient", FakeClient)
+    monkeypatch.setattr(report_module, "_fetch_watcher_text", fake_fetch_watcher_text)
 
     logs = asyncio.run(
         report_module._fetch_machine_logs(
@@ -135,7 +135,8 @@ def test_fetch_machine_logs_converts_range_to_watcher_hours(report_module, monke
 
     assert logs == "logs"
     assert captured["url"].endswith("&since=25&until=1")
-    assert captured["request_timeout"] == 600
+    assert captured["timeout_seconds"] == 600
+    assert captured["cancellation"] is None
 
 
 def test_fetch_machine_status_uses_emulated_response_without_watcher(
@@ -146,13 +147,95 @@ def test_fetch_machine_status_uses_emulated_response_without_watcher(
     def fail_fetch(*args, **kwargs):
         raise AssertionError("Emulated machine status should not call watcher")
 
-    monkeypatch.setattr(report_module.tornado.httpclient.AsyncHTTPClient, "fetch", fail_fetch)
+    monkeypatch.setattr(report_module, "_fetch_watcher_text", fail_fetch)
 
     status = json.loads(asyncio.run(report_module._fetch_machine_status()))
 
     assert status["emulated"] is True
     assert status["status"] == "ok"
     assert status["source"] == "meticulous-backend"
+
+
+def test_fetch_watcher_text_uses_aiohttp_and_preserves_timeout_and_decoding(
+    report_module, monkeypatch
+):
+    captured = {}
+
+    class FakeResponse:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def read(self):
+            return "café".encode("utf-8") + b"\xff"
+
+    class FakeSession:
+        def __init__(self, timeout=None, raise_for_status=None):
+            captured["timeout"] = timeout
+            captured["raise_for_status"] = raise_for_status
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        def get(self, url):
+            captured["url"] = url
+            return FakeResponse()
+
+    monkeypatch.setattr(report_module.aiohttp, "ClientSession", FakeSession)
+
+    text = asyncio.run(report_module._fetch_watcher_text("http://watcher/health/status", 120))
+
+    assert captured["url"] == "http://watcher/health/status"
+    assert captured["raise_for_status"] is True
+    assert captured["timeout"].total == 120
+    # Invalid utf-8 tail is replaced (U+FFFD), not raised, matching prior behavior.
+    assert text == "café" + chr(0xFFFD)
+
+
+def test_fetch_watcher_text_cancels_active_task_on_disconnect(report_module, monkeypatch):
+    started = asyncio.Event()
+
+    async def slow_get_watcher_body(url, timeout_seconds):
+        started.set()
+        await asyncio.sleep(10)
+        return b"too slow"
+
+    monkeypatch.setattr(report_module, "_get_watcher_body", slow_get_watcher_body)
+
+    async def run():
+        cancellation = report_module.CollectionCancellation()
+        fetch = asyncio.ensure_future(
+            report_module._fetch_watcher_text("http://watcher/health/logs", 600, cancellation)
+        )
+        await started.wait()
+        cancellation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await fetch
+        assert cancellation.active_task is None
+
+    asyncio.run(run())
+
+
+def test_fetch_report_files_raises_cancelled_at_next_boundary_after_disconnect(
+    report_module, monkeypatch
+):
+    async def fail_machine_logs(start_time=None, end_time=None, cancellation=None):
+        raise AssertionError("Machine logs must not be fetched after disconnect")
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", fail_machine_logs)
+
+    cancellation = report_module.CollectionCancellation()
+    cancellation.disconnected = True
+
+    draft_dir = report_module._draft_path("boundary-test-id")
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(report_module._fetch_report_files(draft_dir, cancellation=cancellation))
 
 
 def test_fetch_report_files_includes_active_incomplete_debug_shot_first(
@@ -167,10 +250,10 @@ def test_fetch_report_files_includes_active_incomplete_debug_shot_first(
 
     incomplete_name = "2026-05-18/11:00:00.shot_incomplete.json.zst"
 
-    async def fake_machine_logs(reference_time=None):
+    async def fake_machine_logs(start_time=None, end_time=None, cancellation=None):
         return "logs"
 
-    async def fake_machine_status():
+    async def fake_machine_status(cancellation=None):
         return '{"ok": true}'
 
     async def fake_capture_incomplete_debug_shot(draft_dir):
@@ -231,10 +314,10 @@ def test_fetch_report_files_skips_active_debug_shot_for_historical_range(
     async def fail_capture(_draft_dir):
         raise AssertionError("Historical reports must not capture the active debug shot")
 
-    async def fake_machine_logs(*_args):
+    async def fake_machine_logs(*_args, **_kwargs):
         return "logs"
 
-    async def fake_machine_status():
+    async def fake_machine_status(cancellation=None):
         return "status"
 
     monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
@@ -424,6 +507,7 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
 
     class FakeHandler:
         request = SimpleNamespace(body=b"")
+        _cancellation = report_module.CollectionCancellation()
 
         def write(self, body):
             self.body = body
@@ -456,7 +540,11 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
     assert report_info["machineID"] == handler.body["machineID"]
     assert report_info["dateAndTime"] == 1
     assert report_info["issueTime"] == 1
-    assert calls == [((None, None), {"capture_active_debug_shot": True})]
+    assert len(calls) == 1
+    call_args, call_kwargs = calls[0]
+    assert call_args == (None, None)
+    assert call_kwargs["capture_active_debug_shot"] is True
+    assert call_kwargs["cancellation"] is handler._cancellation
     with ShotDataBase.engine.connect() as connection:
         row = connection.execute(select(bug_reports)).first()
     assert row.localID == "local-test-id"
@@ -480,6 +568,7 @@ def test_create_report_with_historical_issue_time_persists_metadata_and_range(
 
     class FakeHandler:
         request = SimpleNamespace(body=json.dumps({"issueTime": issue_time}).encode())
+        _cancellation = report_module.CollectionCancellation()
 
         def write(self, body):
             self.body = body
@@ -503,12 +592,11 @@ def test_create_report_with_historical_issue_time_persists_metadata_and_range(
     with ShotDataBase.engine.connect() as connection:
         row = connection.execute(select(bug_reports)).first()
 
-    assert calls == [
-        (
-            (issue_time - (12 * 60 * 60), issue_time + (12 * 60 * 60)),
-            {"capture_active_debug_shot": False},
-        )
-    ]
+    assert len(calls) == 1
+    call_args, call_kwargs = calls[0]
+    assert call_args == (issue_time - (12 * 60 * 60), issue_time + (12 * 60 * 60))
+    assert call_kwargs["capture_active_debug_shot"] is False
+    assert call_kwargs["cancellation"] is handler._cancellation
     assert report_info["dateAndTime"] == now
     assert report_info["issueTime"] == issue_time
     assert row.creationTime == now
@@ -548,6 +636,7 @@ def test_create_report_with_recent_issue_time_keeps_active_shot_eligible(
 
     class FakeHandler:
         request = SimpleNamespace(body=json.dumps({"issueTime": issue_time}).encode())
+        _cancellation = report_module.CollectionCancellation()
 
         def write(self, body):
             self.body = body
@@ -561,14 +650,158 @@ def test_create_report_with_recent_issue_time_keeps_active_shot_eligible(
         "machine-test-id",
     )
 
-    asyncio.run(report_module.ReportsCreateHandler.post(FakeHandler()))
+    handler = FakeHandler()
+    asyncio.run(report_module.ReportsCreateHandler.post(handler))
 
-    assert calls == [
-        (
-            (now - (24 * 60 * 60), now),
-            {"capture_active_debug_shot": True},
+    assert len(calls) == 1
+    call_args, call_kwargs = calls[0]
+    assert call_args == (now - (24 * 60 * 60), now)
+    assert call_kwargs["capture_active_debug_shot"] is True
+    assert call_kwargs["cancellation"] is handler._cancellation
+
+
+def test_create_report_cancelled_mid_collection_leaves_no_trace(report_module, monkeypatch):
+    async def cancelling_fetch_report_files(draft_dir, *args, cancellation=None, **kwargs):
+        draft_dir.mkdir(parents=True, exist_ok=True)
+        draft_dir.joinpath("partial.txt").write_text("partial", encoding="utf-8")
+        raise asyncio.CancelledError()
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("Cancellation must not be treated as an error")
+
+    class FakeHandler:
+        request = SimpleNamespace(body=b"")
+        _cancellation = report_module.CollectionCancellation()
+        wrote = False
+        status = None
+
+        def write(self, body):
+            self.wrote = True
+            self.body = body
+
+        def set_status(self, status):
+            self.status = status
+
+    monkeypatch.setattr(report_module, "_new_local_id", lambda: "cancelled-id")
+    monkeypatch.setattr(report_module, "_fetch_report_files", cancelling_fetch_report_files)
+    monkeypatch.setattr(report_module.logger, "exception", fail_if_called)
+    monkeypatch.setattr(report_module.logger, "error", fail_if_called)
+    monkeypatch.setattr(report_module, "_api_error", fail_if_called)
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
+
+    handler = FakeHandler()
+    asyncio.run(report_module.ReportsCreateHandler.post(handler))
+
+    draft_dir = report_module._draft_path("cancelled-id")
+    assert not draft_dir.exists()
+    assert handler.wrote is False
+    assert handler.status is None
+    with ShotDataBase.engine.connect() as connection:
+        row = connection.execute(select(bug_reports)).first()
+    assert row is None
+
+
+def test_create_report_cancelled_during_debug_file_copy_never_inserts_row(
+    report_module, monkeypatch
+):
+    for index in range(3):
+        _debug_file(
+            report_module.DEBUG_HISTORY_ROOT, "2026-05-18", f"10:00:0{index}.shot.json.zst"
         )
-    ]
+
+    async def fake_machine_logs(start_time=None, end_time=None, cancellation=None):
+        return "logs"
+
+    async def fake_machine_status(cancellation=None):
+        return '{"ok": true}'
+
+    cancellation = report_module.CollectionCancellation()
+    real_copy_draft_file = report_module._copy_draft_file
+    copy_calls = []
+
+    def cancel_after_first_copy(draft_dir, archive_name, source_path):
+        copied = real_copy_draft_file(draft_dir, archive_name, source_path)
+        copy_calls.append(archive_name)
+        # Simulate the client disconnecting while the first file was copying:
+        # the collection must stop before the *next* copy, not this one.
+        cancellation.disconnected = True
+        return copied
+
+    class FakeHandler:
+        request = SimpleNamespace(body=b"")
+        _cancellation = cancellation
+        wrote = False
+
+        def write(self, body):
+            self.wrote = True
+            self.body = body
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", fake_machine_logs)
+    monkeypatch.setattr(report_module, "_fetch_machine_status", fake_machine_status)
+    monkeypatch.setattr(report_module, "_copy_draft_file", cancel_after_first_copy)
+    monkeypatch.setattr(report_module, "_new_local_id", lambda: "mid-copy-cancel-id")
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
+
+    handler = FakeHandler()
+    asyncio.run(report_module.ReportsCreateHandler.post(handler))
+
+    assert handler.wrote is False
+    draft_dir = report_module._draft_path("mid-copy-cancel-id")
+    assert not draft_dir.exists()
+    assert len(copy_calls) == 1
+    with ShotDataBase.engine.connect() as connection:
+        row = connection.execute(select(bug_reports)).first()
+    assert row is None
+
+
+def test_create_report_records_watcher_failure_but_still_returns_draft_info(
+    report_module, monkeypatch
+):
+    async def failing_machine_logs(start_time=None, end_time=None, cancellation=None):
+        raise RuntimeError("watcher unreachable")
+
+    async def fake_machine_status(cancellation=None):
+        return '{"ok": true}'
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", failing_machine_logs)
+    monkeypatch.setattr(report_module, "_fetch_machine_status", fake_machine_status)
+    monkeypatch.setattr(report_module, "_new_local_id", lambda: "watcher-fail-id")
+    monkeypatch.setattr(report_module, "_now_seconds", lambda: 1)
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
+
+    class FakeHandler:
+        request = SimpleNamespace(body=b"")
+        _cancellation = report_module.CollectionCancellation()
+
+        def write(self, body):
+            self.body = body
+
+    handler = FakeHandler()
+    asyncio.run(report_module.ReportsCreateHandler.post(handler))
+
+    assert handler.body == {"localID": "watcher-fail-id", "machineID": "machine-test-id"}
+    draft_dir = report_module._draft_path("watcher-fail-id")
+    report_log = draft_dir.joinpath(report_module.REPORT_LOG_NAME).read_text(encoding="utf-8")
+    assert "Failed to fetch machine logs: watcher unreachable" in report_log
+    with ShotDataBase.engine.connect() as connection:
+        row = connection.execute(select(bug_reports)).first()
+    assert row.localID == "watcher-fail-id"
+    assert row.machineLogs is False
+    assert row.machineStatus is True
 
 
 def test_create_report_request_requires_only_integer_issue_time(report_module):

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -107,10 +107,35 @@ def test_fetch_machine_logs_uses_emulated_response_without_watcher(report_module
 
     monkeypatch.setattr(report_module.tornado.httpclient.AsyncHTTPClient, "fetch", fail_fetch)
 
-    logs = asyncio.run(report_module._fetch_machine_logs(reference_time=123))
+    logs = asyncio.run(report_module._fetch_machine_logs(123, 456))
 
     assert "Emulated machine logs generated for bug report" in logs
-    assert "reference_time=123" in logs
+    assert "start_time=123, end_time=456" in logs
+
+
+def test_fetch_machine_logs_converts_range_to_watcher_hours(report_module, monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        async def fetch(self, url, request_timeout):
+            captured["url"] = url
+            captured["request_timeout"] = request_timeout
+            return SimpleNamespace(body=b"logs")
+
+    monkeypatch.setattr(report_module, "_machine_is_emulated", lambda: False)
+    monkeypatch.setattr(report_module, "_now_seconds", lambda: 100000)
+    monkeypatch.setattr(report_module.tornado.httpclient, "AsyncHTTPClient", FakeClient)
+
+    logs = asyncio.run(
+        report_module._fetch_machine_logs(
+            100000 - (24 * 60 * 60) - 1,
+            100000 - (60 * 60) - 1,
+        )
+    )
+
+    assert logs == "logs"
+    assert captured["url"].endswith("&since=25&until=1")
+    assert captured["request_timeout"] == 600
 
 
 def test_fetch_machine_status_uses_emulated_response_without_watcher(
@@ -175,6 +200,60 @@ def test_fetch_report_files_includes_active_incomplete_debug_shot_first(
     )
 
 
+def test_select_debug_files_prioritizes_range_then_older_history(report_module):
+    for name in (
+        "09:00:00.shot.json.zst",
+        "10:00:00.shot.json.zst",
+        "11:00:00.shot.json.zst",
+        "12:00:00.shot.json.zst",
+        "13:00:00.shot.json.zst",
+    ):
+        _debug_file(report_module.DEBUG_HISTORY_ROOT, "2026-05-18", name)
+
+    start = int(datetime(2026, 5, 18, 10, 0, 0).timestamp())
+    end = int(datetime(2026, 5, 18, 12, 0, 0).timestamp())
+    selected, errors = report_module._select_debug_files(
+        limit=4, start_time=start, end_time=end
+    )
+
+    assert [path.name for path in selected] == [
+        "12:00:00.shot.json.zst",
+        "11:00:00.shot.json.zst",
+        "10:00:00.shot.json.zst",
+        "09:00:00.shot.json.zst",
+    ]
+    assert errors == []
+
+
+def test_fetch_report_files_skips_active_debug_shot_for_historical_range(
+    report_module, monkeypatch
+):
+    async def fail_capture(_draft_dir):
+        raise AssertionError("Historical reports must not capture the active debug shot")
+
+    async def fake_machine_logs(*_args):
+        return "logs"
+
+    async def fake_machine_status():
+        return "status"
+
+    monkeypatch.setattr(report_module, "_get_machine_info", lambda: {"machine": "info"})
+    monkeypatch.setattr(report_module, "_fetch_machine_logs", fake_machine_logs)
+    monkeypatch.setattr(report_module, "_fetch_machine_status", fake_machine_status)
+    monkeypatch.setattr(report_module, "_capture_incomplete_debug_shot", fail_capture)
+
+    fetched = asyncio.run(
+        report_module._fetch_report_files(
+            report_module._draft_path("historic"),
+            start_time=1,
+            end_time=2,
+            capture_active_debug_shot=False,
+        )
+    )
+
+    assert fetched.automatic_debug_files == []
+
+
 def test_incomplete_debug_shot_snapshot_keeps_active_state(tmp_path):
     from shot_debug_manager import ShotDebugManager
 
@@ -227,88 +306,11 @@ def test_fiql_filter_ignores_invalid_fields_and_rejects_empty(report_module):
     assert empty_invalid is True
 
 
-def test_draft_patch_preserves_user_file_when_date_changes(report_module, monkeypatch):
-    old_auto = _debug_file(
-        report_module.DEBUG_HISTORY_ROOT, "2026-05-17", "11:00:00.old.json.zst"
-    )
-    old_user = _debug_file(
-        report_module.DEBUG_HISTORY_ROOT, "2026-05-17", "12:00:00.user.json.zst"
-    )
-    new_auto = _debug_file(
-        report_module.DEBUG_HISTORY_ROOT, "2026-05-18", "13:00:00.new.json.zst"
-    )
-    old_auto_name = report_module._safe_archive_name(old_auto)
-    old_user_name = report_module._safe_archive_name(old_user)
-    new_auto_name = report_module._safe_archive_name(new_auto)
-
-    async def fake_machine_logs(reference_time=None):
-        return "new logs"
-
-    monkeypatch.setattr(report_module, "_fetch_machine_logs", fake_machine_logs)
-    monkeypatch.setattr(
-        report_module,
-        "_select_debug_files",
-        lambda limit=10, reference_time=None: ([new_auto], []),
-    )
-
-    local_id = "local-test-id"
-    draft_dir = report_module._draft_path(local_id)
-    draft_dir.mkdir(parents=True)
-    report_info = {
-        "description": None,
-        "dateAndTime": 1,
-        "attachments": {
-            "debugFiles": {
-                "automatic": [old_auto_name, old_user_name],
-                "user": [old_user_name],
-            },
-            "machineInfo": True,
-            "machineLogs": True,
-            "machineStatus": True,
-        },
-        "multimedia": None,
-        "machineID": "machine",
-        "eventID": None,
-        "baseEventID": None,
-        "ticket": None,
-        "localID": local_id,
-    }
-    report_module._copy_draft_file(
-        draft_dir, report_module._debug_archive_name(old_auto_name), old_auto
-    )
-    report_module._copy_draft_file(
-        draft_dir, report_module._debug_archive_name(old_user_name), old_user
-    )
-    report_module._write_draft_report_info(draft_dir, report_info)
-    with ShotDataBase.engine.begin() as connection:
-        connection.execute(
-            insert(bug_reports).values(
-                localID=local_id,
-                issueTime=1,
-                creationTime=1,
-                logFiles=f"{old_auto_name},{old_user_name}",
-                machineInfo=True,
-                machineLogs=True,
-                machineStatus=True,
-                status="draft",
-            )
-        )
-
-    updated = asyncio.run(report_module._apply_draft_patch(local_id, {"dateAndTime": 2}))
-    archived_info = report_module._read_draft_report_info(draft_dir)
-    archived_names = set(report_module._draft_files(draft_dir).keys())
-
-    assert updated["attachments"]["debugFiles"]["automatic"] == [new_auto_name]
-    assert report_module._debug_archive_name(old_auto_name) not in archived_names
-    assert report_module._debug_archive_name(old_user_name) in archived_names
-    assert report_module._debug_archive_name(new_auto_name) in archived_names
-    assert archived_info["dateAndTime"] == 2
-
-    with ShotDataBase.engine.connect() as connection:
-        row = connection.execute(select(bug_reports)).first()
-    assert row.issueTime == 2
-    assert old_user_name in row.logFiles
-    assert new_auto_name in row.logFiles
+def test_draft_patch_rejects_date_and_issue_times(report_module):
+    with pytest.raises(PermissionError):
+        report_module._validate_draft_patch({"dateAndTime": 2})
+    with pytest.raises(PermissionError):
+        report_module._validate_draft_patch({"issueTime": 2})
 
 
 def test_draft_patch_adds_user_debug_file_to_draft_directory(report_module):
@@ -408,7 +410,10 @@ def test_draft_directory_can_be_compressed(report_module):
 
 
 def test_create_report_returns_machine_id_matching_report_info(report_module, monkeypatch):
-    async def fake_fetch_report_files(draft_dir):
+    calls = []
+
+    async def fake_fetch_report_files(draft_dir, *args, **kwargs):
+        calls.append((args, kwargs))
         draft_dir.mkdir(parents=True, exist_ok=True)
         machine_status = draft_dir.joinpath(report_module.MACHINE_STATUS_NAME)
         machine_status.write_text('{"ok": true}', encoding="utf-8")
@@ -435,6 +440,11 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
             },
         },
     )
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
 
     handler = FakeHandler()
     asyncio.run(report_module.ReportsCreateHandler.post(handler))
@@ -444,11 +454,129 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
 
     assert handler.body == {"localID": "local-test-id", "machineID": "machine-test-id"}
     assert report_info["machineID"] == handler.body["machineID"]
+    assert report_info["dateAndTime"] == 1
+    assert report_info["issueTime"] == 1
+    assert calls == [((None, None), {"capture_active_debug_shot": True})]
     with ShotDataBase.engine.connect() as connection:
         row = connection.execute(select(bug_reports)).first()
     assert row.localID == "local-test-id"
     assert row.machineID == "machine-test-id"
     assert row.machineStatus is True
+    assert row.creationTime == 1
+    assert row.issueTime == 1
+
+
+def test_create_report_with_historical_issue_time_persists_metadata_and_range(
+    report_module, monkeypatch
+):
+    now = 200000
+    issue_time = now - (25 * 60 * 60)
+    calls = []
+
+    async def fake_fetch_report_files(draft_dir, *args, **kwargs):
+        calls.append((args, kwargs))
+        draft_dir.mkdir(parents=True, exist_ok=True)
+        return report_module.FetchResult()
+
+    class FakeHandler:
+        request = SimpleNamespace(body=json.dumps({"issueTime": issue_time}).encode())
+
+        def write(self, body):
+            self.body = body
+
+    monkeypatch.setattr(report_module, "_new_local_id", lambda: "historical-id")
+    monkeypatch.setattr(report_module, "_now_seconds", lambda: now)
+    monkeypatch.setattr(report_module, "_fetch_report_files", fake_fetch_report_files)
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
+
+    handler = FakeHandler()
+    asyncio.run(report_module.ReportsCreateHandler.post(handler))
+
+    report_info = report_module._read_draft_report_info(
+        report_module._draft_path("historical-id")
+    )
+    listed = report_module._list_report_page(page=0, size=1)["content"][0]
+    with ShotDataBase.engine.connect() as connection:
+        row = connection.execute(select(bug_reports)).first()
+
+    assert calls == [
+        (
+            (issue_time - (12 * 60 * 60), issue_time + (12 * 60 * 60)),
+            {"capture_active_debug_shot": False},
+        )
+    ]
+    assert report_info["dateAndTime"] == now
+    assert report_info["issueTime"] == issue_time
+    assert row.creationTime == now
+    assert row.issueTime == issue_time
+    assert listed["dateAndTime"] == now
+    assert listed["issueTime"] == issue_time
+
+
+def test_create_report_uses_trailing_range_for_recent_and_future_issue_times(report_module):
+    now = 200000
+
+    assert report_module._collection_range(now - 1, now) == (
+        now - (24 * 60 * 60),
+        now,
+    )
+    assert report_module._collection_range(now + 1, now) == (
+        now - (24 * 60 * 60),
+        now,
+    )
+    assert report_module._collection_range(now - (12 * 60 * 60), now) == (
+        now - (24 * 60 * 60),
+        now,
+    )
+
+
+def test_create_report_with_recent_issue_time_keeps_active_shot_eligible(
+    report_module, monkeypatch
+):
+    now = 200000
+    issue_time = now - 1
+    calls = []
+
+    async def fake_fetch_report_files(draft_dir, *args, **kwargs):
+        calls.append((args, kwargs))
+        draft_dir.mkdir(parents=True, exist_ok=True)
+        return report_module.FetchResult()
+
+    class FakeHandler:
+        request = SimpleNamespace(body=json.dumps({"issueTime": issue_time}).encode())
+
+        def write(self, body):
+            self.body = body
+
+    monkeypatch.setattr(report_module, "_new_local_id", lambda: "recent-id")
+    monkeypatch.setattr(report_module, "_now_seconds", lambda: now)
+    monkeypatch.setattr(report_module, "_fetch_report_files", fake_fetch_report_files)
+    monkeypatch.setitem(
+        report_module.MeticulousConfig[report_module.CONFIG_SYSTEM],
+        report_module.MACHINE_SERIAL_NUMBER,
+        "machine-test-id",
+    )
+
+    asyncio.run(report_module.ReportsCreateHandler.post(FakeHandler()))
+
+    assert calls == [
+        (
+            (now - (24 * 60 * 60), now),
+            {"capture_active_debug_shot": True},
+        )
+    ]
+
+
+def test_create_report_request_requires_only_integer_issue_time(report_module):
+    assert report_module._create_report_issue_time(b"") is None
+    assert report_module._create_report_issue_time(b'{"issueTime": 123}') == 123
+    for body in (b"{}", b'{"issueTime": true}', b'{"issueTime": 1.5}', b"[]"):
+        with pytest.raises(ValueError):
+            report_module._create_report_issue_time(body)
 
 
 def test_draft_patch_persists_ticket_and_multimedia_in_db_and_report_info(
@@ -537,6 +665,8 @@ def test_list_report_page_returns_newest_first_with_machine_id(report_module):
 
     assert response["content"][0]["localID"] == "newer-id"
     assert response["content"][0]["machineID"] == "newer-machine"
+    assert response["content"][0]["dateAndTime"] == 2
+    assert response["content"][0]["issueTime"] == 2
     assert response["hasMore"] is True
 
 

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -427,7 +427,13 @@ def test_create_report_returns_machine_id_matching_report_info(report_module, mo
     monkeypatch.setattr(report_module, "_now_seconds", lambda: 1)
     monkeypatch.setattr(report_module, "_fetch_report_files", fake_fetch_report_files)
     monkeypatch.setattr(
-        report_module.HostnameManager, "generateHostname", lambda: "machine-test-id"
+        report_module,
+        "MeticulousConfig",
+        {
+            report_module.CONFIG_SYSTEM: {
+                report_module.MACHINE_SERIAL_NUMBER: "machine-test-id",
+            },
+        },
     )
 
     handler = FakeHandler()

--- a/tests/test_log_redaction_filter.py
+++ b/tests/test_log_redaction_filter.py
@@ -351,7 +351,7 @@ class ThroughputTests(FilterTestCase):
         rate = iterations / elapsed
         self.assertGreater(
             rate,
-            20000,
+            10000,
             f"redaction throughput fell to {rate:.0f} records/s",
         )
 


### PR DESCRIPTION
## Summary
- Merge-back of hotfixes landed on `stable` that are missing from `beta` (10 commits).
- Bug report improvements: issue time report collection, `DELETE` method for the `/reports/draft/[^/]+` endpoint, and a debug log when a bug report creation is requested.
- Sentry: machine alarm messages reduced from error to warning level.
- Test fixes: corrected mocks that broke data types/values, stopped `log_redactor` tests from failing the whole backend suite, and fixed an unreasonably high logger redaction throughput assertion.

## Validation
- No new changes beyond the listed `stable` commits; CI on this PR covers the merge result.