### PR TITLE
Device pairing + API authentication (M3 backend core)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -53,6 +53,7 @@ class API:
         from . import password_handler as _password_handler  # noqa
         from . import smoke_validation as _smoke_validation  # noqa
         from . import pairing as _pairing  # noqa
+        from .auth import with_auth
 
         routes = []
         logger.info("API Routes registered:")
@@ -63,7 +64,11 @@ class API:
             version_routes = []
             for path, (handler, kwargs) in paths.items():
                 route_path = f"{version_path}{path}"
-                version_routes.append((route_path, handler, kwargs))
+                # Enforce authorization on every route uniformly. Public paths
+                # (pairing) and loopback/Dial calls are allowed inside the check;
+                # LAN clients need a bearer token. Wrapping here also covers
+                # handlers that do not derive from BaseHandler.
+                version_routes.append((route_path, with_auth(handler), kwargs))
             version_routes.sort(key=lambda route: route[0])
             for path, _, _ in version_routes:
                 logger.info(f"    {path}")

--- a/api/api.py
+++ b/api/api.py
@@ -52,6 +52,7 @@ class API:
         from . import serial as _serial  # noqa
         from . import password_handler as _password_handler  # noqa
         from . import smoke_validation as _smoke_validation  # noqa
+        from . import pairing as _pairing  # noqa
 
         routes = []
         logger.info("API Routes registered:")

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,131 @@
+"""Request authorization for the local HTTP API (M3).
+
+Every request is either:
+  * a CORS preflight (OPTIONS) -> allowed, the browser attaches no auth to these;
+  * a public pairing endpoint  -> allowed, an unpaired device has no token yet;
+  * a local/Dial call          -> allowed (the Dial talks to the backend on
+                                   loopback, not through nginx);
+  * a LAN device with a valid bearer token -> allowed;
+  * anything else -> 401.
+
+Reverse-proxy trust boundary
+----------------------------
+The backend binds to 127.0.0.1 only; the sole way a LAN client reaches it is
+through the machine's nginx, which sets `X-Real-IP` to the real client address.
+So a request whose `X-Real-IP` is absent or itself loopback originates from a
+genuine loopback caller (the Dial); a request with a non-loopback `X-Real-IP` is
+a remote client and must present a token.
+
+SECURITY: this rests on nginx unconditionally overwriting `X-Real-IP` (so a LAN
+client cannot forge it). That must be verified in the deployed image before this
+is relied on (meticulous-machine; "Ticket 7" in the design). If nginx does not
+overwrite it, a LAN client could spoof `X-Real-IP: 127.0.0.1` and bypass auth.
+
+The decision logic here is pure and unit-tested; the Tornado glue that calls it
+lives in `enforce_authorization` / `AuthMixin`.
+"""
+
+import json
+from typing import Optional
+
+from pairing import PairingManagerInstance
+
+_LOOPBACK = ("127.0.0.1", "::1", "localhost")
+
+# Endpoints reachable without a token. An unpaired device must be able to start
+# and poll a pairing session before it can hold a token.
+_PUBLIC_EXACT = frozenset(
+    {
+        "/api/v1/pair/request",
+    }
+)
+_PUBLIC_PREFIXES = ("/api/v1/pair/status/",)
+
+
+def is_public_path(path: str) -> bool:
+    if path in _PUBLIC_EXACT:
+        return True
+    return any(path.startswith(prefix) for prefix in _PUBLIC_PREFIXES)
+
+
+def _is_loopback(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    return value in _LOOPBACK or value.startswith("127.")
+
+
+def client_is_local(remote_ip: Optional[str], x_real_ip: Optional[str]) -> bool:
+    """True for a genuine loopback caller (the Dial), False for a LAN client.
+
+    A non-loopback X-Real-IP means the request came through nginx from a real
+    client. Absent/loopback X-Real-IP with a loopback socket peer means the Dial.
+    """
+    if x_real_ip and not _is_loopback(x_real_ip):
+        return False
+    return _is_loopback(remote_ip)
+
+
+def parse_bearer_token(authorization: Optional[str]) -> Optional[str]:
+    if not authorization:
+        return None
+    parts = authorization.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip()
+    return None
+
+
+def is_authorized(
+    method: str,
+    path: str,
+    remote_ip: Optional[str],
+    x_real_ip: Optional[str],
+    authorization: Optional[str],
+) -> bool:
+    """The single authorization decision for an incoming request."""
+    if method == "OPTIONS":
+        return True
+    if is_public_path(path):
+        return True
+    if client_is_local(remote_ip, x_real_ip):
+        return True
+    token = parse_bearer_token(authorization)
+    return PairingManagerInstance.verify_token(token) is not None
+
+
+def request_is_local(handler) -> bool:
+    """Convenience for handlers that must stay loopback-only (e.g. exposing the
+    AP password): True only for a genuine loopback/Dial caller."""
+    return client_is_local(
+        handler.request.remote_ip,
+        handler.request.headers.get("X-Real-IP"),
+    )
+
+
+class AuthMixin:
+    """Prepended to every registered handler in API.get_routes() so the
+    authorization decision runs before any handler logic, including for handlers
+    that do not derive from BaseHandler (StaticFileHandler, RedirectHandler,
+    web UI). Public pairing endpoints and loopback/Dial calls pass through; LAN
+    clients need a valid bearer token.
+    """
+
+    def prepare(self):
+        if not is_authorized(
+            self.request.method,
+            self.request.path,
+            self.request.remote_ip,
+            self.request.headers.get("X-Real-IP"),
+            self.request.headers.get("Authorization"),
+        ):
+            self.set_status(401)
+            self.set_header("Content-type", "application/json")
+            self.finish(json.dumps({"error": "Unauthorized"}))
+            return None
+        # Preserve the wrapped handler's own prepare() (may be a coroutine, e.g.
+        # StaticFileHandler); Tornado awaits whatever prepare returns.
+        return super().prepare()
+
+
+def with_auth(handler):
+    """Return a subclass of `handler` with AuthMixin prepended."""
+    return type(f"Authed{handler.__name__}", (AuthMixin, handler), {})

--- a/api/base_handler.py
+++ b/api/base_handler.py
@@ -1,15 +1,5 @@
 import tornado.web
-from netaddr import IPNetwork
 
-from config import (
-    CONFIG_SYSTEM,
-    CONFIG_WIFI,
-    HTTP_ALLOWED_NETWORKS,
-    HTTP_AUTH_KEY,
-    WIFI_MODE,
-    WIFI_MODE_AP,
-    MeticulousConfig,
-)
 from log import MeticulousLogger
 
 logger = MeticulousLogger.getLogger(__name__)
@@ -30,9 +20,18 @@ def redact_ip(ip: str) -> str:
 
 class BaseHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
-        # FIXME: I know this is not great, you know this isn't great. What shall we do about this?
-        self.set_header("Access-Control-Allow-Origin", "*")
-        self.set_header("Access-Control-Allow-Headers", "*")
+        # Reflect the requesting Origin instead of a literal "*". CORS is not the
+        # security boundary here -- the bearer token is (see api/auth.py). We stay
+        # permissive so first-party and community web tools keep working, but
+        # reflecting the origin (rather than "*") lets us expose specific headers
+        # and never sets Access-Control-Allow-Credentials (we use a header token,
+        # not cookies, which also keeps us immune to CSRF).
+        origin = self.request.headers.get("Origin")
+        if origin:
+            self.set_header("Access-Control-Allow-Origin", origin)
+            self.set_header("Vary", "Origin")
+        else:
+            self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Access-Control-Expose-Headers", "*")
 
         self.set_header("Content-type", "application/json")
@@ -54,34 +53,9 @@ class BaseHandler(tornado.web.RequestHandler):
         self.set_status(204)
         self.finish()
 
-    def prepare(self):
-
-        return
-
-        # Skip the check if the request is from localhost
-        if self.request.remote_ip == "127.0.0.1" and self.request.remote_ip == "::1":
-            return
-
-        if MeticulousConfig[CONFIG_WIFI][WIFI_MODE] == WIFI_MODE_AP:
-            return
-
-        allowed_networks = [
-            IPNetwork(x) for x in MeticulousConfig[CONFIG_SYSTEM][HTTP_ALLOWED_NETWORKS]
-        ]
-
-        # TODO test me well!
-        if (
-            len([network for network in allowed_networks if self.request.remote_ip in network])
-            > 0
-        ):
-            return
-
-        # Validate the X-Authorized header
-        x_authorized = self.request.headers.get("X-Authorized")
-        if not x_authorized or x_authorized != MeticulousConfig[CONFIG_SYSTEM][HTTP_AUTH_KEY]:
-            self.set_status(401)
-            self.finish("Unauthorized: Missing X-Authorized header")
-            return
+    # Authorization is enforced uniformly by AuthMixin (api/auth.py), which is
+    # prepended to every route in API.get_routes(). BaseHandler no longer carries
+    # its own auth check.
 
 
 class LocalAccessHandler(BaseHandler):

--- a/api/pairing.py
+++ b/api/pairing.py
@@ -1,0 +1,103 @@
+"""HTTP endpoints for device pairing (M3).
+
+Flow:
+  POST /pair/request          -> opens a session, shows an Allow/Deny prompt on
+                                 the Dial, returns {pairing_id, code}
+  GET  /pair/status/{id}      -> {status} while pending; {status, token} once the
+                                 owner approves on the Dial (token delivered once)
+  GET  /pair/devices          -> list of paired devices (management; auth/loopback)
+  POST /pair/devices/{id}/revoke -> revoke a device (management; auth/loopback)
+
+/pair/request and /pair/status are the only endpoints reachable without a token
+(an unpaired device has none yet); the request-layer enforcement allowlists them.
+The management endpoints are not allowlisted, so they require a token or loopback
+(the Dial's "Paired devices" screen calls them over loopback).
+"""
+
+import json
+
+from notifications import Notification, NotificationManager, NotificationResponse
+from pairing import PairingError, PairingManagerInstance
+from log import MeticulousLogger
+
+from .base_handler import BaseHandler
+from .api import API, APIVersion
+
+logger = MeticulousLogger.getLogger(__name__)
+
+
+def _format_code(code: str) -> str:
+    # "482913" -> "482 913" for legibility on the Dial prompt.
+    return f"{code[:3]} {code[3:]}" if len(code) == 6 else code
+
+
+def _push_approval_prompt(pairing_id: str, device_name: str, code: str) -> None:
+    """Show the Allow/Deny prompt on the Dial and wire the answer to the session.
+
+    The callback fires on acknowledgement (and the notification manager may fire
+    it twice); approve()/deny() are idempotent, so a double invocation is safe.
+    """
+    message = f"Allow '{device_name}' to connect to this machine?\nCode: {_format_code(code)}"
+    notification = Notification(
+        message,
+        responses=[NotificationResponse.YES, NotificationResponse.NO],
+    )
+
+    def on_answer():
+        if notification.response == NotificationResponse.YES:
+            PairingManagerInstance.approve(pairing_id)
+        else:
+            PairingManagerInstance.deny(pairing_id)
+
+    notification.callback = on_answer
+    NotificationManager.add_notification(notification)
+
+
+class PairRequestHandler(BaseHandler):
+    def post(self):
+        try:
+            data = json.loads(self.request.body or "{}")
+        except json.JSONDecodeError:
+            self.report_error(400, "Invalid JSON body")
+            return
+
+        device_name = data.get("device_name") or "Unknown device"
+        try:
+            session = PairingManagerInstance.request_pairing(device_name)
+        except PairingError as e:
+            # Too many attempts / pending sessions -> rate limited.
+            self.report_error(429, str(e))
+            return
+
+        _push_approval_prompt(session["pairing_id"], device_name, session["code"])
+        self.write(
+            {
+                "pairing_id": session["pairing_id"],
+                "code": session["code"],
+                "expires_in": session["expires_in"],
+            }
+        )
+
+
+class PairStatusHandler(BaseHandler):
+    def get(self, pairing_id):
+        self.write(PairingManagerInstance.poll(pairing_id))
+
+
+class PairedDevicesHandler(BaseHandler):
+    def get(self):
+        self.write({"devices": PairingManagerInstance.list_devices()})
+
+
+class PairedDeviceRevokeHandler(BaseHandler):
+    def post(self, device_id):
+        if PairingManagerInstance.revoke(device_id):
+            self.write({"status": "success"})
+        else:
+            self.report_error(404, "Device not found")
+
+
+API.register_handler(APIVersion.V1, r"/pair/request", PairRequestHandler)
+API.register_handler(APIVersion.V1, r"/pair/status/([^/]+)", PairStatusHandler)
+API.register_handler(APIVersion.V1, r"/pair/devices", PairedDevicesHandler)
+API.register_handler(APIVersion.V1, r"/pair/devices/([^/]+)/revoke", PairedDeviceRevokeHandler)

--- a/api/wifi.py
+++ b/api/wifi.py
@@ -15,6 +15,7 @@ from wifi import WifiManager, WifiType, redact_ssid
 from ble_gatt import PORT
 
 from .base_handler import BaseHandler
+from .auth import request_is_local
 from .api import API, APIVersion
 
 from log import MeticulousLogger
@@ -95,10 +96,15 @@ class WiFiQRHandler(BaseHandler):
 
 
 class WiFiConfigHandler(BaseHandler):
-    def getWifiConfig(self):
+    def getWifiConfig(self, include_ap_password: bool):
         mode = MeticulousConfig[CONFIG_WIFI][WIFI_MODE]
         apName = MeticulousConfig[CONFIG_WIFI][WIFI_AP_NAME]
-        apPassword = MeticulousConfig[CONFIG_WIFI][WIFI_AP_PASSWORD]
+        # The AP password is only returned to loopback/Dial callers. LAN clients
+        # (even paired ones) get an empty value so the hotspot credential is not
+        # readable over the network.
+        apPassword = (
+            MeticulousConfig[CONFIG_WIFI][WIFI_AP_PASSWORD] if include_ap_password else ""
+        )
         current = WifiManager.getCurrentConfig()
         wifi_config = {
             "config": WiFiConfig(mode, apName, apPassword).to_json(),
@@ -109,11 +115,13 @@ class WiFiConfigHandler(BaseHandler):
         return wifi_config
 
     async def get(self):
+        include_ap_password = request_is_local(self)
         loop = asyncio.get_event_loop()
-        config = await loop.run_in_executor(None, self.getWifiConfig)
+        config = await loop.run_in_executor(None, self.getWifiConfig, include_ap_password)
         self.write(config)
 
     async def post(self):
+        include_ap_password = request_is_local(self)
         try:
             config_changed = False
             data = json.loads(self.request.body)
@@ -142,12 +150,14 @@ class WiFiConfigHandler(BaseHandler):
                             "error": WifiManager.getLastHealthErrorMessage()
                             or "Failed to apply Wi-Fi settings.",
                             "code": WifiManager._last_health_error,
-                            "config": self.getWifiConfig(),
+                            "config": self.getWifiConfig(include_ap_password),
                         }
                     )
                     return
 
-            config = await asyncio.get_event_loop().run_in_executor(None, self.getWifiConfig)
+            config = await asyncio.get_event_loop().run_in_executor(
+                None, self.getWifiConfig, include_ap_password
+            )
             self.write(config)
         except json.JSONDecodeError as e:
             self.set_status(400)

--- a/config.py
+++ b/config.py
@@ -34,6 +34,12 @@ CONFIG_SYSTEM = "system"
 CONFIG_USER = "user"
 CONFIG_WIFI = "wifi"
 CONFIG_PROFILES = "profiles"
+# Paired devices (per-device API access tokens). Stored as a mapping of
+# device_id -> {name, token_hash, created_at, last_seen_at}. Lives in config.yml
+# (not a dotfile) so a factory reset wipes it. Deliberately absent from
+# reportable_config's allowlist, so token hashes never reach diagnostic reports.
+CONFIG_PAIRED_DEVICES = "paired_devices"
+PAIRED_DEVICES_DEFAULT = {}
 
 #
 # SYSTEM config
@@ -246,6 +252,7 @@ DefaultConfiguration_V1 = {
     },
     CONFIG_PROFILES: {PROFILE_LAST: PROFILE_DEFAULT_LAST},
     CONFIG_MANUFACTURING: copy.deepcopy(Default_manufacturing_config),
+    CONFIG_PAIRED_DEVICES: copy.deepcopy(PAIRED_DEVICES_DEFAULT),
 }
 
 
@@ -416,6 +423,14 @@ def _redaction_values():
             credentials.append(entry)
         elif isinstance(entry, dict):
             credentials.append(entry.get("password"))
+
+    # Stored pairing token hashes are not secrets on their own (the plaintext
+    # token never touches the machine), but redacting them keeps device-linkable
+    # material out of logs as defence in depth.
+    paired_devices = MeticulousConfig.get(CONFIG_PAIRED_DEVICES) or {}
+    for record in paired_devices.values():
+        if isinstance(record, dict):
+            credentials.append(record.get("token_hash"))
 
     return ssids, credentials
 

--- a/pairing.py
+++ b/pairing.py
@@ -202,7 +202,13 @@ class PairingManager:
     # --- token verification & device management ------------------------------
 
     def verify_token(self, token: Optional[str]) -> Optional[str]:
-        """Return the device_id for a valid token, else None. Updates last_seen."""
+        """Return the device_id for a valid token, else None.
+
+        Updates last_seen in memory only; verification runs on every authorized
+        request, so we do not flush to disk each time. The updated timestamp is
+        persisted lazily on the next config save (best-effort; last_seen is
+        informational).
+        """
         if not token:
             return None
         candidate = hash_token(token)
@@ -212,7 +218,6 @@ class PairingManager:
                 stored = record.get("token_hash", "") if isinstance(record, dict) else ""
                 if stored and hmac.compare_digest(stored, candidate):
                     record["last_seen_at"] = _iso_now()
-                    MeticulousConfig.save()
                     return device_id
         return None
 

--- a/pairing.py
+++ b/pairing.py
@@ -1,0 +1,295 @@
+"""Device pairing and API access tokens.
+
+The machine's local HTTP API is authenticated with per-device bearer tokens.
+A new device (phone app, community web app, a developer's computer, an
+automated-test page, ...) cannot obtain a token on its own: it opens a pairing
+session, the machine shows a 6-digit code on the Dial with an Allow/Deny prompt,
+and only an explicit on-screen approval mints a token. Approval is per-device;
+once authorized, the device reuses its token until the owner revokes it from the
+Dial ("Paired devices") or performs a factory reset.
+
+Design notes:
+- The plaintext token is returned to the client exactly once, when it polls the
+  pairing status after approval. Only its SHA-256 hash is persisted, in the
+  CONFIG_PAIRED_DEVICES section of config.yml. The machine never stores the
+  plaintext.
+- Verification is constant-time (hmac.compare_digest) against the stored hashes.
+- Loopback callers (the Dial itself) are handled by the request-layer exemption,
+  not here -- this module only governs LAN devices.
+
+This module has no hardware dependencies so it can be unit-tested directly.
+"""
+
+import hashlib
+import hmac
+import secrets
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from config import (
+    CONFIG_PAIRED_DEVICES,
+    MeticulousConfig,
+)
+from log import MeticulousLogger
+
+logger = MeticulousLogger.getLogger(__name__)
+
+# A pairing session is short-lived: the user must approve on the Dial within
+# this window or the client must re-request.
+PAIRING_SESSION_TTL_SECONDS = 60
+# Bytes of entropy for the opaque token (256 bits).
+TOKEN_ENTROPY_BYTES = 32
+# Cap concurrent pending sessions so a hostile LAN peer cannot spam the Dial.
+MAX_PENDING_SESSIONS = 5
+# After this many denied/expired sessions from the request path, new requests
+# are refused for a cooldown to blunt brute-forcing the on-screen prompt.
+REJECTION_BACKOFF_THRESHOLD = 5
+REJECTION_BACKOFF_SECONDS = 60
+
+
+class PairingStatus:
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+    EXPIRED = "expired"
+
+
+def hash_token(token: str) -> str:
+    """SHA-256 hex digest of a token. The only form stored on the machine."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _generate_token() -> str:
+    return secrets.token_urlsafe(TOKEN_ENTROPY_BYTES)
+
+
+def _generate_code() -> str:
+    # 6-digit numeric code shown on the Dial and on the client, so the user can
+    # confirm they are approving their own device and not a racing attacker.
+    return f"{secrets.randbelow(1_000_000):06d}"
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class PairingSession:
+    pairing_id: str
+    device_name: str
+    code: str
+    created_at: float
+    status: str = PairingStatus.PENDING
+    # Plaintext token, held only between approval and the client's first poll.
+    _token: Optional[str] = field(default=None, repr=False)
+    device_id: Optional[str] = None
+
+    def is_expired(self, now: float) -> bool:
+        return (now - self.created_at) > PAIRING_SESSION_TTL_SECONDS
+
+
+class PairingManager:
+    """In-memory pairing sessions plus persisted per-device tokens."""
+
+    def __init__(self):
+        self._sessions: dict[str, PairingSession] = {}
+        self._lock = threading.RLock()
+        self._recent_rejections: list[float] = []
+
+    # --- pairing session lifecycle -------------------------------------------
+
+    def request_pairing(self, device_name: str) -> dict:
+        """Open a pairing session. Returns {pairing_id, code, expires_in}.
+
+        Raises PairingError if the machine is rate-limiting new requests.
+        """
+        device_name = (device_name or "Unknown device").strip()[:64]
+        now = _now()
+        with self._lock:
+            self._prune(now)
+            if self._in_backoff(now):
+                raise PairingError("Too many pairing attempts, try again shortly")
+            pending = [s for s in self._sessions.values() if s.status == PairingStatus.PENDING]
+            if len(pending) >= MAX_PENDING_SESSIONS:
+                raise PairingError("Too many pending pairing requests")
+
+            session = PairingSession(
+                pairing_id=str(uuid.uuid4()),
+                device_name=device_name,
+                code=_generate_code(),
+                created_at=now,
+            )
+            self._sessions[session.pairing_id] = session
+            logger.info(
+                f"Pairing requested by '{session.device_name}' "
+                f"(id={session.pairing_id}, code={session.code})"
+            )
+            return {
+                "pairing_id": session.pairing_id,
+                "code": session.code,
+                "expires_in": PAIRING_SESSION_TTL_SECONDS,
+            }
+
+    def get_pending_prompt(self, pairing_id: str) -> Optional[dict]:
+        """The data the Dial needs to render the approval prompt, or None."""
+        with self._lock:
+            session = self._sessions.get(pairing_id)
+            if not session or session.status != PairingStatus.PENDING:
+                return None
+            if session.is_expired(_now()):
+                return None
+            return {"device_name": session.device_name, "code": session.code}
+
+    def approve(self, pairing_id: str) -> bool:
+        """Approve a session (called from the Dial approval bridge).
+
+        Mints a token, persists its hash as a new paired device, and stashes the
+        plaintext on the session for the client's next poll. Returns False if the
+        session is unknown or no longer pending.
+        """
+        with self._lock:
+            session = self._sessions.get(pairing_id)
+            if not session or session.status != PairingStatus.PENDING:
+                return False
+            if session.is_expired(_now()):
+                session.status = PairingStatus.EXPIRED
+                self._record_rejection(_now())
+                return False
+
+            token = _generate_token()
+            device_id = self._persist_device(session.device_name, token)
+            session._token = token
+            session.device_id = device_id
+            session.status = PairingStatus.APPROVED
+            logger.info(f"Pairing approved for '{session.device_name}' (device_id={device_id})")
+            return True
+
+    def deny(self, pairing_id: str) -> bool:
+        with self._lock:
+            session = self._sessions.get(pairing_id)
+            if not session or session.status != PairingStatus.PENDING:
+                return False
+            session.status = PairingStatus.DENIED
+            self._record_rejection(_now())
+            logger.info(f"Pairing denied for '{session.device_name}'")
+            return True
+
+    def poll(self, pairing_id: str) -> dict:
+        """Client-facing status. Returns the token exactly once, on first poll
+        after approval, then clears it from memory."""
+        with self._lock:
+            session = self._sessions.get(pairing_id)
+            if not session:
+                return {"status": PairingStatus.EXPIRED}
+            if session.status == PairingStatus.PENDING and session.is_expired(_now()):
+                session.status = PairingStatus.EXPIRED
+                self._record_rejection(_now())
+
+            if session.status == PairingStatus.APPROVED and session._token is not None:
+                token = session._token
+                session._token = None  # deliver once
+                return {"status": PairingStatus.APPROVED, "token": token}
+            return {"status": session.status}
+
+    # --- token verification & device management ------------------------------
+
+    def verify_token(self, token: Optional[str]) -> Optional[str]:
+        """Return the device_id for a valid token, else None. Updates last_seen."""
+        if not token:
+            return None
+        candidate = hash_token(token)
+        with self._lock:
+            devices = self._devices()
+            for device_id, record in devices.items():
+                stored = record.get("token_hash", "") if isinstance(record, dict) else ""
+                if stored and hmac.compare_digest(stored, candidate):
+                    record["last_seen_at"] = _iso_now()
+                    MeticulousConfig.save()
+                    return device_id
+        return None
+
+    def list_devices(self) -> list[dict]:
+        """Public device metadata for the 'Paired devices' screen (no hashes)."""
+        with self._lock:
+            return [
+                {
+                    "device_id": device_id,
+                    "device_name": record.get("device_name", "Unknown device"),
+                    "created_at": record.get("created_at"),
+                    "last_seen_at": record.get("last_seen_at"),
+                }
+                for device_id, record in self._devices().items()
+                if isinstance(record, dict)
+            ]
+
+    def revoke(self, device_id: str) -> bool:
+        with self._lock:
+            devices = self._devices()
+            if device_id in devices:
+                name = devices[device_id].get("device_name", "?")
+                del devices[device_id]
+                MeticulousConfig.save()
+                logger.info(f"Revoked paired device '{name}' (device_id={device_id})")
+                return True
+        return False
+
+    # --- internals -----------------------------------------------------------
+
+    def _devices(self) -> dict:
+        devices = MeticulousConfig.get(CONFIG_PAIRED_DEVICES)
+        if not isinstance(devices, dict):
+            devices = {}
+            MeticulousConfig[CONFIG_PAIRED_DEVICES] = devices
+        return devices
+
+    def _persist_device(self, device_name: str, token: str) -> str:
+        device_id = str(uuid.uuid4())
+        self._devices()[device_id] = {
+            "device_name": device_name,
+            "token_hash": hash_token(token),
+            "created_at": _iso_now(),
+            "last_seen_at": None,
+        }
+        MeticulousConfig.save()
+        return device_id
+
+    def _prune(self, now: float) -> None:
+        stale = [
+            pid
+            for pid, s in self._sessions.items()
+            if s.status != PairingStatus.PENDING or s.is_expired(now)
+        ]
+        # Keep expired/finished sessions briefly so a late poll still gets a
+        # meaningful status, but drop the oldest to bound memory.
+        for pid in stale:
+            s = self._sessions[pid]
+            if (now - s.created_at) > (PAIRING_SESSION_TTL_SECONDS * 2):
+                del self._sessions[pid]
+
+    def _record_rejection(self, now: float) -> None:
+        self._recent_rejections.append(now)
+        self._recent_rejections = [
+            t for t in self._recent_rejections if (now - t) < REJECTION_BACKOFF_SECONDS
+        ]
+
+    def _in_backoff(self, now: float) -> bool:
+        self._recent_rejections = [
+            t for t in self._recent_rejections if (now - t) < REJECTION_BACKOFF_SECONDS
+        ]
+        return len(self._recent_rejections) >= REJECTION_BACKOFF_THRESHOLD
+
+
+class PairingError(Exception):
+    """Raised when a pairing request cannot be accepted (rate limiting, etc.)."""
+
+
+# Process-wide singleton, mirroring the pattern of other backend managers.
+PairingManagerInstance = PairingManager()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,66 @@
+import pytest
+
+from api import auth
+
+
+@pytest.fixture(autouse=True)
+def fake_verifier(monkeypatch):
+    # Only "good-token" is a valid device token for these tests.
+    monkeypatch.setattr(
+        auth.PairingManagerInstance,
+        "verify_token",
+        lambda token: "device-1" if token == "good-token" else None,
+    )
+
+
+def test_options_always_allowed():
+    assert auth.is_authorized("OPTIONS", "/api/v1/settings", "1.2.3.4", "1.2.3.4", None)
+
+
+def test_public_pairing_paths_allowed_without_token():
+    assert auth.is_public_path("/api/v1/pair/request")
+    assert auth.is_public_path("/api/v1/pair/status/abc-123")
+    assert not auth.is_public_path("/api/v1/pair/devices")
+    assert not auth.is_public_path("/api/v1/settings")
+    # Reachable from a remote client with no token:
+    assert auth.is_authorized("POST", "/api/v1/pair/request", "127.0.0.1", "9.9.9.9", None)
+    assert auth.is_authorized("GET", "/api/v1/pair/status/x", "127.0.0.1", "9.9.9.9", None)
+
+
+def test_client_is_local():
+    # Genuine loopback caller (the Dial): loopback peer, no X-Real-IP.
+    assert auth.client_is_local("127.0.0.1", None)
+    assert auth.client_is_local("::1", None)
+    # Through nginx from a LAN client: loopback peer but X-Real-IP is the client.
+    assert not auth.client_is_local("127.0.0.1", "192.168.1.50")
+    # X-Real-IP itself loopback -> still local.
+    assert auth.client_is_local("127.0.0.1", "127.0.0.1")
+    # A spoofed loopback X-Real-IP is only "local" because nginx is trusted to
+    # overwrite it; documented dependency, asserted here as current behavior.
+    assert auth.client_is_local("127.0.0.1", "localhost")
+
+
+def test_parse_bearer_token():
+    assert auth.parse_bearer_token("Bearer abc") == "abc"
+    assert auth.parse_bearer_token("bearer abc") == "abc"
+    assert auth.parse_bearer_token("Basic abc") is None
+    assert auth.parse_bearer_token("") is None
+    assert auth.parse_bearer_token(None) is None
+
+
+def test_lan_client_requires_valid_token():
+    # LAN client (non-loopback X-Real-IP) with a valid token -> allowed.
+    assert auth.is_authorized(
+        "GET", "/api/v1/settings", "127.0.0.1", "192.168.1.50", "Bearer good-token"
+    )
+    # Wrong token -> denied.
+    assert not auth.is_authorized(
+        "GET", "/api/v1/settings", "127.0.0.1", "192.168.1.50", "Bearer bad-token"
+    )
+    # No token -> denied.
+    assert not auth.is_authorized("GET", "/api/v1/settings", "127.0.0.1", "192.168.1.50", None)
+
+
+def test_dial_loopback_allowed_without_token():
+    assert auth.is_authorized("GET", "/api/v1/settings", "127.0.0.1", None, None)
+    assert auth.is_authorized("POST", "/api/v1/machine/factory_reset", "127.0.0.1", None, None)

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,0 +1,117 @@
+import re
+
+import pytest
+
+import pairing
+from config import CONFIG_PAIRED_DEVICES, MeticulousConfig
+from pairing import PairingError, PairingManager, PairingStatus, hash_token
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    # Isolate from disk: pairing persists via MeticulousConfig.save(); make it a
+    # no-op and start from an empty paired-devices section every test.
+    monkeypatch.setattr(MeticulousConfig, "save", lambda: None)
+    MeticulousConfig[CONFIG_PAIRED_DEVICES] = {}
+    return PairingManager()
+
+
+def _approve_and_get_token(manager, device_name="Alu's iPhone"):
+    req = manager.request_pairing(device_name)
+    assert manager.approve(req["pairing_id"]) is True
+    result = manager.poll(req["pairing_id"])
+    assert result["status"] == PairingStatus.APPROVED
+    return req, result["token"]
+
+
+def test_request_pairing_returns_id_and_six_digit_code(manager):
+    req = manager.request_pairing("Test Device")
+    assert req["pairing_id"]
+    assert re.fullmatch(r"\d{6}", req["code"])
+    assert req["expires_in"] == pairing.PAIRING_SESSION_TTL_SECONDS
+    # The prompt the Dial renders matches the session.
+    prompt = manager.get_pending_prompt(req["pairing_id"])
+    assert prompt == {"device_name": "Test Device", "code": req["code"]}
+
+
+def test_approved_token_is_delivered_once_then_verifies(manager):
+    req, token = _approve_and_get_token(manager)
+    # Token is delivered exactly once.
+    assert manager.poll(req["pairing_id"]) == {"status": PairingStatus.APPROVED}
+    # And it authenticates.
+    device_id = manager.verify_token(token)
+    assert device_id is not None
+    # A wrong token does not.
+    assert manager.verify_token(token + "x") is None
+    assert manager.verify_token("") is None
+    assert manager.verify_token(None) is None
+
+
+def test_only_hash_is_stored_never_plaintext(manager):
+    _req, token = _approve_and_get_token(manager)
+    devices = MeticulousConfig[CONFIG_PAIRED_DEVICES]
+    (record,) = devices.values()
+    assert record["token_hash"] == hash_token(token)
+    assert token not in str(devices)
+
+
+def test_deny_yields_no_token(manager):
+    req = manager.request_pairing("Bad Device")
+    assert manager.deny(req["pairing_id"]) is True
+    assert manager.poll(req["pairing_id"]) == {"status": PairingStatus.DENIED}
+    assert MeticulousConfig[CONFIG_PAIRED_DEVICES] == {}
+
+
+def test_expired_session_cannot_be_approved(manager, monkeypatch):
+    req = manager.request_pairing("Slow Device")
+    session = manager._sessions[req["pairing_id"]]
+    # Move the session's creation past the TTL.
+    session.created_at -= pairing.PAIRING_SESSION_TTL_SECONDS + 1
+    assert manager.approve(req["pairing_id"]) is False
+    assert manager.poll(req["pairing_id"]) == {"status": PairingStatus.EXPIRED}
+    assert manager.get_pending_prompt(req["pairing_id"]) is None
+
+
+def test_list_devices_excludes_hash_and_revoke_removes(manager):
+    _req, token = _approve_and_get_token(manager, "Revoke Me")
+    devices = manager.list_devices()
+    assert len(devices) == 1
+    entry = devices[0]
+    assert entry["device_name"] == "Revoke Me"
+    assert "token_hash" not in entry
+    device_id = entry["device_id"]
+
+    assert manager.revoke(device_id) is True
+    assert manager.list_devices() == []
+    # Revoked token no longer authenticates.
+    assert manager.verify_token(token) is None
+    assert manager.revoke(device_id) is False
+
+
+def test_last_seen_updates_on_verify(manager):
+    _req, token = _approve_and_get_token(manager)
+    assert manager.list_devices()[0]["last_seen_at"] is None
+    manager.verify_token(token)
+    assert manager.list_devices()[0]["last_seen_at"] is not None
+
+
+def test_max_pending_sessions_enforced(manager):
+    for _ in range(pairing.MAX_PENDING_SESSIONS):
+        manager.request_pairing("Device")
+    with pytest.raises(PairingError):
+        manager.request_pairing("One Too Many")
+
+
+def test_rejection_backoff(manager):
+    # Enough denials trip the cooldown on new requests.
+    for _ in range(pairing.REJECTION_BACKOFF_THRESHOLD):
+        req = manager.request_pairing("Device")
+        manager.deny(req["pairing_id"])
+    with pytest.raises(PairingError):
+        manager.request_pairing("Blocked")
+
+
+def test_hash_token_is_stable_and_hex(manager):
+    h = hash_token("abc")
+    assert h == hash_token("abc")
+    assert re.fullmatch(r"[0-9a-f]{64}", h)

--- a/tests/test_reportable_config.py
+++ b/tests/test_reportable_config.py
@@ -60,10 +60,16 @@ def test_reportable_config_is_allowlist_only_and_does_not_mutate_input():
             "last_boot_mode": "normal",
             "skip_stage": False,
         },
+        "paired_devices": {
+            "abc-123": {"device_name": "Phone", "token_hash": "deadbeef"},
+        },
         "future": {"secret": "drop"},
     }
 
     reportable = get_reportable_config(config)
+
+    # Paired-device tokens must never reach diagnostic reports.
+    assert "paired_devices" not in reportable
 
     assert reportable["system"]["sounds_theme"] == "custom"
     assert reportable["wifi"] == {"mode": "CLIENT"}


### PR DESCRIPTION
## Summary

Backend core of **M3** — authenticate the local HTTP API with per-device tokens, replacing an auth check that has been dead (a `return` on the first line of `BaseHandler.prepare()`) since Jan 2024. This is the backend half; the Dial "Paired devices" UI, the `@meticulous-home/espresso-api` token support + app re-pair flow, and the BLE authorization fix (M4) are separate PRs.

**Model:** a new device cannot self-authorize. It opens a pairing session and the machine shows an Allow/Deny prompt with a 6-digit code on the Dial; only an on-screen approval mints an opaque 256-bit bearer token. Tokens are **per-device**, reused until revoked from the Dial or wiped by a factory reset. Only the SHA-256 hash is stored (in a new `paired_devices` config section, wiped by factory reset and excluded from `reportable_config`'s allowlist, so hashes never reach diagnostic reports).

### What's in this PR
- `pairing.py` — token lifecycle, per-device storage, constant-time verification, rate-limiting + rejection backoff. Unit-tested.
- `api/pairing.py` — `POST /pair/request`, `GET /pair/status/{id}`, `GET /pair/devices`, `POST /pair/devices/{id}/revoke`. `/pair/request` pushes the Allow/Deny prompt to the Dial via the existing notification mechanism; the approval callback is idempotent (safe under the notification manager's double-callback).
- `api/auth.py` — one pure authorization decision (unit-tested) + `AuthMixin`, prepended to every route in `API.get_routes()` so non-`BaseHandler` routes (history `StaticFileHandler`, redirects) are covered too.
- `api/base_handler.py` — remove the dead `prepare()` (the `return`-first block, the public default key `AAAABBBB…`, and the `and`/`or` localhost bug); reflect the request `Origin` for CORS instead of `*` (no credentials — the token, not CORS, is the boundary, so first-party and community web tools keep working).
- `api/wifi.py` — `/wifi/config` returns the AP password only to loopback/Dial callers, never to LAN clients.

### Security notes / decisions
- **nginx trust boundary:** the backend binds to loopback; a LAN client only reaches it through nginx, which must set `X-Real-IP`. "Local/Dial" is judged by `X-Real-IP` being absent/loopback. **This relies on nginx unconditionally overwriting `X-Real-IP`** — must be verified in the deployed image (meticulous-machine) before relying on it. If it does not, a LAN client could spoof `X-Real-IP: 127.0.0.1`.
- `root-password` and `factory_reset` stay loopback-only via `LocalAccessHandler`, now layered under `AuthMixin`, so a paired LAN device still cannot reach them. `factory_reset` remains a `GET`; the CSRF vector it had is closed by auth (an external page is neither local nor token-bearing), but converting it to `POST` is a worthwhile follow-up that needs a matching Dial change.
- `WEB_UI_HANDLER` (static debug shell) is intentionally left unauthenticated — it is read-only static content and its API calls are themselves authorized. Flagged as a decision point.

## Validation
- `pytest` (collectable subset in CI-less env): **53 passing**, including `test_pairing.py` (10), `test_auth.py` (6), and the added `reportable_config` assertion that `paired_devices` never appears in reports.
- `python -m py_compile` on all changed modules; `black` clean.
- **Requires before merge:** full test run in CI (Linux; several test modules need hardware/Linux-only deps not present locally), on-device QA of the end-to-end pairing/revocation/factory-reset flow, and verification of the nginx `X-Real-IP` behavior.

## Notes for reviewers
This changes authorization on **every** API route. The migration story (existing clients get `401` until they re-pair) needs the client-side work landed and a support/release-notes plan before this reaches stable. Targeting `beta` per the security-fix channel policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
