### PR TITLE
ota: stop restarting rauc-hawkbit-updater on channel change

### DIFF
--- a/ota.py
+++ b/ota.py
@@ -112,7 +112,6 @@ class UpdateManager:
                 with open(channel_file, "w") as f:
                     f.write(channel + "\n")
                 logger.info(f"Changed update channel from {current_channel} to {channel}")
-                subprocess.run(["systemctl", "restart", "rauc-hawkbit-updater"])
             except Exception as e:
                 logger.error(f"Failed to change update channel: {e}")
 


### PR DESCRIPTION
setChannel restarted the updater so it would re-read config.conf and report the new update_channel. The updater no longer reports that attribute at all: the machine publishes it directly now (SW-114). The restart therefore refreshes nothing, and it can mess an in-flight OTA download

A systemd path unit on /etc/hawkbit/channel republishes the attributes when this function writes the file.

The responsibility was transfered
> :warning: requires https://github.com/MeticulousHome/meticulous-machine/pull/112 :warning:

> NOTE: redactor and tests check fixes have not been back-propagated from stable, do not attend to their results