### PR TITLE
Clamp debug shot retention to a maximum of 365 days

### DIFF
--- a/shot_debug_manager.py
+++ b/shot_debug_manager.py
@@ -37,6 +37,8 @@ logger = MeticulousLogger.getLogger(__name__)
 DEBUG_FOLDER_FORMAT = "%Y-%m-%d"
 DEBUG_FILE_FORMAT = "%H:%M:%S"
 
+MAX_DEBUG_SHOT_RETENTION_DAYS = 365
+
 
 class ShotLogHandler(logging.Handler):
     def emit(self, record):
@@ -250,11 +252,22 @@ class ShotDebugManager:
                     ShotDebugManager._current_data.set_shot_type(status)
 
     @staticmethod
-    def deleteOldDebugShotData():
+    def _getRetentionDays() -> int:
+        # Retention is bounded: out-of-range values (negative used to mean
+        # "keep forever") are clamped so debug shots are never retained
+        # indefinitely.
         retention_days = MeticulousConfig[CONFIG_USER][DEBUG_SHOT_DATA_RETENTION]
-        if retention_days < 0:
-            logger.info("Debug shot data retention is disabled, not deleting old files")  #
-            return
+        if retention_days < 0 or retention_days > MAX_DEBUG_SHOT_RETENTION_DAYS:
+            logger.warning(
+                f"Debug shot data retention of {retention_days} days is out of range, "
+                f"clamping to {MAX_DEBUG_SHOT_RETENTION_DAYS} days"
+            )
+            return MAX_DEBUG_SHOT_RETENTION_DAYS
+        return retention_days
+
+    @staticmethod
+    def deleteOldDebugShotData():
+        retention_days = ShotDebugManager._getRetentionDays()
 
         logger.info(
             f"Debug shot data retention is set to {retention_days} days, deleting old files"
@@ -274,11 +287,6 @@ class ShotDebugManager:
 
     @staticmethod
     def zipAllDebugShots():
-        retention_days = MeticulousConfig[CONFIG_USER][DEBUG_SHOT_DATA_RETENTION]
-        if retention_days < 0:
-            logger.info("Debug shot data retention is disabled, not deleting old files")  #
-            return
-
         logger.info("Zipping all debug files")
         start = time.time()
 


### PR DESCRIPTION
## Summary
- Debug shot retention (`debug_shot_data_retention_days`) is now bounded: negative values — which previously disabled deletion entirely and kept debug shots forever — and values above 365 are clamped to 365 days.
- The clamp is applied at read time in a single helper used by the cleanup job, and a warning is logged whenever an out-of-range value is encountered.
- `zipAllDebugShots` no longer skips zipping when retention was negative; that guard existed only for the removed "keep forever" mode.
- No change for machines using the default (31 days) or any value in the 0–365 range.

## Validation
- `python -m py_compile shot_debug_manager.py`
- Existing tests only reference the config key, not the deletion behavior; no test changes needed.
- Suggested QA on a dev machine: set `debug_shot_data_retention_days: -1`, trigger the cleanup job, and confirm folders older than 365 days are deleted and the clamp warning is logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
